### PR TITLE
Add a delay for twitchbot announce; fix transparent png

### DIFF
--- a/nowplaying/resources/twitchbot_ui.ui
+++ b/nowplaying/resources/twitchbot_ui.ui
@@ -17,9 +17,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>40</y>
+     <y>20</y>
      <width>621</width>
-     <height>161</height>
+     <height>183</height>
     </rect>
    </property>
    <layout class="QFormLayout" name="settings_layout">
@@ -117,13 +117,30 @@
       </property>
      </widget>
     </item>
+    <item row="5" column="0">
+     <widget class="QLabel" name="announce_delay_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Announce Delay</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QLineEdit" name="announce_delay_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QCheckBox" name="enable_checkbox">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>10</y>
+     <y>0</y>
      <width>141</width>
      <height>23</height>
     </rect>
@@ -467,6 +484,38 @@
     <hint type="destinationlabel">
      <x>181</x>
      <y>352</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_delay_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>64</x>
+     <y>188</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>announce_delay_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>188</y>
     </hint>
    </hints>
   </connection>

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -258,6 +258,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods
             self.config.cparser.value('twitchbot/announce'))
         self.widgets['twitchbot'].commandchar_lineedit.setText(
             self.config.cparser.value('twitchbot/commandchar'))
+        self.widgets['twitchbot'].announce_delay_lineedit.setText(
+            self.config.cparser.value('twitchbot/announcedelay'))
 
     def _upd_win_plugins(self):
         ''' tell config to trigger plugins to update windows '''
@@ -420,6 +422,10 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods
         self.config.cparser.setValue(
             'twitchbot/commandchar',
             self.widgets['twitchbot'].commandchar_lineedit.text())
+
+        self.config.cparser.setValue(
+            'twitchbot/announcedelay',
+            self.widgets['twitchbot'].announce_delay_lineedit.text())
 
         reset_commands(self.widgets['twitchbot'].command_perm_table,
                        self.config.cparser)

--- a/nowplaying/twitchbot.py
+++ b/nowplaying/twitchbot.py
@@ -124,6 +124,16 @@ class TwitchBot(irc.bot.SingleServerIRCBot):  # pylint: disable=too-many-instanc
         self.watcher.start(customhandler=self._announce_track)
         self._announce_track(None)
 
+    def _delay_write(self):
+        try:
+            delay = self.config.cparser.value('twitchbot/announcedelay',
+                                              type=float,
+                                              defaultValue=1.0)
+        except ValueError:
+            delay = 1.0
+        logging.debug('got delay of %s', delay)
+        time.sleep(delay)
+
     def _announce_track(self, event):  # pylint: disable=unused-argument
         ''' announce new tracks '''
         self.config.get()
@@ -136,6 +146,8 @@ class TwitchBot(irc.bot.SingleServerIRCBot):  # pylint: disable=too-many-instanc
 
         self.lastannounced['artist'] = metadata['artist']
         self.lastannounced['title'] = metadata['title']
+
+        self._delay_write()
 
         logging.info('Announcing %s',
                      self.config.cparser.value('twitchbot/announce'))

--- a/nowplaying/webserver.py
+++ b/nowplaying/webserver.py
@@ -43,9 +43,10 @@ INDEXREFRESH = \
     '<body></body></html>\n'
 
 
-TRANSPARENT_PNG = base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC'\
-                                   '1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAA'\
-                                   'ASUVORK5CYII=')
+TRANSPARENT_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC'\
+                  '1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAA'\
+                  'ASUVORK5CYII='
+TRANSPARENT_PNG_BIN = base64.b64decode(TRANSPARENT_PNG)
 
 
 class WebHandler():
@@ -149,7 +150,7 @@ class WebHandler():
                                 body=metadata['coverimageraw'])
         # rather than return an error, just send a transparent PNG
         # this makes the client code significantly easier
-        return web.Response(content_type='image/png', body=TRANSPARENT_PNG)
+        return web.Response(content_type='image/png', body=TRANSPARENT_PNG_BIN)
 
     async def api_v1_last_handler(self, request):
         ''' handle static index.txt '''
@@ -179,7 +180,10 @@ class WebHandler():
             # early launch can be a bit weird so
             # pause a bit
             await asyncio.sleep(1)
-            metadata = database.read_last_meta()
+            metadata = None
+            while not metadata:
+                metadata = database.read_last_meta()
+                await asyncio.sleep(1)
             if 'coverimageraw' in metadata:
                 metadata['coverimagebase64'] = base64.b64encode(
                     metadata['coverimageraw']).decode('utf-8')


### PR DESCRIPTION
fixes #208 

The fallback transparent PNG wasn't in the correct format so it was failing websocket clients.