### PR TITLE
Fix the version number with PyInstaller+Windows

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -61,6 +61,7 @@ jobs:
           python-version: 3.8
       - name: install dependencies
         run: |
+          python fix_win_ver.py
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install .

--- a/fix_win_ver.py
+++ b/fix_win_ver.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+''' versioneer doesn't work for pyinstaller+windows for some reason so
+    this code is a hack to work around it '''
+
+import os
+import nowplaying.version
+
+
+def main():
+    ''' hack '''
+    official = nowplaying.version.get_versions()
+    filename = os.path.join('nowplaying', 'version.py')
+    os.unlink(filename)
+
+    routine = f'''
+def get_versions():
+    return {{"version": "{official['version']}",
+                         "full-revisionid": "{official['full-revisionid']}",
+                         "error": None,
+                         "dirty": {official['dirty']},
+                "date": "{official['date']}"}}
+
+  '''
+
+    with open(filename, 'w') as fileh:
+        fileh.write(routine)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This code is a terrible hack but....  the core problem seems to be that versioneer doesn't work inside pyinstaller-built binaries for Windows.  Running from the Windows command line, etc, works as expected.  Since this is a blocking issue for 3.x, this hack will at least move the project forward.

fixes #179 