### PR TITLE
More tests and more bugfixes as a result of testing

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -48,7 +48,7 @@ jobs:
             export FPCALC
             popd
             source /tmp/venv/bin/activate
-            python3 -m pytest
+            pytest
           fi
       - name: artifact mac test
         uses: actions/upload-artifact@v2
@@ -105,7 +105,7 @@ jobs:
             FPCALC=/tmp/chromaprint-fpcalc-1.5.0-windows-x86_64/fpcalc.exe
             export FPCALC
             popd
-            python -m pytest
+            pytest
           fi
       - name: artifact windows test
         uses: actions/upload-artifact@v2
@@ -166,7 +166,7 @@ jobs:
             export FPCALC
             popd
             #source /tmp/venv/bin/activate
-            python3 -m pytest
+            pytest
           fi
       - name: artifact linux test
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ nowplaying.pyproject.user
 .coverage
 .coverage.*
 htmlcov/
+.pytest_cache

--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -4,3 +4,4 @@ nowplaying/vendor/
 bincomponents/
 versioneer.py
 NowPlaying.spec
+tests/seratolive/2021_08_25_pong.html

--- a/conftest.py
+++ b/conftest.py
@@ -1,29 +1,88 @@
 #!/usr/bin/env python3
 ''' pytest fixtures '''
 
-import os
 import logging
+import os
+import sys
+
+import psutil
 import pytest
+from PySide2.QtCore import QCoreApplication, QSettings  # pylint: disable=no-name-in-module
 
 import nowplaying.bootstrap
 import nowplaying.config
 
+if sys.platform == 'darwin':
+    import pwd
 
-@pytest.fixture
-def bootstrap():
-    ''' bootstrap a configuration '''
-    bundledir = os.path.abspath(os.path.dirname(__file__))
-    logging.basicConfig(level=logging.DEBUG)
-    nowplaying.bootstrap.set_qt_names(appname='testsuite')
-    config = nowplaying.config.ConfigFile(bundledir=bundledir, testmode=True)
-    config.cparser.sync()
-    yield config
-    config.cparser.clear()
-    if os.path.exists(config.cparser.fileName()):
-        os.unlink(config.cparser.fileName())
+
+def reboot_macosx_prefs():
+    ''' work around Mac OS X's preference caching '''
+    if sys.platform == 'darwin':
+        for process in psutil.process_iter():
+            if 'cfprefsd' in process.name() and pwd.getpwuid(
+                    os.getuid()).pw_name == process.username():
+                process.terminate()
+                process.wait()
 
 
 @pytest.fixture
 def getroot(pytestconfig):
     ''' get the base of the source tree '''
     return pytestconfig.rootpath
+
+
+@pytest.fixture
+def bootstrap(getroot):  # pylint: disable=redefined-outer-name
+    ''' bootstrap a configuration '''
+    bundledir = os.path.join(getroot, 'nowplaying')
+    nowplaying.bootstrap.set_qt_names(appname='testsuite')
+    config = nowplaying.config.ConfigFile(bundledir=bundledir, testmode=True)
+    config.cparser.setValue('acoustidmb/enabled', False)
+    config.cparser.setValue('acrcloud/enabled', False)
+    config.cparser.sync()
+    yield config
+
+
+#
+# OS X has a lot of caching wrt preference files
+# so we have do a lot of work to make sure they
+# don't stick around
+#
+@pytest.fixture(autouse=True, scope="function")
+def clear_old_testsuite():
+    ''' clear out old testsuite configs '''
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    nowplaying.bootstrap.set_qt_names(appname='testsuite')
+    config = QSettings(qsettingsformat, QSettings.SystemScope,
+                       QCoreApplication.organizationName(),
+                       QCoreApplication.applicationName())
+    config.clear()
+    config.sync()
+
+    config = QSettings(qsettingsformat, QSettings.UserScope,
+                       QCoreApplication.organizationName(),
+                       QCoreApplication.applicationName())
+    config.clear()
+    config.sync()
+    filename = config.fileName()
+    del config
+    if os.path.exists(filename):
+        os.unlink(filename)
+    reboot_macosx_prefs()
+    if os.path.exists(filename):
+        os.unlink(filename)
+    reboot_macosx_prefs()
+    if os.path.exists(filename):
+        logging.error('Still exists, wtf?')
+    yield filename
+    if os.path.exists(filename):
+        os.unlink(filename)
+    reboot_macosx_prefs()
+    if os.path.exists(filename):
+        os.unlink(filename)
+    reboot_macosx_prefs()

--- a/nowplaying/__init__.py
+++ b/nowplaying/__init__.py
@@ -11,10 +11,10 @@ import nowplaying.version
 __version__ = nowplaying.version.get_versions()['version']
 
 
-def main():  #pylint: disable=missing-function-docstring
+def main():  #pylint: disable=missing-function-docstring; pragma: no cover
     from .__main__ import main as realmain  #pylint: disable=import-outside-toplevel
     realmain()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -16,6 +16,11 @@ import nowplaying.config
 import nowplaying.db
 import nowplaying.systemtray
 
+# pragma: no cover
+#
+# as of now, there isn't really much here to test... basic bootstrap stuff
+#
+
 
 def run_bootstrap(bundledir=None):
     ''' bootstrap the app '''

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -105,7 +105,7 @@ class MetadataDB:
 
         if databasefile:
             self.databasefile = databasefile
-        else:
+        else:  # pragma: no cover
             self.databasefile = os.path.join(
                 QStandardPaths.standardLocations(
                     QStandardPaths.CacheLocation)[0], 'npsql.db')

--- a/nowplaying/inputs/__init__.py
+++ b/nowplaying/inputs/__init__.py
@@ -18,7 +18,7 @@ class InputPlugin():
             self.defaults(qsettings)
             return
 
-        if not config:
+        if not config:  # pragma: no cover
             self.config = nowplaying.config.ConfigFile()
 
 #### Settings UI methods

--- a/nowplaying/recognition/__init__.py
+++ b/nowplaying/recognition/__init__.py
@@ -18,7 +18,7 @@ class RecognitionPlugin():
             self.defaults(qsettings)
             return
 
-        if not config:
+        if not config:  # pragma: no cover
             self.config = nowplaying.config.ConfigFile()
 
 #### Settings UI methods

--- a/nowplaying/trackpoll.py
+++ b/nowplaying/trackpoll.py
@@ -58,6 +58,7 @@ class TrackPoll(QThread):  # pylint: disable=too-many-instance-attributes
 
     def __del__(self):
         logging.debug('TrackPoll is being killed!')
+        self.input.stop()
         self.endthread = True
         self.plugins = None
 

--- a/nowplaying/utils.py
+++ b/nowplaying/utils.py
@@ -75,7 +75,7 @@ def getmoremetadata(metadata=None):
     try:
         myclass = nowplaying.metadata.MetadataProcessors(metadata=metadata)
         metadata = myclass.metadata
-    except IOError as error:  # pylint: disable=broad-except
+    except IOError as error:  # pragma: no cover
         logging.error('MetadataProcessor failed for %s with %s',
                       metadata['filename'], error)
 
@@ -120,10 +120,10 @@ def import_plugins(namespace):
         # See https://github.com/pyinstaller/pyinstaller/issues/1905#issuecomment-445787510
         toc = set()
         for importer in pkgutil.iter_importers(
-                ns_pkg.__name__.partition(".")[0]):
+                ns_pkg.__name__.partition(".")[0]):  # pragma: no cover
             if hasattr(importer, 'toc'):
                 toc |= importer.toc
-        for name in toc:
+        for name in toc:  # pragma: no cover
             if name.startswith(prefix):
                 yield name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,14 @@ testpaths = [
 ]
 markers = [
     "seratosettings: custom settings for serato ",
+    "templatesettings: custom settings for templates",
 ]
 qt_api = "pyside2"
 log_cli = true
 addopts = [
   "--cov=nowplaying",
   "--cov-config=.coveragerc",
-  "--cov-report=html"
+  "--cov-report=html",
+  "-ra",
 ]
+log_level = "DEBUG"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ lxml==4.6.3
 musicbrainzngs==0.7.1
 obs-websocket-py==0.5.3
 pillow==8.3.1
+psutil==5.8.0
 pyacoustid==1.2.0
 pyinstaller==4.4
 pyinstaller_versionfile==2.0.0
@@ -14,6 +15,7 @@ PySide2==5.15.2
 pytest==6.2.4
 pytest-qt==4.0.2
 pytest-cov==2.12.1
+pytest-httpserver==1.0.1
 requests==2.26.0
 Sphinx==4.1.2
 tinytag==1.5.0

--- a/tests/seratolive/2021_08_25_pong.html
+++ b/tests/seratolive/2021_08_25_pong.html
@@ -1,0 +1,1518 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <!-- Head -->
+    <!-- Google Optimize -->
+<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/optimize.js"></script>
+<!-- Required meta tags -->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<!-- Javascript -->
+<script type="application/javascript">
+  var notificationsBaseUri = "https://notifications.serato.com/api/v1/notifications"
+</script>
+            <!-- The nice minified version stripped of warnings  -->
+        <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/vue2.12"></script>
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_external_jquery-3.js" type="text/javascript" charset="utf-8"></script>
+<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_tracking_612c107a926abd3294a98b0f366a5b9d.js" type="text/javascript" charset="utf-8"></script>
+<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/meganav_b2f6321c9404e02c77271d5b6ef05a93.js" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript">
+	dataLayer = window.dataLayer || [];
+				dataLayer.push({
+							'dimension1': 'no',
+							'userId': undefined,
+							'dimension28': 'row',
+							'dimension2': 'Playlists pages'
+			
+		});
+		
+</script><!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5GKR44');</script>
+<!-- End Google Tag Manager --><script type="text/javascript">
+	(function( window ){
+		var f = function(){
+			if( $( '#g-recaptcha' ).length > 0 ){
+				grecaptcha.render('g-recaptcha', {
+					sitekey : '6LeCBCoTAAAAAChhj9L8t8u7HW-9TwfAokU_nJIu'
+				});
+			}
+		}
+		window.render_recaptcha_callback = f;
+	})(window);
+	window.onload=window.render_recaptcha_callback;
+</script>
+<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/api.js" async="" defer="defer"></script>
+
+<meta name="description" content="Serato DJ, World Leading DJ and Music software. Serato provides award-winning DJ software used by the leading touring and club DJs. Blend, mix and scratch your tracks with Serato DJ.">
+
+    <meta name="keywords" content="DJ Software, DJ management software, mixing software, vinyl, timecode, scratch, DJ hardware, software download, numark, pioneer, roland dj, turntables, controller, beat matching, BPM matching, pro dj software, free dj software, mix, learn to dj, loops, sampler, denon, flip.">
+
+
+<!-- Google Webmaster Tools -->
+<meta name="google-site-verification" content="O80tMSpnuSew5sesYz8nwr35ZVOy9LGnoJqwSUkuUCw">
+<!-- Google Apps -->
+<meta name="google-site-verification" content="SQPjt9ArGCQazxZ2LAPFBxFHRqnzXyWM9u1dvyL6rRk">
+<!-- Facebook instant article -->
+<meta property="fb:pages" content="168400533015">
+
+<meta property="og:type" content="website">
+    <meta property="og:image" content="https://m.cdn.sera.to/v3/open-graph/playlists-og.jpg"><meta property="og:type" content="website">
+<meta property="og:image" content="">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<title>2021/08/25 - pong - Serato DJ Playlists</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="https://m.cdn.sera.to/favicon-32.ico">
+
+<!-- Fonts.com -->
+<link type="text/css" rel="stylesheet" href="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/295174d8-ce9c-4a7f-99ba-98bfaede73f9.css">
+
+<!-- CSS -->
+<link href="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_external_bootstrap.css" rel="stylesheet" type="text/css" media="">
+<link href="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_main_df433dcd40cfb3555ccbd3a16bcbdc48.css" rel="stylesheet" type="text/css" media="">
+<link href="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/atomic_style_style_339316448fbe8077b69b24f80ace0e88.css" rel="stylesheet" type="text/css">
+
+
+
+<!-- What even is this? -->
+<script type="text/javascript">
+    var site = 'html5-serato';
+    
+var SeratoCDNNames = {
+css : 'a.cdn.sera.to',
+js : 'a.cdn.sera.to',
+img : 'm.cdn.sera.to'
+}
+    var displayForMobile = false;
+        </script>
+
+<!-- Default sitewide og:image -->
+<meta property="og:image" content="https://m.cdn.sera.to/v3/homepage/background/home-hero-ls-3-md.jpg">
+  </head>
+
+  <body data-new-gr-c-s-check-loaded="8.883.0" data-gr-ext-installed="">
+    <!-- GTM noscript -->
+    
+<!-- Google Tag Manager (noscript) -->
+<span><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5GKR44" style="display:none;visibility:hidden" q8c6xflu3="" width="0" height="0"></iframe></span>
+<!-- End Google Tag Manager (noscript) -->
+    <!-- Header -->
+    <header id="primary-header">
+      <div class="white alert-banner" id="alert-banner">
+    <span class="alert-banner-body"></span>
+    <span class="alert-banner-close"> CLOSE <strong>X</strong></span>
+</div>
+
+<div class="o-header">
+    <div id="logoHeader">
+        <a href="https://serato.com/" class="a-Logo--Header">
+            <img src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/logo.svg" alt="Serato logo">
+        </a>
+    </div>
+    <span id="toggle-nav" class="fa fas fa-bars hidden-md hidden-lg"></span>
+      
+
+
+    <nav class="m-NavHeader">
+        <ul class="level-10 u-ResetUl">
+            <li class="m-NavHeader--Expanded">
+                <a class="a-Link--PrimaryNavItem  a-Link--PrimaryNavItem a-Link--PrimaryNavItemIcon ">Products</a>
+                <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+                <ul class="o-MegaNav js-DropdownMenuMobile">
+                    <li class="m-MegaNavColumn m-MegaNavColumn--IconTile hidden-xs hidden-sm">
+                        <ul class="u-ResetUl level-20">
+                            <li class="m-MegaNavColumn__NavAnnouncement">
+                                <a class="a-Link--PrimaryNavItem " id="meganav-link-copy" href="">
+                                    <i class="fa fas fa-bullhorn a-Icon--LightBlueIcon"></i>
+                                </a>
+                                <ul class="level-30 m-List m-List--HrDivider">
+                                    <li class="m-ListLi">
+                                        <a id="meganav-link-img" href="">
+                                            <img class="img-responsive" src="" alt="">
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+
+                    <li class="m-MegaNavColumn">
+                        <ul class="level-20 u-ResetUl">
+                            <li class="">
+                                <a href="https://serato.com/dj" class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIcon--OnlyMobile">Serato
+                                    DJ</a>
+                                <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+
+                                <ul class="level-30 m-List m-List--HrDivider js-DropdownMenuMobile">
+                                    <li class="m-ListLi m-ListLi--DownloadNav">
+                                        <a href="https://serato.com/dj/pro" class="a-Link--PrimaryNavItem ">Serato DJ Pro</a>
+                                        <a class="a-Link--PrimaryNavItem  a-Link--DownLoadNavItem  hidden-xs hidden-sm" href="https://serato.com/dj/pro/downloads">
+                                            <i class="fa fas fa-download a-Icon--BlueIcon" aria-hidden="true"></i>Download
+                                        </a>
+                                    </li>
+                                    <li class="m-ListLi m-ListLi--DownloadNav">
+                                        <a href="https://serato.com/dj/lite" class="a-Link--PrimaryNavItem ">Serato DJ Lite</a>
+                                        <a class="a-Link--PrimaryNavItem  a-Link--DownLoadNavItem  hidden-xs hidden-sm --primaryNavItem" href="https://serato.com/dj/lite/downloads">
+                                            <i class="fa fas fa-download a-Icon--GreenIcon" aria-hidden="true"></i>Download
+                                        </a>
+                                    </li>
+                                    <li class="m-ListLi"><a href="https://serato.com/dj/pro/expansions" class="a-Link--PrimaryNavItem ">Expansion
+                                            Packs</a></li>
+                                    <li class="m-ListLi"><a href="https://serato.com/dj/hardware" class="a-Link--PrimaryNavItem ">DJ
+                                            Hardware</a></li>
+                                    <li class="m-ListLi"><a href="https://serato.com/dj/pro/buy-dj-pro" class="a-Link--PrimaryNavItem ">Pricing</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+
+                    <li class="m-MegaNavColumn">
+                        <ul class="level-20 u-ResetUl">
+                            <li>
+                                <a href="https://serato.com/music-production" class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIcon--OnlyMobile">Music
+                                    Production</a>
+                                <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+
+                                <ul class="level-30 m-List m-List--HrDivider js-DropdownMenuMobile">
+                                    <li class="m-ListLi m-ListLi--DownloadNav">
+                                        <a href="https://serato.com/studio" class="a-Link--PrimaryNavItem ">Serato Studio</a>
+                                        <a class="a-Link--PrimaryNavItem  a-Link--DownLoadNavItem  hidden-xs hidden-sm --primaryNavItem hidden-xs hidden-sm" href="https://serato.com/studio/downloads">
+                                            <i class="fa fas fa-download a-Icon--PurpleIcon" aria-hidden="true"></i>Download
+                                        </a>
+                                    </li>
+                                    <li class="m-ListLi m-ListLi--DownloadNav">
+                                        <a href="https://serato.com/sample" class="a-Link--PrimaryNavItem ">Serato Sample</a>
+                                        <a class="a-Link--PrimaryNavItem  a-Link--DownLoadNavItem  hidden-xs hidden-sm --primaryNavItem hidden-xs hidden-sm" href="https://serato.com/sample/downloads">
+                                            <i class="fa fas fa-download a-Icon--YellowIcon" aria-hidden="true"></i>Download
+                                        </a>
+                                    </li>
+                                    <li class="m-ListLi"><a href="https://serato.com/pitchntime" class="a-Link--PrimaryNavItem ">Pitch
+                                            ’n Time</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+
+                    <li class="m-MegaNavColumn">
+                        <ul class="u-ResetUl level-20">
+                            <li>
+                                <a href="https://serato.com/vinyl-and-merch" class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIcon--OnlyMobile">Control
+                                    Vinyl &amp; Merch</a>
+                                <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+                                <ul class="level-30 m-List m-List--HrDivider js-DropdownMenuMobile">
+                                    <li class="m-ListLi"><a class="a-Link--PrimaryNavItem" href="https://serato.com/vinyl-and-merch/vinyl">Vinyl</a></li>
+                                    <li class="m-ListLi"><a class="a-Link--PrimaryNavItem" href="https://serato.com/vinyl-and-merch/apparel">Apparel</a></li>
+                                    <li class="m-ListLi"><a class="a-Link--PrimaryNavItem" href="https://serato.com/vinyl-and-merch/accessories">Accessories</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="hidden-xs hidden-sm">
+                                <ul class="level-30 m-List m-List--HrDivider">
+                                    <li class="m-ListLi"><a class="a-Link--PrimaryNavItem " href="https://serato.com/legacy-products">Legacy
+                                            Software</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+
+                    <li class="m-MegaNavColumn visible-xs visible-sm hidden-md hidden-lg">
+                        <ul class="u-ResetUl level-20">
+                            <li>
+                                <a class="a-Link--PrimaryNavItem " href="https://serato.com/legacy-products">Legacy Software</a></li>
+                            
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+
+            <li>
+                <a class="a-Link--PrimaryNavItem   " href="https://serato.com/artists">Artists</a>
+            </li>
+
+            <li class="m-NavHeader--Expanded">
+                <a class="a-Link--PrimaryNavItem  a-Link--PrimaryNavItem a-Link--PrimaryNavItemIcon selected">Community</a>
+                <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+                <ul class="o-MegaNav o-MegaNav__Small u-ResetUl js-DropdownMenuMobile">
+                    <li class="m-MegaNavColumn m-MegaNavColumn__Small">
+                        <ul class="level-20">
+                            <li class="m-ListLi"><a class="a-Link--PrimaryNavItem " href="https://serato.com/forum">Forum</a></li>
+                            <li class="m-ListLi"><a class="a-Link--PrimaryNavItem " href="https://serato.com/playlists">Playlists</a></li>
+                            <li class="m-ListLi"><a class="a-Link--PrimaryNavItem " href="https://serato.com/certified-dj-schools">Certified DJ Schools</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+
+            <li>
+                <a class="a-Link--PrimaryNavItem " href="https://the-drop.serato.com/">Blog</a>
+            </li>
+            <li class="hidden-md hidden-lg">
+                <a class="a-Link--PrimaryNavItem" href="https://support.serato.com/hc/en-us">Support</a>
+            </li>
+            <li class="hidden-md hidden-lg m-NavHeader--Expanded m-NavHeader--Expanded--UserMenu m-NavHeaderAccountMenu">
+                <span class="m-NavHeader--Expanded">
+     <a class="m-NavUser__Profile  m-NavHeader--Expanded--UserMenu a-Link--PrimaryNavItem  a-Link--PrimaryNavItem ">
+        <img class="m-NavUser__Profile__ImgLoggedOut" src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/account-icon.svg" alt="User Avatar">
+    </a>
+    <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+    <ul class="o-MegaNav o-MegaNav__UserMenu u-ResetUl js-DropdownMenuMobile js-hover-AvatarUserMenu">
+        <li class="m-MegaNavColumn m-MegaNavColumn__UserMenu">
+            <ul class="level-20">
+                <li class="m-ListLi">
+                    <a class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIconUserMenu" href="https://serato.com/login?redirect=%2Fplaylists%2Fpong%2Flive">
+                        Sign in
+                    </a>
+                </li>
+                <li class="m-ListLi m-ListLi--UserTitle"><p>Don't have an account?</p></li>
+                <li class="m-ListLi">
+                    <a class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIconUserMenu" href="https://serato.com/create?redirect=%2Fplaylists%2Fpong%2Flive">
+                        Create account
+                    </a>
+                </li>
+            </ul>
+        </li>
+    </ul>
+ </span>
+            </li>
+        </ul>
+    </nav>
+
+    <div class="m-NavUser">
+        <a class="m-NavUser__Support a-Link--PrimaryNavItem " href="https://support.serato.com/hc/en-us">Support</a>
+        <span class="m-NavUser__Forum"></span>
+        <span class="m-NavHeader--Expanded">
+     <a class="m-NavUser__Profile  m-NavHeader--Expanded--UserMenu a-Link--PrimaryNavItem  a-Link--PrimaryNavItem ">
+        <img class="m-NavUser__Profile__ImgLoggedOut" src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/account-icon.svg" alt="User Avatar">
+    </a>
+    <i class="fa fas fa-angle-down js-ToogleMenuIcon hidden-md hidden-lg"></i>
+    <ul class="o-MegaNav o-MegaNav__UserMenu u-ResetUl js-DropdownMenuMobile js-hover-AvatarUserMenu">
+        <li class="m-MegaNavColumn m-MegaNavColumn__UserMenu">
+            <ul class="level-20">
+                <li class="m-ListLi">
+                    <a class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIconUserMenu" href="https://serato.com/login?redirect=%2Fplaylists%2Fpong%2Flive">
+                        Sign in
+                    </a>
+                </li>
+                <li class="m-ListLi m-ListLi--UserTitle"><p>Don't have an account?</p></li>
+                <li class="m-ListLi">
+                    <a class="a-Link--PrimaryNavItem a-Link--PrimaryNavItemIconUserMenu" href="https://serato.com/create?redirect=%2Fplaylists%2Fpong%2Flive">
+                        Create account
+                    </a>
+                </li>
+            </ul>
+        </li>
+    </ul>
+ </span>
+    </div>
+
+</div>
+<div class="ck-banner " id="cookie-info-banner">
+
+    <div class="inner-box">
+        <i class="fa fas fa-info-circle" aria-hidden="true"></i>
+        <p>We use cookies to ensure that we give you the best experience on our website.</p>
+        <div class="no-wrap">
+            <a id="cookie-info-link" href="https://serato.com/legal/cookies?ref=banner" ref="no-opt-in">MANAGE SETTINGS</a>
+            <a id="cookie-info-accept" onclick="cookieConsent.acceptCookieAgreement()" class="agree-btn">Accept &amp;
+                Continue</a>
+        </div>
+    </div>
+</div>
+    </header>
+    <div class="push"></div>
+    <!-- Content -->
+    <div id="main" role="main" class="pbb" data-page-classes="">
+	<!-- Masthead -->
+
+
+
+
+<div class="wrap-playlist-header">
+    <div class="bg-blurred" style="background-image: url();">
+        <svg width="100%" height="100%">
+            <defs>
+                <filter id="svgBlur" x="0" y="0" width="100%" height="100%">
+                    <feGaussianBlur in="SourceGraphic" stdDeviation="3"></feGaussianBlur>
+                </filter>
+            </defs>
+            <image xlink:href="https://m.cdn.sera.to/playlists/playlist-default/default_large.png" width="100%" height="100%" filter="url(#svgBlur)"></image>
+        </svg>
+    </div>
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
+                <div class="playlist-image">
+                    <img id="playlist_image" class="img-responsive" src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/default_large.png" alt="2021/08/25">
+                    <div id="playlist-image-options" class="playlist-image-options">
+                        					</div>
+                </div>
+            </div>
+            <div class="col-xs-12 col-sm-6 col-md-8 col-lg-9">
+                <div class="playlist-heading">
+                    <h1>2021/08/25</h1>
+                    <span class="playlist-dj-subtitle">Serato Playlist by pong</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<!-- Secondary nav or breadcrumbs -->
+<div class="bg-black">
+	<div class="container breadcrumb-container">
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="breadcrumb-nav bold">
+    <div class="grad"></div>
+    <div class="scroll-container">
+        <a class="ib item first" href="https://serato.com/playlists">Serato Playlists<div class="divider"></div></a>
+                <i class="fa fas fa-lg fa-angle-right ib"></i><a class="ib item" href="https://serato.com/playlists/pong">pong<div class="divider"></div></a>
+                <i class="fa fas fa-lg fa-angle-right ib"></i>                    <div class="current ib item">
+                2021/08/25</div>
+            </div>
+</div>
+
+
+			</div>
+		</div>
+	</div>
+</div>
+
+<!-- Mobile download / call to action button -->
+
+<div id="content" class="container page-playlists">
+	<div class="row">
+		<div class="col-xs-12 col-md-7">
+                            			<h2 class="section-heading">Tracklist</h2>
+			<div id="playlist_tracklist" class="card no-border playlist-tracklist-view">
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                                                                        
+                            
+		<div class="playlist-track " id="track_85675512">
+            				<div class="playlist-timestamp">8:31pm				</div>
+								<div class="playlist-tracktime">
+					00:00:00				</div>
+            				<div class="playlist-trackname">
+                    Budgie - Touch Me 2				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675514">
+            				<div class="playlist-tracktime">
+                    00:02:05				</div>
+            				<div class="playlist-trackname">
+                    SiR - Footsteps in the Dark Pts. 1 &amp; 2				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675515">
+            				<div class="playlist-tracktime">
+                    00:03:02				</div>
+            				<div class="playlist-trackname">
+                    Aka Zeb, China, Pascal - Slow Sex				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675516">
+            				<div class="playlist-tracktime">
+                    00:03:05				</div>
+            				<div class="playlist-trackname">
+                    Thundercat - Dragonball Durag				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675517">
+            				<div class="playlist-tracktime">
+                    00:03:06				</div>
+            				<div class="playlist-trackname">
+                    The Pheels, LION BABE - Be Like That				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675518">
+            				<div class="playlist-tracktime">
+                    00:03:07				</div>
+            				<div class="playlist-trackname">
+                    Lady Donli, Kida Kudz - Classic				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675519">
+            				<div class="playlist-tracktime">
+                    00:03:08				</div>
+            				<div class="playlist-trackname">
+                    土岐麻子 - Hello, my friend				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675520">
+            				<div class="playlist-tracktime">
+                    00:03:11				</div>
+            				<div class="playlist-trackname">
+                    Brahny - Bloom				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675521">
+            				<div class="playlist-tracktime">
+                    00:03:12				</div>
+            				<div class="playlist-trackname">
+                    Budgie - Touch Me 2				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675522">
+            				<div class="playlist-tracktime">
+                    00:03:14				</div>
+            				<div class="playlist-trackname">
+                    City Girl, tiffi - Anything Like Her (feat. Tiffi)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675523">
+            				<div class="playlist-tracktime">
+                    00:03:15				</div>
+            				<div class="playlist-trackname">
+                    Hare Squead - 100 Miles				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675524">
+            				<div class="playlist-tracktime">
+                    00:03:17				</div>
+            				<div class="playlist-trackname">
+                    Kiana Ledé - Mad At Me.				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675525">
+            				<div class="playlist-tracktime">
+                    00:03:18				</div>
+            				<div class="playlist-trackname">
+                    nimino, Harrison Mayo - Back Up				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675526">
+            				<div class="playlist-tracktime">
+                    00:03:20				</div>
+            				<div class="playlist-trackname">
+                    Psalm Trees, Guillaume Muschalle - bringmesun				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675527">
+            				<div class="playlist-tracktime">
+                    00:03:21				</div>
+            				<div class="playlist-trackname">
+                    Reuben James, Keyon Harrold - Burn (feat. Keyon Harrold)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675528">
+            				<div class="playlist-tracktime">
+                    00:03:25				</div>
+            				<div class="playlist-trackname">
+                    Saib - Sweet Love				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675529">
+            				<div class="playlist-tracktime">
+                    00:03:26				</div>
+            				<div class="playlist-trackname">
+                    Shura, Ivy Sole - elevator girl ft. Ivy Sole				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675530">
+            				<div class="playlist-tracktime">
+                    00:03:30				</div>
+            				<div class="playlist-trackname">
+                    Sunni Colón - Baby I Don't Mind				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675531">
+            				<div class="playlist-tracktime">
+                    00:03:32				</div>
+            				<div class="playlist-trackname">
+                    EVISBEATS - City of light				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675532">
+            				<div class="playlist-tracktime">
+                    00:03:34				</div>
+            				<div class="playlist-trackname">
+                    KAMAUU, Adeline - MANGO (feat. Adeline)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675533">
+            				<div class="playlist-tracktime">
+                    00:04:18				</div>
+            				<div class="playlist-trackname">
+                    SiR - Footsteps in the Dark Pts. 1 &amp; 2				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675534">
+            				<div class="playlist-tracktime">
+                    00:05:03				</div>
+            				<div class="playlist-trackname">
+                    Budgie - Touch Me 2				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675535">
+            				<div class="playlist-tracktime">
+                    00:05:06				</div>
+            				<div class="playlist-trackname">
+                    LBL - trip on a trailer				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675536">
+            				<div class="playlist-tracktime">
+                    00:06:10				</div>
+            				<div class="playlist-trackname">
+                    Madlib - Drive In				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675538">
+            				<div class="playlist-tracktime">
+                    00:08:49				</div>
+            				<div class="playlist-trackname">
+                    Ezra Collective - Space is the Place				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675539">
+            				<div class="playlist-tracktime">
+                    00:12:08				</div>
+            				<div class="playlist-trackname">
+                    Sad, Slum Village, Melodiesinfonie - Nothing Left To Say - Melodiesinfonie Remix				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675540">
+            				<div class="playlist-tracktime">
+                    00:13:16				</div>
+            				<div class="playlist-trackname">
+                    Haile Supreme - Elsewhere				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675541">
+            				<div class="playlist-tracktime">
+                    00:14:48				</div>
+            				<div class="playlist-trackname">
+                    Julianna Townsend, Shuko, The BREED - Sunday Blues - Shuko &amp; The Breed Remix				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675542">
+            				<div class="playlist-tracktime">
+                    00:22:58				</div>
+            				<div class="playlist-trackname">
+                    Haile Supreme - Elsewhere				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675543">
+            				<div class="playlist-timestamp">9:14pm				</div>
+								<div class="playlist-tracktime">
+					00:43:18				</div>
+            				<div class="playlist-trackname">
+                    j'san - this feeling's too good				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675544">
+            				<div class="playlist-tracktime">
+                    00:43:25				</div>
+            				<div class="playlist-trackname">
+                    J. LAMOTTA すずめ - Turning - Flofilz Remix				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675545">
+            				<div class="playlist-tracktime">
+                    00:43:26				</div>
+            				<div class="playlist-trackname">
+                    Jazzbois, Kid Abstrakt - Live &amp; Direct - Live				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675546">
+            				<div class="playlist-tracktime">
+                    00:43:29				</div>
+            				<div class="playlist-trackname">
+                    Joe Hertz - Playing For You				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675547">
+            				<div class="playlist-tracktime">
+                    00:43:32				</div>
+            				<div class="playlist-trackname">
+                    Joel Culpepper, Kojey Radical - Caroline No				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675548">
+            				<div class="playlist-tracktime">
+                    00:43:33				</div>
+            				<div class="playlist-trackname">
+                    Kasia Konstance, Thelonious Coltrane - Cosmic Dust - Thelonious Coltrane Remix				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675549">
+            				<div class="playlist-tracktime">
+                    00:43:34				</div>
+            				<div class="playlist-trackname">
+                    maeshima soshi - ORR				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675550">
+            				<div class="playlist-tracktime">
+                    00:43:36				</div>
+            				<div class="playlist-trackname">
+                    Masego - Veg Out (Wasting Thyme)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675551">
+            				<div class="playlist-tracktime">
+                    00:43:39				</div>
+            				<div class="playlist-trackname">
+                    Master Soul Boy - Catharsis				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675552">
+            				<div class="playlist-tracktime">
+                    00:43:41				</div>
+            				<div class="playlist-trackname">
+                    Medasin, sophie meiers - Tired (feat. Sophie Meiers)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675553">
+            				<div class="playlist-tracktime">
+                    00:44:13				</div>
+            				<div class="playlist-trackname">
+                    Melody Gardot - Baby I'm A Fool				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675554">
+            				<div class="playlist-tracktime">
+                    00:44:14				</div>
+            				<div class="playlist-trackname">
+                    NakamuraEmi - 東京タワー				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675555">
+            				<div class="playlist-tracktime">
+                    00:44:15				</div>
+            				<div class="playlist-trackname">
+                    Nia Sultana - Positions				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675556">
+            				<div class="playlist-tracktime">
+                    00:44:40				</div>
+            				<div class="playlist-trackname">
+                    Phlocalyst, lōland - Arise				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675557">
+            				<div class="playlist-tracktime">
+                    00:44:41				</div>
+            				<div class="playlist-trackname">
+                    Robotaki, City Fidelia - Satisfied				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675558">
+            				<div class="playlist-tracktime">
+                    00:44:43				</div>
+            				<div class="playlist-trackname">
+                    Sweet William - Walkin				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675559">
+            				<div class="playlist-tracktime">
+                    00:44:44				</div>
+            				<div class="playlist-trackname">
+                    Wez Atlas - Overthink				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675560">
+            				<div class="playlist-tracktime">
+                    00:44:46				</div>
+            				<div class="playlist-trackname">
+                    xander., WEI, Annie Lux - Youth				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675561">
+            				<div class="playlist-tracktime">
+                    00:44:47				</div>
+            				<div class="playlist-trackname">
+                    Wez Atlas - Overthink				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675564">
+            				<div class="playlist-tracktime">
+                    00:45:10				</div>
+            				<div class="playlist-trackname">
+                    xander., WEI, Annie Lux - Youth				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675565">
+            				<div class="playlist-tracktime">
+                    00:45:20				</div>
+            				<div class="playlist-trackname">
+                    Young Bull, Christian Sinclair, Claire Dickson - Quiet (feat. Christian Sinclair &amp; Claire Dickson)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675566">
+            				<div class="playlist-tracktime">
+                    00:45:30				</div>
+            				<div class="playlist-trackname">
+                    ZIN - The Sign				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675569">
+            				<div class="playlist-tracktime">
+                    00:47:50				</div>
+            				<div class="playlist-trackname">
+                    唾奇 - Walkin				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675570">
+            				<div class="playlist-tracktime">
+                    00:47:52				</div>
+            				<div class="playlist-trackname">
+                    児玉奈央, Kan Sano - 瀬戸際のマーマレード				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675571">
+            				<div class="playlist-tracktime">
+                    00:47:54				</div>
+            				<div class="playlist-trackname">
+                    53 Thieves - what you do to me				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675572">
+            				<div class="playlist-tracktime">
+                    00:47:55				</div>
+            				<div class="playlist-trackname">
+                    Awich - Bad Bad				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675573">
+            				<div class="playlist-tracktime">
+                    00:48:23				</div>
+            				<div class="playlist-trackname">
+                    Burns Twins, Sam Hudgens, Omar Apollo - Day by Day				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675574">
+            				<div class="playlist-tracktime">
+                    00:48:51				</div>
+            				<div class="playlist-trackname">
+                    Dogg Master - Montmartre				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675575">
+            				<div class="playlist-tracktime">
+                    00:48:57				</div>
+            				<div class="playlist-trackname">
+                    J. LAMOTTA すずめ - If You Wanna				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675576">
+            				<div class="playlist-tracktime">
+                    00:49:01				</div>
+            				<div class="playlist-trackname">
+                    Dogg Master - Montmartre				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675577">
+            				<div class="playlist-tracktime">
+                    00:49:02				</div>
+            				<div class="playlist-trackname">
+                    J. LAMOTTA すずめ - If You Wanna				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675578">
+            				<div class="playlist-tracktime">
+                    00:49:04				</div>
+            				<div class="playlist-trackname">
+                    Dogg Master - Montmartre				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675579">
+            				<div class="playlist-tracktime">
+                    00:51:06				</div>
+            				<div class="playlist-trackname">
+                    j'san - this feeling's too good				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675580">
+            				<div class="playlist-tracktime">
+                    00:51:38				</div>
+            				<div class="playlist-trackname">
+                    D'Angelo - Feel Like Makin' Love				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675583">
+            				<div class="playlist-timestamp">10:03pm				</div>
+								<div class="playlist-tracktime">
+					01:32:09				</div>
+            				<div class="playlist-trackname">
+                    ZIN - The Sign				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675584">
+            				<div class="playlist-tracktime">
+                    01:34:57				</div>
+            				<div class="playlist-trackname">
+                    Dogg Master - Montmartre				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675585">
+            				<div class="playlist-tracktime">
+                    01:37:18				</div>
+            				<div class="playlist-trackname">
+                    J. LAMOTTA すずめ - If You Wanna				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675589">
+            				<div class="playlist-tracktime">
+                    01:40:31				</div>
+            				<div class="playlist-trackname">
+                    9m88 - Aim High				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675597">
+            				<div class="playlist-tracktime">
+                    01:43:13				</div>
+            				<div class="playlist-trackname">
+                    松任谷由実 - 影になって				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675606">
+            				<div class="playlist-tracktime">
+                    01:45:18				</div>
+            				<div class="playlist-trackname">
+                    yeyts., igory - 93.				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675616">
+            				<div class="playlist-tracktime">
+                    01:47:16				</div>
+            				<div class="playlist-trackname">
+                    Miller Blue, Kan Sano - Rhythm in the Dance - Kan Sano Remix				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675617">
+            				<div class="playlist-tracktime">
+                    01:49:04				</div>
+            				<div class="playlist-trackname">
+                    Monsune - OUTTA MY MIND				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675618">
+            				<div class="playlist-tracktime">
+                    01:52:29				</div>
+            				<div class="playlist-trackname">
+                    Nymano, Pandrezz, Namuuna - This Is Love				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675623">
+            				<div class="playlist-tracktime">
+                    01:53:34				</div>
+            				<div class="playlist-trackname">
+                    Moonchild - Too Much to Ask				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675627">
+            				<div class="playlist-tracktime">
+                    01:55:14				</div>
+            				<div class="playlist-trackname">
+                    Burns Twins, Sam Hudgens, Omar Apollo - Day by Day				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675635">
+            				<div class="playlist-tracktime">
+                    01:56:51				</div>
+            				<div class="playlist-trackname">
+                    xander., WEI, Annie Lux - Youth				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675643">
+            				<div class="playlist-tracktime">
+                    01:59:28				</div>
+            				<div class="playlist-trackname">
+                    Taste of Pluto, Navy, Marwin - Scorpio's Letter				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675661">
+            				<div class="playlist-tracktime">
+                    02:02:03				</div>
+            				<div class="playlist-trackname">
+                    Nia Sultana - Positions				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675674">
+            				<div class="playlist-tracktime">
+                    02:04:19				</div>
+            				<div class="playlist-trackname">
+                    Snoh Aalegra - I Want You Around				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675676">
+            				<div class="playlist-tracktime">
+                    02:05:23				</div>
+            				<div class="playlist-trackname">
+                    Galdive - Maybe I				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675677">
+            				<div class="playlist-tracktime">
+                    02:06:28				</div>
+            				<div class="playlist-trackname">
+                    J. LAMOTTA すずめ - Turning - Flofilz Remix				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675679">
+            				<div class="playlist-tracktime">
+                    02:08:56				</div>
+            				<div class="playlist-trackname">
+                    Master Soul Boy - Catharsis				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675684">
+            				<div class="playlist-tracktime">
+                    02:10:03				</div>
+            				<div class="playlist-trackname">
+                    53 Thieves - what you do to me				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675937">
+            				<div class="playlist-tracktime">
+                    02:11:44				</div>
+            				<div class="playlist-trackname">
+                    Hablot Brown, Gabrielle Current - Pressure				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675953">
+            				<div class="playlist-tracktime">
+                    02:13:23				</div>
+            				<div class="playlist-trackname">
+                    Eli Way, Emily Muli - Stuck				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675959">
+            				<div class="playlist-tracktime">
+                    02:15:05				</div>
+            				<div class="playlist-trackname">
+                    BOiTELLO - STAY				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675961">
+            				<div class="playlist-tracktime">
+                    02:15:30				</div>
+            				<div class="playlist-trackname">
+                    Primary, OHHYUK - Bawling				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675968">
+            				<div class="playlist-tracktime">
+                    02:16:47				</div>
+            				<div class="playlist-trackname">
+                    offonoff, Tablo, Miso - Cigarette (Feat. Tablo, MISO)				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675973">
+            				<div class="playlist-tracktime">
+                    02:19:34				</div>
+            				<div class="playlist-trackname">
+                    Jorja Smith - Imperfect Circle				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675980">
+            				<div class="playlist-tracktime">
+                    02:20:49				</div>
+            				<div class="playlist-trackname">
+                    Masego - Navajo				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675986">
+            				<div class="playlist-tracktime">
+                    02:23:34				</div>
+            				<div class="playlist-trackname">
+                    TOSHIKI HAYASHI(%C), 9m88 - Stay A While				</div>
+		</div>
+        		<div class="playlist-track " id="track_85675996">
+            				<div class="playlist-tracktime">
+                    02:24:56				</div>
+            				<div class="playlist-trackname">
+                    Chelan, Vad - D.Y.K (Don't You Know) [feat. Vad]				</div>
+		</div>
+        		<div class="playlist-track " id="track_85676003">
+            				<div class="playlist-timestamp">11:00pm				</div>
+								<div class="playlist-tracktime">
+					02:29:12				</div>
+            				<div class="playlist-trackname">
+                    Chris McClenney - Tuning Up				</div>
+		</div>
+        			</div>
+		</div>
+		<div class="col-xs-12 col-sm-8 col-md-5 col-lg-4 col-lg-offset-1">
+            <div class="card playlist-details">
+	<div class="bottom">
+        
+		<div class="playlist-genres">
+			<div class="playlist-location-time">
+				<span class="playlist-start-time">25 Aug 2021</span> |
+				<span class="playlist-location">Afghanistan</span>
+			</div>
+			<span class="playlist-features">Features:</span>
+			<span class="genre-name"></span>
+		</div>
+
+		<div>
+			<a href="https://serato.com/playlists/pong" class="link">More by pong<i class="far fa-angle-right"></i></a>
+		</div>
+		</div>
+</div>		</div>
+	</div>
+</div>
+
+
+
+<div class="container" id="playlist_comments">
+	<div class="row">
+		<div class="col-md-7 col-sm-6 col-xs-12">
+			<div class="playlist-comments">
+				<h3 class="section-heading">
+					Comments
+				</h3>
+				<div id="messages_list" class="messages_list list clearfix">
+</div>
+
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="container playlist-postbox">
+	<div class="row">
+		<div class="col-md-7 col-sm-6 col-xs-12">
+			<div class="playlist-comments">
+                                    
+<div class="page-section">
+	<div class="login-join-container en">
+			<p>To comment on the playlist "2021/08/25" please log in to your Serato account.</p>
+	<div>
+		<a class="a-Button--Reset a-Button--LightBlue a-Button--Small" href="https://serato.com/auth/start?continue=%2Fplaylists%2Fpong%2Flive%2Fcomments&amp;flow_params=%5B%5D">Sign in</a>
+	</div>
+	</div>	
+</div>                			</div>
+		</div>
+	</div>
+</div>
+
+
+<!-- Vue App end here -->
+
+<script>
+"use strict";
+
+// Used for validation of props
+var colourOptions = ['a-btn--light-blue', 'a-btn--inverted-light-blue', 'a-btn--orange', 'a-btn--dark-blue', 'a-btn--green', 'a-btn--purple', 'a-btn--yellow', 'a-btn--solid-color a-btn--dj-pro', 'a-btn--solid-color a-btn--dj-lite', 'a-btn--solid-color a-btn--studio', 'a-btn--solid-color a-btn--sample', 'a-btn--alert a-btn--alert--success', 'a-btn--alert a-btn--alert--warning', 'a-btn--alert a-btn--alert--danger'];
+Vue.component('base-button', {
+  template: "\n<a\n  v-if=\"href !=''\"\n  @click=\"handleClick\"\n  class=\"a-btn\"\n  :class=\"[color, size, {'disabled': isDisabled}]\"\n  :href=\"href\"\n>{{ buttonTitle }}</a>\n<button\n  v-else\n  @click=\"handleClick\"\n  class=\"a-btn\"\n  :class=\"[color, size, {'disabled': isDisabled, 'a-btn--is-loading': isLoading, 'a-btn--is-toggled-on' : isToggleable && isToggledOn}]\"\n  :disabled=\"isDisabled || isLoading\"\n>\n  <transition\n    name=\"an-loading-fade\"\n    mode=\"out-in\"\n    appear\n  >\n    <span v-if=\"isLoading\">\n      <i class=\"a-btn__icon--left fas fa-spinner-third fa-spin\"></i>\n      <span v-if=\"useDefaultLoadingMessage && !isInlineTitle\">Loading...</span>\n      <span v-else-if=\"!useDefaultLoadingMessage && isInlineTitle\">{{ buttonTitle }}</span>\n    </span>\n    <span v-else>\n      <i v-if=\"icon && iconPosition === 'left'\" :class=\"[{'a-btn__icon--left': icon}, icon]\"></i> \n      {{ buttonTitle }} \n      <i v-if=\"icon && iconPosition === 'right'\" :class=\"[{'a-btn__icon--right': icon}, icon]\"></i>\n    </span>\n  </transition>\n</button>",
+  props: {
+    buttonTitle: {
+      type: String,
+      default: '',
+      required: true
+    },
+    size: {
+      type: String,
+      default: '',
+      required: false
+    },
+    color: {
+      type: String,
+      default: '',
+      required: true
+    },
+    isDisabled: {
+      type: Boolean,
+      default: false,
+      required: false
+    },
+    isToggleable: {
+      type: Boolean,
+      default: false,
+      required: false
+    },
+    isToggledOn: {
+      type: Boolean,
+      default: false
+    },
+    href: {
+      type: String,
+      default: '',
+      required: false
+    },
+    icon: {
+      type: String,
+      required: false
+    },
+    iconPosition: {
+      type: String,
+      default: 'left',
+      required: false
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    },
+    useDefaultLoadingMessage: {
+      type: Boolean,
+      default: false
+    },
+    isInlineTitle: {
+      type: Boolean,
+      default: true
+    }
+  },
+  methods: {
+    handleClick: function handleClick() {
+      this.$emit('click');
+    }
+  }
+});
+</script><script>
+    "use strict";
+
+    Vue.component('base-card', {
+        template: "\n<transition name=\"an-fade\">\n  <div\n    class=\"a-card__base\"\n    :class=\"\n    [\n      {'a-card__base--shadow': hasShadow},\n      {'a-card__base--with-alert': hasAlert},\n      {'a-card__base--compact': isCompact},\n      {'a-card__base--pricing': isPricing},\n      alertType\n    ]\"\n  >\n    <div v-if=\"hasAlert\" class=\"a-card__base--alert\">\n      <slot name=\"alert\" />\n    </div>\n    <slot name=\"content\" />\n  </div>\n</transition>",
+        props: {
+            hasShadow: {
+                type: Boolean,
+                default: true
+            },
+            hasAlert: {
+                type: Boolean,
+                default: false
+            },
+            alertType: {
+                type: String,
+                default: ''
+            },
+            isCompact: {
+                type: Boolean,
+                default: false
+            },
+            isPricing: {
+                type: Boolean,
+                default: false
+            }
+        }
+    });
+</script>
+<script>
+    "use strict";
+
+    var TransitionTimingFunctionOptions = {
+        'Ease': 'ease',
+        'Ease In Out': 'ease-in-out',
+        'Ease In': 'ease-in',
+        'Ease Out': 'ease-out',
+        'Linear': 'linear'
+    };
+    Vue.component('accordion-card', {
+        template: "\n<base-card\n  :hasShadow=\"true\"\n  class=\"m-accordion-card\"\n  :class=\"{\n    'm-accordion-card--opened': isOpened && !isOpening,\n    'm-accordion-card--opening': isOpening,\n    'm-accordion-card--closing': isClosing\n  }\"\n>\n  <template #content>\n    <div class=\"m-accordion-card__header\" @click=\"toggleOpen()\">\n      <div class=\"m-accordion-card__header-title\">\n        <slot name=\"title\">\n          {{ cardTitle }}\n        </slot>\n      </div>\n      <i\n        class=\"far fa-angle-down m-accordion-card__header-icon\"\n        :class=\"{ 'm-accordion-card__header-icon--rotate': isOpened }\"\n      />\n    </div>\n    <div\n      class=\"m-accordion-card__content\"\n      :class=\"{ 'm-accordion-card__content--opened': isOpened }\"\n      :style=\"{\n        transitionDuration: transitionDuration,\n        transitionTimingFunction: transitionTimingFunction\n      }\"\n    >\n      <slot name=\"content\" />\n    </div>\n  </template>\n</base-card>",
+        props: {
+            cardTitle: {
+                type: String,
+                default: '',
+                required: true
+            },
+            isExpanded: {
+                type: Boolean,
+                default: false
+            },
+            transitionDuration: {
+                type: String,
+                default: '350ms'
+            },
+            transitionTimingFunction: {
+                type: String,
+                default: TransitionTimingFunctionOptions['Ease In Out'],
+                validator: function validator(val) {
+                    return Object.values(TransitionTimingFunctionOptions).includes(val);
+                }
+            }
+        },
+        created: function created() {
+            // initual the state
+            this.isOpened = this.isExpanded;
+            this.isOpening = false;
+            this.isClosing = false;
+        },
+        data: function data() {
+            return {
+                isOpened: {
+                    type: Boolean,
+                    default: false
+                },
+                isOpening: {
+                    type: Boolean,
+                    default: false
+                },
+                isClosing: {
+                    type: Boolean,
+                    default: false
+                }
+            };
+        },
+        methods: {
+            toggleOpen: function toggleOpen() {
+                var _this = this;
+
+                this.isOpened ? this.isClosing = true : this.isOpening = true;
+                var intervals = this.transitionDuration.includes('ms') ? parseInt(this.transitionDuration) : parseInt(this.transitionDuration) * 1000;
+                setTimeout(function () {
+                    _this.isClosing = false;
+                    _this.isOpening = false;
+                }, intervals);
+                this.isOpened = !this.isOpened;
+                this.$emit('click', this.isOpened);
+            }
+        }
+    });
+</script>
+<script>
+    "use strict";
+
+    // Used for validation of props
+    Vue.component('text-link', {
+        template: "\n  <a\n    @click=\"handleClick\"\n    class=\"a-link__text\"\n    :class=\"[type]\"\n    :href=\"href\"\n  >\n    <i\n      v-if=\"enableIcon && (iconPosition=='Before' || iconPosition=='Both')\"\n      class=\"fas\"\n      :class=\"icon\"\n    ></i>{{ linkText }}<i\n      v-if=\"enableIcon && (iconPosition=='After' || iconPosition=='Both')\"\n      class=\"fas\"\n      :class=\"icon\"\n    ></i>\n  </a>\n",
+        props: {
+            linkText: {
+                type: String,
+                default: '',
+                required: true
+            },
+            type: {
+                type: String,
+                default: '',
+                required: true
+            },
+            href: {
+                type: String,
+                default: null,
+                required: false
+            },
+            iconEnabled: {
+                type: Boolean,
+                default: null
+            },
+            icon: {
+                type: String,
+                required: false,
+                default: ''
+            },
+            iconPosition: {
+                type: String,
+                required: false,
+                default: ''
+            }
+        },
+        computed: {
+            enableIcon: function enableIcon() {
+                return this.iconEnabled;
+            }
+        },
+        methods: {
+            handleClick: function handleClick() {
+                this.$emit('click', this.href);
+            }
+        }
+    });
+</script>
+<script>
+    Vue.component('input-text', {
+        template: "\n<div class=\"a-input-text\">\n  <label\n    class=\"a-input-text__label\"\n    :for=\"name\"\n  >\n    {{ labelText }}\n  </label>\n  <input\n    class=\"a-input-text__input\"\n    :class=\"{'a-input-text__input--danger': errorMessage, 'a-input-text__input--success': successState}\"\n    :type=\"type\"\n    :id=\"name\"\n    :name=\"name\"\n    :maxlength=\"maxlength\"\n    :minlength=\"minlength\"\n    :value=\"value\"\n    :labelText=\"labelText\"\n    :placeholder=\"placeholder\"\n    :disabled=\"disabled\"\n    :required=\"required\"\n    :aria-required=\"required\"\n  />\n  <!-- Error message to go in here -->\n  <p class=\"a-input-text__error-message\">{{ errorMessage }}</p>\n</div>",
+        props: {
+            type: {
+                type: String,
+                default: 'text'
+            },
+            name: {
+                type: String,
+                default: ''
+            },
+            placeholder: {
+                type: String,
+                default: ''
+            },
+            disabled: {
+                type: Boolean,
+                default: false
+            },
+            minlength: {
+                type: Number,
+                default: 0
+            },
+            maxlength: {
+                type: Number,
+                default: 128
+            },
+            value: {
+                type: String,
+                default: ''
+            },
+            required: {
+                type: Boolean,
+                default: false
+            },
+            labelText: {
+                type: String,
+                default: ''
+            },
+            errorMessage: {
+                type: String,
+                default: ''
+            },
+            successState: {
+                type: Boolean,
+                default: false
+            }
+        }
+    });
+</script>
+<script>
+    Vue.component('label-tag', {
+        template: "\n<div\n  class=\"a-label\"\n  :class=\"['a-label--' + labelState, {'a-label--compact': isCompact}]\"\n>\n  <div class=\"a-label-tag\">\n    <p class=\"a-label-tag__title\">{{ labelTitle }}</p>\n  </div>\n  <p class=\"a-label__text\">\n      {{ hasText }}\n  </p>\n</div>",
+        props: {
+            labelState: {
+                type: String,
+                default: "default"
+            },
+            labelTitle: {
+                type: String,
+                default: ""
+            },
+            isCompact: {
+                type: Boolean,
+                default: false
+            },
+            hasText: {
+                type: String,
+                default: ""
+            }
+        },
+        computed: {
+            hasSlotData: function hasSlotData() {
+                return "label-text" in this.$slots;
+            }
+        }
+    });
+</script>
+<script>
+    "use strict";
+
+    Vue.component('basic-alert', {
+        template: "\n<div :class=\"[alertType ? alertType : '', isFullWidth ? 'm-basic-alert--full-width': '']\" class=\"m-basic-alert\">\n  <div\n    class=\"m-basic-alert__content\"\n    :class=\"[{'m-basic-alert__content--full-width': isFullWidth}]\"\n  >\n    <div class=\"m-basic-alert__text\">\n      <span class=\"m-basic-alert__heading\">{{title}} -</span>\n      <span>{{text}}</span>\n    </div>\n    <div class=\"m-basic-alert__button\">\n      <slot v-if=\"!hasButton\" name=\"button\"></slot>\n    </div>\n  </div>\n  <div v-if=\"showCloseButton\" class=\"m-basic-alert__close\" @click=\"close\">\n    <i class=\"far fa-times\" />\n  </div>\n</div>",
+        props: {
+            title: {
+                type: String,
+                default: ''
+            },
+            text: {
+                type: String,
+                default: ''
+            },
+            hasButton: {
+                type: Boolean,
+                default: false
+            },
+            alertType: {
+                type: String,
+                default: ''
+            },
+            showCloseButton: {
+                type: Boolean,
+                default: false
+            },
+            hideDismissButton: {
+                type: Boolean,
+                default: false
+            },
+            isFullWidth: {
+                type: Boolean,
+                default: false
+            }
+        },
+        methods: {
+            close: function close() {
+                this.$emit('close');
+            }
+        }
+    });
+</script>
+
+<script>
+    "use strict";
+    var vueApp = new Vue({
+        el: '#content',
+    });
+</script></div>
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+    <ul class="nav list-unstyled">
+        <li class="nav-item">
+            <a class="nav-link" href="https://support.serato.com/hc/en-us">Support</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="https://serato.com/contact">Contact Us</a>
+        </li>
+                <li class="nav-item">
+            <a class="nav-link" href="https://serato.com/about">About Us</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="https://serato.com/careers">Careers</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="https://serato.com/resources">Resources</a>
+        </li>
+                <li class="nav-item">
+            <a class="nav-link" href="https://serato.com/legal">Legal</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="https://serato.com/legal/website-privacy-policy">Privacy Policy</a>
+        </li>
+    </ul>
+
+    <img class="footer-logo lazy" src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/serato-pom-white-v3.svg" alt="Serato logo">
+        <ul class="footer-social-media list-inline">
+        <li class="list-inline-item mr-3 ml-3">
+            <a href="https://www.youtube.com/user/seratohq" target="_blank" rel="noopener noreferrer" title="YouTube">
+                <i class="fab fa-2x fa-youtube"></i>
+            </a>
+        </li>
+        <li class="list-inline-item mr-3 ml-3">
+            <a href="https://instagram.com/serato" target="_blank" rel="noopener noreferrer" title="Instagram">
+                <i class="fab fa-2x fa-instagram"></i>
+            </a>
+        </li>
+        <li class="list-inline-item mr-3 ml-3">
+            <a href="https://www.twitch.tv/serato" target="_blank" rel="noopener noreferrer" title="Twitch">
+                <i class="fab fa-2x fa-twitch"></i>
+            </a>
+        </li>
+        <li class="list-inline-item mr-3 ml-3">
+            <a href="https://www.facebook.com/serato" target="_blank" rel="noopener noreferrer" title="Facebook">
+                <i class="fab fa-2x fa-facebook"></i>
+            </a>
+        </li>
+    </ul>
+        <div class="copyright">
+        <p><small>© Serato 1999 - 2021. All&nbsp;rights&nbsp;reserved.</small></p>
+    </div>
+</div>    </footer>
+
+    <!-- Variables -->
+    <script>
+      var serverVars = {
+        geoipContinent: 'NA'
+      }
+
+      // remove the u query parameter from url
+      var searchParams = new URLSearchParams(window.location.search)
+      var u = searchParams.get('u')
+      if (u) {
+          // Remove the u params from the url
+          var newUrl = location.href
+              // this Regex is to remove the u param from the middle of the url
+              // e.g. http://abc/?u=123&foo=bar will become http://abc/?foo=bar
+              .replace(/([&|?])u=\d+&/, '$1')
+              // This Regex is to remove the u from the end of the url
+              // e.g. http://abc/?foo=bar&u=123 will become http://abc/?foo=bar
+              .replace(/[&|?]u=\d+/, '')
+          history.pushState({}, null, newUrl)
+      }
+    </script>
+
+    <!-- Polyfill for srcset (and picture elements) -->
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_external_picturefill.js" type="text/javascript" charset="utf-8" async="" defer="defer"></script>
+
+    <!-- Optional JavaScript -->
+    <!-- Bootstrap JS -->
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_external_bootstrap.js" type="text/javascript" charset="utf-8"></script>
+
+    <!-- Lazy loader (lazy-loader.js - configuration code - must run before lazysizes) -->
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_lazy-loader_7d81238ccec515317d396437069aff98.js" type="text/javascript" charset="utf-8"></script>
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_external_ls.js" type="text/javascript" charset="utf-8"></script>
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_external_lazysizes.js" type="text/javascript" charset="utf-8"></script>
+
+    <!-- JavaScript -->
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_cookie-consent_3a672aa98f96f607b3b54d81b34ad797.js" type="text/javascript" charset="utf-8"></script>
+
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_build_header_8d7474a57c231ba6d284a97aaaf56ff5.js" type="text/javascript" charset="utf-8"></script>
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_build_main_45a138bb6b2c3064b0b5786276025d8d.js" type="text/javascript" charset="utf-8"></script>
+
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_swapp.js" type="text/javascript" charset="utf-8"></script>
+    <script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/swapp.js" type="text/javascript" charset="utf-8"></script>
+
+    <!-- Zendesk chat widget script -->
+    
+    <script type="text/javascript">
+					var Playlist;
+			$( document ).ready( function(){
+				Playlist = new swapp.app.playlists.live({
+					playlistId: '1391826',
+					edit_time: '1629898774',
+					refresh: true,
+					object_name: 'Playlist',
+					end_track_id: 85676005,
+					htmlElementId: "playlist_tracklist",
+					playlist_owner: false				});
+			});
+			</script>
+	<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/shared_playlists_c9b916ade8f9270e99a4348407508356.js" type="text/javascript" charset="utf-8"></script>
+<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_swapp.js" type="text/javascript" charset="utf-8"></script>
+<script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_swapp_002.js" type="text/javascript" charset="utf-8"></script><script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_swapp_002.js" type="text/javascript" charset="utf-8"></script><script>
+
+	var $commentsSection = $('#playlist_comments');
+	var $messageList = $('#messages_list');
+
+	var showHideComments = function () {
+		$commentsSection.toggle($messageList.children().length > 0);
+	};
+
+	showHideComments();
+	$commentsSection.bind('DOMNodeInserted', showHideComments);
+
+</script><script src="2021_08_25%20-%20pong%20-%20Serato%20DJ%20Playlists_files/v3_contact-me_18894ac0452a82da664ab0c73aaabd6e.js" type="text/javascript" charset="utf-8"></script>
+    <!-- Deferred CSS -->
+    
+    <!-- Deferred JavaScript -->
+      
+
+</body><grammarly-desktop-integration data-grammarly-shadow-root="true"></grammarly-desktop-integration></html>

--- a/tests/templates/simple.txt
+++ b/tests/templates/simple.txt
@@ -1,0 +1,2 @@
+{{ artist }}
+{{ title }}

--- a/tests/templates/songquotes.txt
+++ b/tests/templates/songquotes.txt
@@ -1,0 +1,1 @@
+{{ artist }} - "{{ title }}"

--- a/tests/test_acoustidmb.py
+++ b/tests/test_acoustidmb.py
@@ -7,7 +7,7 @@ import pytest
 
 import nowplaying.recognition.acoustidmb  # pylint: disable=import-error
 
-if not os.environ['ACOUSTID_TEST_APIKEY']:
+if 'ACOUSTID_TEST_APIKEY' not in os.environ:
     pytest.skip("skipping, ACOUSTID_TEST_APIKEY is not set",
                 allow_module_level=True)
 

--- a/tests/test_acrcloud.py
+++ b/tests/test_acrcloud.py
@@ -6,15 +6,15 @@ import pytest
 
 import nowplaying.recognition.ACRCloud  # pylint: disable=import-error
 
-if not os.environ['ACRCLOUD_TEST_KEY']:
+if 'ACRCLOUD_TEST_KEY' not in os.environ:
     pytest.skip("skipping, ACRCLOUD_TEST_KEY is not set",
                 allow_module_level=True)
 
-if not os.environ['ACRCLOUD_TEST_SECRET']:
+if 'ACRCLOUD_TEST_SECRET' not in os.environ:
     pytest.skip("skipping, ACRCLOUD_TEST_SECRET is not set",
                 allow_module_level=True)
 
-if not os.environ['ACRCLOUD_TEST_HOST']:
+if 'ACRCLOUD_TEST_HOST' not in os.environ:
     pytest.skip("skipping, ACRCLOUD_TEST_HOST is not set",
                 allow_module_level=True)
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,6 +9,8 @@ import nowplaying.metadata  # pylint: disable=import-error
 def test_15ghosts2_orig(bootstrap, getroot):
     ''' automated integration test '''
     config = bootstrap
+    config.cparser.setValue('acoustidmb/enabled', False)
+    config.cparser.setValue('acrcloud/enabled', False)
     metadata = {
         'filename':
         os.path.join(getroot, 'tests', 'audio', '15_Ghosts_II_64kb_orig.mp3')
@@ -26,6 +28,8 @@ def test_15ghosts2_orig(bootstrap, getroot):
 def test_15ghosts2_fullytagged(bootstrap, getroot):
     ''' automated integration test '''
     config = bootstrap
+    config.cparser.setValue('acoustidmb/enabled', False)
+    config.cparser.setValue('acrcloud/enabled', False)
     metadata = {
         'filename':
         os.path.join(getroot, 'tests', 'audio',

--- a/tests/test_templatehandler.py
+++ b/tests/test_templatehandler.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+''' test templatehandler '''
+
+import os
+import tempfile
+
+import pytest
+
+import nowplaying.utils  # pylint: disable=import-error
+
+
+@pytest.fixture
+def gettemplatehandler(getroot, bootstrap, request):
+    ''' automated integration test '''
+    config = bootstrap  # pylint: disable=unused-variable
+    mark = request.node.get_closest_marker("templatesettings")
+    if mark and 'template' in mark.kwargs:
+        template = os.path.join(getroot, 'tests', 'templates',
+                                mark.kwargs['template'])
+    else:
+        template = None
+    return nowplaying.utils.TemplateHandler(filename=template)
+
+
+@pytest.mark.templatesettings(template='simple.txt')
+def test_writingmeta(gettemplatehandler):  # pylint: disable=redefined-outer-name
+    ''' try writing a text '''
+    with tempfile.TemporaryDirectory() as newpath:
+        filename = os.path.join(newpath, 'test.txt')
+
+        metadata = {
+            'artist': 'this is an artist',
+            'title': 'this is the title',
+        }
+
+        nowplaying.utils.writetxttrack(filename=filename,
+                                       templatehandler=gettemplatehandler,
+                                       metadata=metadata)
+        with open(filename, 'r') as tempfn:
+            content = tempfn.readlines()
+
+        assert 'this is an artist' in content[0]
+        assert 'this is the title' in content[1]
+
+
+@pytest.mark.templatesettings(template='simple.txt')
+def test_missingmeta(gettemplatehandler):  # pylint: disable=redefined-outer-name
+    ''' empty metadata '''
+    with tempfile.TemporaryDirectory() as newpath:
+        filename = os.path.join(newpath, 'test.txt')
+
+        metadata = {}
+
+        nowplaying.utils.writetxttrack(filename=filename,
+                                       templatehandler=gettemplatehandler,
+                                       metadata=metadata)
+        with open(filename, 'r') as tempfn:
+            content = tempfn.readlines()
+
+        assert content[0].strip() == ''
+
+
+@pytest.mark.templatesettings(template='missing.txt')
+def test_missingtemplate(gettemplatehandler):  # pylint: disable=redefined-outer-name
+    ''' template is missing '''
+    with tempfile.TemporaryDirectory() as newpath:
+        filename = os.path.join(newpath, 'test.txt')
+
+        metadata = {
+            'artist': 'this is an artist',
+            'title': 'this is the title',
+        }
+
+        nowplaying.utils.writetxttrack(filename=filename,
+                                       templatehandler=gettemplatehandler,
+                                       metadata=metadata)
+        with open(filename, 'r') as tempfn:
+            content = tempfn.readlines()
+
+        assert 'No template found' in content[0]
+
+
+def test_missingfilename(gettemplatehandler):  # pylint: disable=redefined-outer-name
+    ''' no template '''
+    with tempfile.TemporaryDirectory() as newpath:
+        filename = os.path.join(newpath, 'test.txt')
+
+        metadata = {
+            'artist': 'this is an artist',
+            'title': 'this is the title',
+        }
+
+        nowplaying.utils.writetxttrack(filename=filename,
+                                       templatehandler=gettemplatehandler,
+                                       metadata=metadata)
+        with open(filename, 'r') as tempfn:
+            content = tempfn.readlines()
+
+        assert 'No template found' in content[0]
+
+
+def test_cleartemplate():  # pylint: disable=redefined-outer-name
+    ''' try writing a text '''
+    with tempfile.TemporaryDirectory() as newpath:
+        filename = os.path.join(newpath, 'test.txt')
+        nowplaying.utils.writetxttrack(filename=filename, clear=True)
+        with open(filename, 'r') as tempfn:
+            content = tempfn.readlines()
+
+        assert not content
+
+
+def test_justafile():  # pylint: disable=redefined-outer-name
+    ''' try writing a text '''
+    with tempfile.TemporaryDirectory() as newpath:
+        filename = os.path.join(newpath, 'test.txt')
+        nowplaying.utils.writetxttrack(filename=filename)
+        with open(filename, 'r') as tempfn:
+            content = tempfn.readlines()
+
+        assert content[0] == '{{ artist }} - {{ title }}'

--- a/tests/test_upgradetemplates.py
+++ b/tests/test_upgradetemplates.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+''' test m3u '''
+
+import io
+import os
+import pathlib
+import logging
+import shutil
+import tempfile
+
+import pytest
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+import nowplaying.config  # pylint: disable=import-error
+
+
+@pytest.fixture
+def upgrade_bootstrap(getroot):
+    ''' bootstrap a configuration '''
+    with tempfile.TemporaryDirectory() as newpath:
+        bundledir = os.path.join(getroot, 'nowplaying')
+        logging.basicConfig(level=logging.DEBUG)
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+        config = nowplaying.config.ConfigFile(bundledir=bundledir,
+                                              testmode=True)
+        config.cparser.sync()
+        old_cwd = os.getcwd()
+        os.chdir(newpath)
+        yield newpath, config
+        os.chdir(old_cwd)
+        config.cparser.clear()
+        config.cparser.sync()
+        if os.path.exists(config.cparser.fileName()):
+            os.unlink(config.cparser.fileName())
+
+
+def compare_content(srcdir, destdir, conflict=None):
+    ''' compare src templates to what was copied '''
+    srctemplates = os.listdir(srcdir)
+    desttemplates = os.listdir(destdir)
+    filelist = []
+    for filename in srctemplates + desttemplates:
+        basefn = os.path.basename(filename)
+        filelist.append(basefn)
+
+    filelist = sorted(set(filelist))
+
+    for filename in filelist:
+        srcfn = os.path.join(srcdir, filename)
+        destfn = os.path.join(destdir, filename)
+
+        if '.new' in filename:
+            continue
+
+        if conflict and os.path.basename(srcfn) == os.path.basename(conflict):
+            newname = filename.replace('.txt', '.new')
+            newname = newname.replace('.htm', '.new')
+            newdestfn = os.path.join(destdir, newname)
+            assert filename and list(io.open(srcfn)) != list(io.open(destfn))
+            assert filename and list(io.open(srcfn)) == list(
+                io.open(newdestfn))
+        else:
+            assert filename and list(io.open(srcfn)) == list(io.open(destfn))
+
+
+def test_upgrade_blank(upgrade_bootstrap):  # pylint: disable=redefined-outer-name
+    ''' check a blank dir '''
+    (testpath, config) = upgrade_bootstrap
+    bundledir = config.getbundledir()
+    nowplaying.bootstrap.UpgradeTemplates(bundledir=bundledir,
+                                          testdir=testpath)
+    srcdir = os.path.join(bundledir, 'templates')
+    destdir = os.path.join(testpath, 'testsuite', 'templates')
+    compare_content(srcdir, destdir)
+
+
+def test_upgrade_conflict(upgrade_bootstrap):  # pylint: disable=redefined-outer-name,too-many-locals
+    ''' different content of standard template should create new '''
+    (testpath, config) = upgrade_bootstrap
+    bundledir = config.getbundledir()
+    srcdir = os.path.join(bundledir, 'templates')
+    destdir = os.path.join(testpath, 'testsuite', 'templates')
+    srctemplates = os.listdir(srcdir)
+    pathlib.Path(destdir).mkdir(parents=True, exist_ok=True)
+    touchfile = os.path.join(destdir, os.path.basename(srctemplates[0]))
+    pathlib.Path(touchfile).touch()
+    nowplaying.bootstrap.UpgradeTemplates(bundledir=bundledir,
+                                          testdir=testpath)
+    compare_content(srcdir, destdir, touchfile)
+
+
+def test_upgrade_same(upgrade_bootstrap):  # pylint: disable=redefined-outer-name,too-many-locals
+    ''' if a file already exists it shouldn't get .new'd '''
+    (testpath, config) = upgrade_bootstrap
+    bundledir = config.getbundledir()
+    srcdir = os.path.join(bundledir, 'templates')
+    destdir = os.path.join(testpath, 'testsuite', 'templates')
+    srctemplates = os.listdir(srcdir)
+    pathlib.Path(destdir).mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(os.path.join(srcdir, srctemplates[1]),
+                    os.path.join(destdir, os.path.basename(srctemplates[1])))
+    nowplaying.bootstrap.UpgradeTemplates(bundledir=bundledir,
+                                          testdir=testpath)
+    compare_content(srcdir, destdir)
+
+
+def test_upgrade_old(upgrade_bootstrap, getroot):  # pylint: disable=redefined-outer-name,too-many-locals
+    ''' custom .txt, .new from previous upgrade '''
+    (testpath, config) = upgrade_bootstrap
+    bundledir = config.getbundledir()
+    srcdir = os.path.join(bundledir, 'templates')
+    destdir = os.path.join(testpath, 'testsuite', 'templates')
+    pathlib.Path(destdir).mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(
+        os.path.join(getroot, 'tests', 'templates', 'songquotes.txt'),
+        os.path.join(destdir, 'songquotes.new'))
+    touchfile = os.path.join(destdir, 'songquotes.txt')
+    pathlib.Path(touchfile).touch()
+    nowplaying.bootstrap.UpgradeTemplates(bundledir=bundledir,
+                                          testdir=testpath)
+    assert list(io.open(os.path.join(srcdir, 'songquotes.txt'))) == list(
+        io.open(os.path.join(destdir, 'songquotes.new')))
+    compare_content(srcdir, destdir, conflict=touchfile)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+''' test utils not covered elsewhere '''
+
+import nowplaying.utils  # pylint: disable=import-error
+
+
+def results(expected, metadata):
+    ''' take a metadata result and compare to expected '''
+    for expkey in expected:
+        assert expkey in metadata
+        assert expected[expkey] == metadata[expkey]
+        del metadata[expkey]
+    assert metadata == {}
+
+
+def test_getmoremetadata_brokenmd():
+    ''' test getmoremetadata when based garbage '''
+
+    assert not nowplaying.utils.getmoremetadata()
+
+    metadatain = {'filename': 'filenamedoesnotexist'}
+
+    metadataout = nowplaying.utils.getmoremetadata(metadatain.copy())
+    results(metadatain, metadataout)

--- a/tests/upgrade/README.md
+++ b/tests/upgrade/README.md
@@ -1,0 +1,6 @@
+
+# IMPORTANT
+
+Due to the way pytest+Qt is loaded, results tend to get cached
+in the same file. Needless to say, that can't be worked around
+when dealing with configuration file upgrade code...

--- a/tests/upgrade/test_200.py
+++ b/tests/upgrade/test_200.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+''' test m3u '''
+
+import os
+import logging
+import random
+import sys
+import tempfile
+
+import psutil
+import pytest
+
+from PySide2.QtCore import QCoreApplication, QSettings  # pylint: disable=no-name-in-module
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+
+if sys.platform == 'darwin':
+    import pwd
+
+
+def reboot_macosx_prefs():
+    ''' work around Mac OS X's preference caching '''
+    if sys.platform == 'darwin':
+        for process in psutil.process_iter():
+            if 'cfprefsd' in process.name() and pwd.getpwuid(
+                    os.getuid()).pw_name == process.username():
+                process.terminate()
+                process.wait()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def move_old_config():
+    ''' make sure the old em1ran config is out of the way '''
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    othersettings = QSettings(qsettingsformat, QSettings.UserScope,
+                              'com.github.em1ran', 'NowPlaying')
+    renamed = False
+    reboot_macosx_prefs()
+    if os.path.exists(othersettings.fileName()):
+        logging.warning('Moving old em1ran config around')
+        os.rename(othersettings.fileName(), othersettings.fileName() + '.bak')
+        renamed = True
+    reboot_macosx_prefs()
+    yield
+    if renamed:
+        logging.warning('Moving old em1ran back')
+        os.rename(othersettings.fileName() + '.bak', othersettings.fileName())
+    reboot_macosx_prefs()
+
+
+def make_fake_200_config(trialnum):
+    ''' generate v2.0.0 config '''
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    othersettings = QSettings(qsettingsformat, QSettings.UserScope,
+                              'com.github.em1ran', 'NowPlaying')
+    othersettings.clear()
+    othersettings.setValue('settings/configversion', '2.0.0')
+    othersettings.setValue('settings/interval', trialnum)
+    othersettings.setValue('settings/handler', 'serato')
+    othersettings.sync()
+    filename = othersettings.fileName()
+    del othersettings
+    reboot_macosx_prefs()
+    assert os.path.exists(filename)
+    return filename
+
+
+def test_version200_to_current():  # pylint: disable=redefined-outer-name
+    ''' test old config file '''
+    with tempfile.TemporaryDirectory() as newpath:
+        trialnum = random.randint(11, 2000) + 0.0
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+        filename = make_fake_200_config(trialnum)
+        backupdir = os.path.join(newpath, 'testsuite', 'configbackup')
+        assert not os.path.exists(os.path.join(backupdir))
+        reboot_macosx_prefs()
+        if sys.platform != 'darwin':
+            logging.debug('old file')
+            with open(filename, 'r') as configfh:
+                logging.debug(configfh.readlines())
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+        upgrade = nowplaying.bootstrap.UpgradeConfig(testdir=newpath)  #pylint: disable=unused-variable
+        config = QSettings(qsettingsformat, QSettings.UserScope,
+                           QCoreApplication.organizationName(),
+                           QCoreApplication.applicationName())
+        interval = config.value('serato/interval', type=float)
+        handler = config.value('settings/input')
+
+        if sys.platform != 'darwin':
+            logging.debug('new file')
+            with open(config.fileName(), 'r') as configfh:
+                logging.debug(configfh.readlines())
+        os.unlink(filename)
+        reboot_macosx_prefs()
+        assert interval == trialnum
+        assert handler == 'serato'

--- a/tests/upgrade/test_300.py
+++ b/tests/upgrade/test_300.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+''' test m3u '''
+
+import hashlib
+import logging
+import os
+import random
+import string
+import sys
+import tempfile
+
+import psutil
+import pytest
+
+from PySide2.QtCore import QCoreApplication, QSettings  # pylint: disable=no-name-in-module
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+
+if sys.platform == 'darwin':
+    import pwd
+
+
+def reboot_macosx_prefs():
+    ''' work around Mac OS X's preference caching '''
+    if sys.platform == 'darwin':
+        for process in psutil.process_iter():
+            if 'cfprefsd' in process.name() and pwd.getpwuid(
+                    os.getuid()).pw_name == process.username():
+                process.terminate()
+                process.wait()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def move_old_config():
+    ''' make sure the old em1ran config is out of the way '''
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    othersettings = QSettings(qsettingsformat, QSettings.UserScope,
+                              'com.github.em1ran', 'NowPlaying')
+    renamed = False
+    reboot_macosx_prefs()
+    if os.path.exists(othersettings.fileName()):
+        logging.warning('Moving old em1ran config around')
+        os.rename(othersettings.fileName(), othersettings.fileName() + '.bak')
+        renamed = True
+    reboot_macosx_prefs()
+    yield
+    if renamed:
+        logging.warning('Moving old em1ran back')
+        os.rename(othersettings.fileName() + '.bak', othersettings.fileName())
+    reboot_macosx_prefs()
+
+
+def make_fake_300_config(fakestr):
+    ''' generate v2.0.0 config '''
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    nowplaying.bootstrap.set_qt_names(appname='testsuite')
+
+    othersettings = QSettings(qsettingsformat, QSettings.UserScope,
+                              QCoreApplication.organizationName(),
+                              QCoreApplication.applicationName())
+    othersettings.clear()
+    reboot_macosx_prefs()
+    othersettings.setValue('settings/configversion', '3.0.0-rc1')
+    othersettings.setValue('settings/notdefault', fakestr)
+    othersettings.sync()
+    filename = othersettings.fileName()
+    del othersettings
+    reboot_macosx_prefs()
+    assert os.path.exists(filename)
+    return filename
+
+
+def checksum(filename):  # pylint: disable=no-self-use
+    ''' generate sha512 . See also build-update-sha.py '''
+    hashfunc = hashlib.sha512()
+    with open(filename, 'rb') as fileh:
+        while chunk := fileh.read(128 * hashfunc.block_size):
+            hashfunc.update(chunk)
+    return hashfunc.hexdigest()
+
+
+def test_version_300rc1_to_current():  # pylint: disable=redefined-outer-name
+    ''' test old config file '''
+    with tempfile.TemporaryDirectory() as newpath:
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+        teststr = ''.join(
+            random.choice(string.ascii_lowercase) for i in range(5))
+        oldfilename = make_fake_300_config(teststr)
+        oldchecksum = checksum(oldfilename)
+        backupdir = os.path.join(newpath, 'testsuite', 'configbackup')
+        assert not os.path.exists(os.path.join(backupdir))
+        reboot_macosx_prefs()
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+        upgrade = nowplaying.bootstrap.UpgradeConfig(testdir=newpath)  #pylint: disable=unused-variable
+        config = QSettings(qsettingsformat, QSettings.UserScope,
+                           QCoreApplication.organizationName(),
+                           QCoreApplication.applicationName())
+        newfilename = config.fileName()
+        config.sync()
+        fakevalue = config.value('settings/notdefault')
+        files = os.listdir(backupdir)
+        backupchecksum = checksum(os.path.join(backupdir, files[0]))
+        config.clear()
+        del config
+        if os.path.exists(newfilename):
+            os.unlink(newfilename)
+        reboot_macosx_prefs()
+        assert oldchecksum == backupchecksum
+        assert fakevalue == teststr

--- a/tests/upgrade/test_noconfig.py
+++ b/tests/upgrade/test_noconfig.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+''' test m3u '''
+
+import os
+import logging
+import sys
+import tempfile
+
+import psutil
+import pytest
+
+from PySide2.QtCore import QSettings  # pylint: disable=no-name-in-module
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+
+if sys.platform == 'darwin':
+    import pwd
+
+
+def reboot_macosx_prefs():
+    ''' work around Mac OS X's preference caching '''
+    if sys.platform == 'darwin':
+        for process in psutil.process_iter():
+            if 'cfprefsd' in process.name() and pwd.getpwuid(
+                    os.getuid()).pw_name == process.username():
+                process.terminate()
+                process.wait()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def move_old_config():
+    ''' make sure the old em1ran config is out of the way '''
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    othersettings = QSettings(qsettingsformat, QSettings.UserScope,
+                              'com.github.em1ran', 'NowPlaying')
+    renamed = False
+    reboot_macosx_prefs()
+    if os.path.exists(othersettings.fileName()):
+        logging.warning('Moving old em1ran config around')
+        os.rename(othersettings.fileName(), othersettings.fileName() + '.bak')
+        renamed = True
+    reboot_macosx_prefs()
+    yield
+    if renamed:
+        logging.warning('Moving old em1ran back')
+        os.rename(othersettings.fileName() + '.bak', othersettings.fileName())
+    reboot_macosx_prefs()
+
+
+def test_noconfigfile():  # pylint: disable=redefined-outer-name
+    ''' test no config file '''
+    with tempfile.TemporaryDirectory() as newpath:
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+        backupdir = os.path.join(newpath, 'testsuite', 'configbackup')
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+        upgrade = nowplaying.bootstrap.UpgradeConfig(testdir=newpath)  #pylint: disable=unused-variable
+        config = QSettings(qsettingsformat, QSettings.UserScope,
+                           'com.github.whatsnowplaying', 'testsuite')
+        config.clear()
+        config.setValue('fakevalue', 'force')
+        config.sync()
+        filename = config.fileName()
+        assert os.path.exists(filename)
+        assert not os.path.exists(backupdir)
+        config.clear()
+        del config
+        reboot_macosx_prefs()
+        if os.path.exists(filename):
+            os.unlink(filename)
+        reboot_macosx_prefs()


### PR DESCRIPTION
* switch to calling pytest directly after fixing pyproject
* add a workaround for Mac OS X cfprefsd during testing
* add an autouse fixture to remove old test config file
* add no cover pragmas for now:
  * rare error conditions
  * systemtray
* fix a bad bug in bootstrap's upgrade code: open the
  qsettings file _directly_ to see what has and has
  not been set!
* add ability to specify a testdir for upgrade code
* add better logging all over the place
* remove Class level vars from Serato and the necessary
  rework for that
  * there is still a conflict between local and remote
    defaults in seratohandler and the plugin that should
    probably be clarified or resolved at some point
* add tests for serato remote
* add tests for m3u and fixed several bugs
* add tests for most of utils