### PR TITLE
Add input plugin start() method

### DIFF
--- a/nowplaying/inputs/__init__.py
+++ b/nowplaying/inputs/__init__.py
@@ -85,6 +85,10 @@ class InputPlugin():
 
 #### Control methods
 
+    def start(self):
+        ''' any initialization before actual polling starts '''
+        raise NotImplementedError
+
     def stop(self):
         ''' stopping either the entire program or just this
             input '''

--- a/nowplaying/inputs/m3u.py
+++ b/nowplaying/inputs/m3u.py
@@ -33,10 +33,11 @@ class Plugin(InputPlugin):
         self.observer = None
         self.qwidget = None
 
-        if not qsettings:
-            self._setup_watcher()
-
     def _setup_watcher(self):
+
+        if self.observer:
+            return
+
         if not self.m3udir:
             self.m3udir = self.config.cparser.value('m3u/directory')
 
@@ -122,8 +123,15 @@ class Plugin(InputPlugin):
         newmeta = {'filename': found}
         Plugin.metadata = newmeta
 
+    def start(self):
+        ''' setup the watcher to run in a separate thread '''
+        self._setup_watcher()
+
     def getplayingtrack(self):  #pylint: disable=no-self-use
         ''' wrapper to call getplayingtrack '''
+
+        # just in case called without calling start...
+        self._setup_watcher()
         return None, Plugin.metadata['filename']
 
     def getplayingmetadata(self):  #pylint: disable=no-self-use

--- a/nowplaying/inputs/mpris2.py
+++ b/nowplaying/inputs/mpris2.py
@@ -185,9 +185,6 @@ class Plugin(InputPlugin):
         self.mpris2 = MPRIS2Handler()
         self.dbus_status = True
 
-        if not qsettings:
-            self.gethandler()
-
     def gethandler(self):
         ''' setup the MPRIS2Handler for this session '''
 
@@ -208,6 +205,10 @@ class Plugin(InputPlugin):
         self.service = sameservice
         self.mpris2.resetservice(service=sameservice)
         return
+
+    def start(self):
+        ''' configure MPRIS2 client '''
+        self.gethandler()
 
     def getplayingtrack(self):
         ''' wrapper to call getplayingtrack '''

--- a/nowplaying/inputs/serato.py
+++ b/nowplaying/inputs/serato.py
@@ -753,9 +753,6 @@ class Plugin(InputPlugin):
         self.mixmode = "newest"
         self.qwidget = None
 
-        if not qsettings:
-            self.gethandler()
-
     def gethandler(self):
         ''' setup the SeratoHandler for this session '''
 
@@ -802,6 +799,10 @@ class Plugin(InputPlugin):
                                         mixmode=self.mixmode)
             #if self.serato:
             #    self.serato.process_sessions()
+
+    def start(self):
+        ''' get a handler '''
+        self.gethandler()
 
     def getplayingtrack(self):
         ''' wrapper to call getplayingtrack '''

--- a/nowplaying/trackpoll.py
+++ b/nowplaying/trackpoll.py
@@ -54,6 +54,7 @@ class TrackPoll(QThread):  # pylint: disable=too-many-instance-attributes
                 previousinput = self.config.cparser.value('settings/input')
                 self.input = self.plugins[
                     f'nowplaying.inputs.{previousinput}'].Plugin()
+                self.input.start()
             self.gettrack()
 
     def __del__(self):

--- a/nowplaying/trackpoll.py
+++ b/nowplaying/trackpoll.py
@@ -54,6 +54,7 @@ class TrackPoll(QThread):  # pylint: disable=too-many-instance-attributes
                 previousinput = self.config.cparser.value('settings/input')
                 self.input = self.plugins[
                     f'nowplaying.inputs.{previousinput}'].Plugin()
+                logging.debug('Starting %s plugin', previousinput)
                 self.input.start()
             self.gettrack()
 

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -55,6 +55,8 @@ def test_nom3u(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     if not os.path.exists(mydir):
         logging.error('mydir does not exist!')
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
     plugin.stop()
     time.sleep(5)
@@ -70,6 +72,8 @@ def test_emptym3u(m3u_bootstrap):  # pylint: disable=redefined-outer-name
         logging.error('mydir does not exist!')
     pathlib.Path(os.path.join(mydir, 'fake.m3u')).touch()
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
     plugin.stop()
     time.sleep(5)
@@ -87,6 +91,8 @@ def test_emptym3u2(m3u_bootstrap):  # pylint: disable=redefined-outer-name
         m3ufh.write(os.linesep)
         m3ufh.write(os.linesep)
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
     plugin.stop()
     time.sleep(5)
@@ -100,6 +106,8 @@ def test_no2newm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-n
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
     (artist, title) = plugin.getplayingtrack()
+    plugin.start()
+    time.sleep(5)
     assert artist is None
     assert title is None
 
@@ -107,13 +115,12 @@ def test_no2newm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-n
                             '15_Ghosts_II_64kb_orig.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u')
     write_m3u(m3ufile, filename)
-    # need to give some time for watcher it pick it up
     time.sleep(1)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert '15_Ghosts_II_64kb_orig.mp3' in title
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)
 
 
 def test_noencodingm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-name
@@ -121,19 +128,20 @@ def test_noencodingm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-ou
     config = m3u_bootstrap
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
 
     filename = os.path.join(getroot, 'tests', 'audio',
                             '15_Ghosts_II_64kb_orig.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u')
     write_m3u8(m3ufile, filename)
-    # need to give some time for watcher it pick it up
     time.sleep(1)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert '15_Ghosts_II_64kb_orig.mp3' in title
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)
 
 
 def test_encodingm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-name
@@ -141,19 +149,20 @@ def test_encodingm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer
     config = m3u_bootstrap
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
+    plugin.start()
+    time.sleep(5)
     filename = os.path.join(getroot, 'tests', 'audio',
                             '15_Ghosts_II_64kb_füllytâgged.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u')
     write_m3u(m3ufile, filename)
-    # need to give some time for watcher it pick it up
-    time.sleep(2)
+    time.sleep(1)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert '15_Ghosts_II_64kb_füllytâgged.mp3' in title
     assert 'tests' in title
     assert 'audio' in title
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)
 
 
 def test_no2newm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-name
@@ -161,6 +170,8 @@ def test_no2newm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-
     config = m3u_bootstrap
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
@@ -169,15 +180,14 @@ def test_no2newm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-
                             '15_Ghosts_II_64kb_füllytâgged.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u8')
     write_m3u8(m3ufile, filename)
-    # need to give some time for watcher it pick it up
-    time.sleep(2)
+    time.sleep(1)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert '15_Ghosts_II_64kb_füllytâgged.mp3' in title
     assert 'tests' in title
     assert 'audio' in title
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)
 
 
 def test_m3urelative(m3u_bootstrap):  # pylint: disable=redefined-outer-name
@@ -185,6 +195,8 @@ def test_m3urelative(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     config = m3u_bootstrap
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
@@ -195,14 +207,13 @@ def test_m3urelative(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     pathlib.Path(os.path.join(mym3udir, filename)).touch()
     m3ufile = os.path.join(mym3udir, 'test.m3u8')
     write_m3u(m3ufile, filename)
-    # need to give some time for watcher it pick it up
     time.sleep(1)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert filename in title
 
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)
 
 
 def test_m3ustream(m3u_bootstrap):  # pylint: disable=redefined-outer-name
@@ -210,29 +221,31 @@ def test_m3ustream(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     config = m3u_bootstrap
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
+    plugin.start()
+    time.sleep(5)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
 
     m3ufile = os.path.join(mym3udir, 'test.m3u')
     write_m3u(m3ufile, 'http://somecooltrack')
-    # need to give some time for watcher it pick it up
     time.sleep(1)
     (artist, title) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
 
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)
 
 
 def test_m3umixmode(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     ''' make sure mix mode is always newest '''
     config = m3u_bootstrap
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
-    time.sleep(1)
+    plugin.start()
+    time.sleep(5)
     assert plugin.validmixmodes()[0] == 'newest'
     assert plugin.setmixmode('fred') == 'newest'
     assert plugin.getmixmode() == 'newest'
     plugin.stop()
-    time.sleep(2)
+    time.sleep(5)

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -45,6 +45,7 @@ def getseratoplugin(serato_bootstrap, getroot, request):  # pylint: disable=rede
                               'Sessions'))
     config.cparser.sync()
     plugin = nowplaying.inputs.serato.Plugin(config=config)
+    plugin.start()
     yield plugin
     plugin.stop()
 


### PR DESCRIPTION
The __init__ method is called way too many times and thus triggers
a bunch of extra watchdog threads.  Add an explicit start()
method and call it from trackpoll to tell the plugin that
it is now live.

Fixes #242