### PR TITLE
Add comments as a key

### DIFF
--- a/docs/templatevariables.rst
+++ b/docs/templatevariables.rst
@@ -40,6 +40,8 @@ Support Variables
      - Bitrate the file was encoded at
    * - bpm
      - Beats per minute of the song
+   * - comments
+     - Comments from either the DJ software or the song file, whichever is discovered first
    * - composer
      - Composer of the song
    * - coverurl

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -72,6 +72,7 @@ class MetadataDB:
         'artist',
         'bitrate',
         'bpm',
+        'comments',
         'composer',
         'coverurl',
         'date',

--- a/nowplaying/inputs/serato.py
+++ b/nowplaying/inputs/serato.py
@@ -708,6 +708,7 @@ class SeratoHandler():
                 'artist',
                 'bitrate',
                 'bpm',
+                'comments',
                 'composer',
                 'date',
                 'deck',
@@ -873,7 +874,6 @@ class Plugin(InputPlugin):
 
     def load_settingsui(self, qwidget):
         ''' draw the plugin's settings page '''
-
         def handle_deckskip(cparser, qwidget):
             deckskip = cparser.value('serato/deckskip')
             qwidget.deck1_checkbox.setChecked(False)
@@ -912,7 +912,6 @@ class Plugin(InputPlugin):
         qwidget.remote_poll_lineedit.setText(
             str(self.config.cparser.value('serato/interval')))
         handle_deckskip(self.config.cparser, qwidget)
-
 
     def verify_settingsui(self, qwidget):
         ''' no verification to do '''

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -46,8 +46,8 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
             return
 
         for key in [
-                'album', 'albumartist', 'artist', 'bpm', 'composer', 'genre',
-                'key', 'label', 'title'
+                'album', 'albumartist', 'artist', 'bpm', 'comments',
+                'composer', 'genre', 'key', 'label', 'title'
         ]:
             if key not in self.metadata and key in base.tags:
                 if isinstance(base.tags[key], list):
@@ -95,9 +95,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         if tag:
             for key in [
                     'album', 'albumartist', 'artist', 'bitrate', 'bpm',
-                    'composer', 'disc', 'disc_total', 'genre', 'key',
-                    'publisher', 'lang', 'title', 'track', 'track_total',
-                    'year'
+                    'comments', 'composer', 'disc', 'disc_total', 'genre',
+                    'key', 'lang', 'publisher', 'title', 'track',
+                    'track_total', 'year'
             ]:
                 if key not in self.metadata and hasattr(tag, key) and getattr(
                         tag, key):


### PR DESCRIPTION
Fixes #196 

Basically:
  Metadata provided by Serato > metadata provided by files

An important note is that AIFF have _two_ comment fields.  The one in the ID3 field takes precedence, IIRC.