### PR TITLE
Various cleanups and test code added

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,13 @@ import nowplaying.config
 if sys.platform == 'darwin':
     import pwd
 
+try:
+    from pytest_cov.embed import cleanup_on_sigterm
+except ImportError:
+    pass
+else:
+    cleanup_on_sigterm()
+
 
 def reboot_macosx_prefs():
     ''' work around Mac OS X's preference caching '''

--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing
 import os
 import pathlib
+import socket
 import sys
 
 from PySide2.QtCore import QCoreApplication, QStandardPaths, Qt  # pylint: disable=no-name-in-module
@@ -31,6 +32,10 @@ def run_bootstrap(bundledir=None):
     pathlib.Path(logpath).mkdir(parents=True, exist_ok=True)
     logpath = os.path.join(logpath, "debug.log")
 
+    # we are in a hurry to get results.  If it takes longer than
+    # 5 seconds, consider it a failure and move on.  At some
+    # point this should be configurable but this is good enough for now
+    socket.setdefaulttimeout(5.0)
     nowplaying.bootstrap.setuplogging(logpath=logpath)
 
     nowplaying.bootstrap.upgrade(bundledir=bundledir)

--- a/nowplaying/hostmeta.py
+++ b/nowplaying/hostmeta.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+''' deal with IP address malarky '''
+
+# pylint: disable=c-extension-no-member
+
+import socket
+import logging
+
+try:
+    import netifaces
+    IFACES = True
+except ImportError:
+    IFACES = False
+
+HOSTFQDN = None
+HOSTNAME = None
+HOSTIP = None
+
+
+def trysocket():
+    ''' try using socket.*; this works most of the time '''
+    global HOSTFQDN, HOSTNAME, HOSTIP  #pylint: disable=global-statement
+    try:
+        HOSTNAME = socket.gethostname()
+        HOSTFQDN = socket.getfqdn()
+        HOSTIP = socket.gethostbyname(HOSTFQDN)
+    except Exception as error:  # pylint: disable = broad-except
+        logging.error('Getting host or IP information via socket failed: %s',
+                      error)
+
+
+def trynetifaces():
+    ''' try using socket.*; this works most of the time '''
+    global HOSTFQDN, HOSTNAME, HOSTIP  #pylint: disable=global-statement
+
+    try:
+        gws = netifaces.gateways()
+        defnic = gws['default'][netifaces.AF_INET][1]
+        defnicipinfo = netifaces.ifaddresses(defnic).setdefault(
+            netifaces.AF_INET, [{
+                'addr': None
+            }])
+        HOSTIP = defnicipinfo[0]['addr']
+    except Exception as error:  # pylint: disable = broad-except
+        logging.error('Getting IP information via netifaces failed: %s', error)
+
+
+def gethostmeta():
+    ''' resolve hostname/ip of this machine '''
+
+    trysocket()
+    if not HOSTIP and IFACES:
+        trynetifaces()
+
+    return {'hostname': HOSTNAME, 'hostfqdn': HOSTFQDN, 'hostip': HOSTIP}

--- a/nowplaying/inputs/serato.py
+++ b/nowplaying/inputs/serato.py
@@ -626,7 +626,7 @@ class SeratoHandler():  #pylint: disable=too-many-instance-attributes
         # and companies don't have APIs for data.
         #
         try:
-            page = requests.get(self.url)
+            page = requests.get(self.url, timeout=5)
         except Exception as error:  # pylint: disable=broad-except
             logging.error("Cannot process %s: %s", self.url, error)
             return None, None

--- a/nowplaying/musicbrainz.py
+++ b/nowplaying/musicbrainz.py
@@ -24,9 +24,7 @@ class MusicBrainzHelper():
         else:
             self.config = nowplaying.config.ConfigFile()
 
-
         self.emailaddressset = False
-
 
     def _setemail(self):
         ''' make sure the musicbrainz fetch has an email address set

--- a/nowplaying/recognition/acoustidmb.py
+++ b/nowplaying/recognition/acoustidmb.py
@@ -80,7 +80,7 @@ class Plugin(RecognitionPlugin):
             return None
 
         try:
-            if isinstance(results['results'], list):
+            if isinstance(results['results'], list) and results['results']:
                 self.acoustidmd['acoustidid'] = results['results'][0]['id']
             elif 'id' in results:
                 self.acoustidmd['acoustidid'] = results['results']['id']

--- a/nowplaying/recognition/theaudiodb.py
+++ b/nowplaying/recognition/theaudiodb.py
@@ -45,7 +45,8 @@ class Plugin(RecognitionPlugin):
         try:
             logging.debug('Fetching %s', api)
             page = requests.get(
-                f'https://theaudiodb.com/api/v1/json/{apikey}/{api}')
+                f'https://theaudiodb.com/api/v1/json/{apikey}/{api}',
+                timeout=5)
         except Exception as error:  # pylint: disable=broad-except
             logging.error('TheAudioDB hit %s', error)
             return None

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import socket
 
 from PySide2.QtCore import Slot, QFile, Qt  # pylint: disable=no-name-in-module
 from PySide2.QtWidgets import QCheckBox, QErrorMessage, QFileDialog, QTableWidgetItem, QWidget  # pylint: disable=no-name-in-module
@@ -12,6 +11,7 @@ from PySide2.QtUiTools import QUiLoader  # pylint: disable=no-name-in-module
 import PySide2.QtXml  # pylint: disable=unused-import, import-error, no-name-in-module
 
 import nowplaying.config
+import nowplaying.hostmeta
 from nowplaying.exceptions import PluginVerifyError
 
 
@@ -116,19 +116,13 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods
 
     def _connect_webserver_widget(self, qobject):
         ''' file in the hostname/ip and connect the template button'''
-        hostname = None
-        hostip = None
 
-        try:
-            hostname = socket.gethostname()
-            hostip = socket.gethostbyname(hostname)
-        except Exception as error:  # pylint: disable = broad-except
-            logging.error('Getting IP information failed: %s', error)
+        data = nowplaying.hostmeta.gethostmeta()
 
-        if hostname:
-            qobject.hostname_label.setText(hostname)
-        if hostip:
-            qobject.hostip_label.setText(hostip)
+        if data['hostfqdn']:
+            qobject.hostname_label.setText(data['hostfqdn'])
+        if data['hostip']:
+            qobject.hostip_label.setText(data['hostip'])
 
         qobject.template_button.clicked.connect(self.on_html_template_button)
 

--- a/nowplaying/templates/basic-web.htm
+++ b/nowplaying/templates/basic-web.htm
@@ -23,7 +23,9 @@
   </head>
   <body>
     <div id="titlecard">
+      {% if title %}
       <p>Title: {{ title }}</p>
+      {% endif %}
       {% if artist %}
       <p>Artist: {{ artist }}</p>
       {% endif %}

--- a/nowplaying/templates/cover-title-artist.htm
+++ b/nowplaying/templates/cover-title-artist.htm
@@ -28,6 +28,7 @@
     <script src="https://code.jquery.com/jquery-3.5.0.js"></script>
   </head>
   <body>
+    {% if title %}
     <div id="titlecard">
       {% if coverurl %}
       <img src="{{ coverurl }}">
@@ -43,5 +44,6 @@
         $('#titlecard').delay(6000).fadeOut(2000);
       });
     </script>
+    {% endif %}
   </body>
 </html>

--- a/nowplaying/templates/mtv-cover-fade-ws.htm
+++ b/nowplaying/templates/mtv-cover-fade-ws.htm
@@ -21,6 +21,7 @@
            margin: 10px;
            float: left;
            max-height: 190px;
+           min-height: 190px;
            width: auto;
          }
       </style>
@@ -52,13 +53,21 @@
                      var img = document.createElement("img")
                      img.src = 'data:image/png;base64,' + metadata.coverimagebase64;
                      img.className = "npimage"
-                     $("#cover").html(img);
-                     $("#title").html('\"'+metadata.title+'\"');
-                     $("#artist").html(metadata.artist);
-                     $("#album").html(metadata.album);
-                     $("#label").html(metadata.label);
-                     $('#titlecard').delay(2000).fadeIn(2000);
-                     $('#titlecard').delay(5000).fadeOut(2000);
+                     if (metadata.title) {
+                        $("#cover").html(img);
+                        $("#title").html('\"'+metadata.title+'\"');
+                        $("#artist").html(metadata.artist);
+                        $("#album").html(metadata.album);
+                        $("#label").html(metadata.label);
+                        $('#titlecard').delay(2000).fadeIn(2000);
+                        $('#titlecard').delay(10000).fadeOut(2000);
+                     } else {
+                        $("#cover").html('');
+                        $("#title").html('');
+                        $("#artist").html('');
+                        $("#album").html('');
+                        $("#label").html('');
+                     }
                   };
 
                   ws.onclose = function(){

--- a/nowplaying/templates/mtv-cover-fade.htm
+++ b/nowplaying/templates/mtv-cover-fade.htm
@@ -39,7 +39,9 @@
       {% if artist %}
       <p>{{ artist }}</p>
       {% endif %}
+      {% if title %}
       <p>"{{ title }}"</p>
+      {% endif %}
       {% if album is not none %}
       <p>{{ album }}</p>
       {% endif %}

--- a/nowplaying/templates/mtv-cover-nofade-ws.htm
+++ b/nowplaying/templates/mtv-cover-nofade-ws.htm
@@ -21,6 +21,7 @@
            margin: 10px;
            float: left;
            max-height: 190px;
+           min-height: 190px;
            width: auto;
          }
       </style>
@@ -52,11 +53,19 @@
                      var img = document.createElement("img")
                      img.src = 'data:image/png;base64,' + metadata.coverimagebase64;
                      img.className = "npimage"
-                     $("#cover").html(img);
-                     $("#title").html('\"'+metadata.title+'\"');
-                     $("#artist").html(metadata.artist);
-                     $("#album").html(metadata.album);
-                     $("#label").html(metadata.label);
+                     if (metadata.title) {
+                        $("#cover").html(img);
+                        $("#title").html('\"'+metadata.title+'\"');
+                        $("#artist").html(metadata.artist);
+                        $("#album").html(metadata.album);
+                        $("#label").html(metadata.label);
+                     } else {
+                        $("#cover").html('');
+                        $("#title").html('');
+                        $("#artist").html('');
+                        $("#album").html('');
+                        $("#label").html('');
+                     }
                   };
 
                   ws.onclose = function(){

--- a/nowplaying/templates/mtv-nofade-ws.htm
+++ b/nowplaying/templates/mtv-nofade-ws.htm
@@ -42,10 +42,17 @@
                   ws.onmessage = function (event) {
                      var metadata = JSON.parse(event.data);
                      console.log(metadata.title);
-                     $("#title").html('\"'+metadata.title+'\"');
-                     $("#artist").html(metadata.artist);
-                     $("#album").html(metadata.album);
-                     $("#label").html(metadata.label);
+                     if (metadata.title) {
+                        $("#title").html('\"'+metadata.title+'\"');
+                        $("#artist").html(metadata.artist);
+                        $("#album").html(metadata.album);
+                        $("#label").html(metadata.label);
+                     } else {
+                        $("#title").html('');
+                        $("#artist").html('');
+                        $("#album").html('');
+                        $("#label").html('');
+                     }
                   };
 
                   ws.onclose = function(){

--- a/nowplaying/templates/mtv.htm
+++ b/nowplaying/templates/mtv.htm
@@ -26,6 +26,7 @@
     <script src="https://code.jquery.com/jquery-3.5.0.js"></script>
   </head>
   <body>
+    {% if title %}
     <div id="titlecard">
       {% if artist %}
       <p>{{ artist }}</p>
@@ -44,5 +45,6 @@
         $('#titlecard').delay(2000).fadeOut(2000);
       });
     </script>
+    {% endif %}
   </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ audio_metadata==0.11.1
 irc==19.0.1
 jinja2==3.0.1
 lxml==4.6.3
+netifaces==0.11.0
 musicbrainzngs==0.7.1
 obs-websocket-py==0.5.3
 pillow==8.3.1
@@ -13,6 +14,7 @@ pyinstaller==4.4
 pyinstaller_versionfile==2.0.0
 PySide2==5.15.2
 pytest==6.2.4
+pytest-asyncio==0.15.1
 pytest-qt==4.0.2
 pytest-cov==2.12.1
 pytest-httpserver==1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ install_requires =
   irc==19.0.1
   jinja2==3.0.1
   lxml==4.6.3
+  netifaces==0.11.0
   musicbrainzngs==0.7.1
   obs-websocket-py==0.5.3
   pillow==8.3.1

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+''' test webserver '''
+
+import multiprocessing
+import os
+import tempfile
+import time
+
+import pytest
+import requests
+
+import nowplaying.webserver  # pylint: disable=import-error
+
+
+@pytest.fixture
+def getwebserver(bootstrap):
+    ''' configure the webserver, dependents with prereqs '''
+    with tempfile.TemporaryDirectory() as newpath:
+        config = bootstrap
+        metadb = nowplaying.db.MetadataDB(databasefile=os.path.join(
+            newpath, 'test.db'),
+                                          initialize=True)
+        config.templatedir = os.path.join(newpath, 'templates')
+        bundledir = config.getbundledir()
+        webprocess = multiprocessing.Process(target=nowplaying.webserver.start,
+                                             args=(bundledir, newpath))
+        webprocess.start()
+        time.sleep(1)
+        yield config, metadb, webprocess
+        if webprocess:
+            nowplaying.webserver.stop(webprocess.pid)
+            if not webprocess.join(5):
+                webprocess.terminate()
+            webprocess.join(5)
+            webprocess.close()
+            webprocess = None
+
+
+def test_startstopwebserver(getwebserver):  # pylint: disable=redefined-outer-name
+    ''' test a simple start/stop '''
+    config, metadb, webprocess = getwebserver  #pylint: disable=unused-variable
+    config.cparser.setValue('weboutput/httpenabled', 'true')
+    config.cparser.sync()
+    time.sleep(5)
+
+
+def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-outer-name
+    ''' start webserver, read existing data, add new data, then read that '''
+    config, metadb, webprocess = getwebserver  #pylint: disable=unused-variable
+    config.cparser.setValue('weboutput/httpenabled', 'true')
+    config.cparser.setValue(
+        'weboutput/htmltemplate',
+        os.path.join(config.getbundledir(), 'templates', 'basic-plain.txt'))
+    config.cparser.setValue('weboutput/once', True)
+    config.cparser.sync()
+    time.sleep(10)
+
+    # handle no data, should return refresh
+
+    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    assert req.status_code == 202
+    assert req.text == nowplaying.webserver.INDEXREFRESH
+
+    # handle first write
+
+    metadb.write_to_metadb(metadata={
+        'title': 'testhtmtitle',
+        'artist': 'testhtmartist'
+    })
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ' testhtmartist - testhtmtitle'
+
+    # another read should give us refresh
+
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    assert req.status_code == 200
+    assert req.text == nowplaying.webserver.INDEXREFRESH
+
+    config.cparser.setValue('weboutput/once', False)
+    config.cparser.sync()
+
+    # flipping once to false should give us back same info
+
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ' testhtmartist - testhtmtitle'
+
+    # handle second write
+
+    metadb.write_to_metadb(metadata={
+        'artist': 'artisthtm2',
+        'title': 'titlehtm2',
+    })
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ' artisthtm2 - titlehtm2'
+
+
+def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-outer-name
+    ''' start webserver, read existing data, add new data, then read that '''
+    config, metadb, webprocess = getwebserver  #pylint: disable=unused-variable
+    config.cparser.setValue('weboutput/httpenabled', 'true')
+    config.cparser.setValue(
+        'weboutput/htmltemplate',
+        os.path.join(config.getbundledir(), 'templates', 'basic-plain.txt'))
+    config.cparser.setValue(
+        'textoutput/txttemplate',
+        os.path.join(config.getbundledir(), 'templates', 'basic-plain.txt'))
+    config.cparser.setValue('weboutput/once', True)
+    config.cparser.sync()
+    time.sleep(10)
+
+    # handle no data, should return refresh
+
+    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ''
+
+    # handle first write
+
+    metadb.write_to_metadb(metadata={
+        'title': 'testtxttitle',
+        'artist': 'testtxtartist'
+    })
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ' testtxtartist - testtxttitle'
+
+    # another read should give us same info
+
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ' testtxtartist - testtxttitle'
+
+    # handle second write
+
+    metadb.write_to_metadb(metadata={
+        'artist': 'artisttxt2',
+        'title': 'titletxt2',
+    })
+    time.sleep(1)
+    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    assert req.status_code == 200
+    assert req.text == ' artisttxt2 - titletxt2'


### PR DESCRIPTION
Big debugging session to deal with some of the issues
reported from RC5:

* Fix pytest coverage with multiprocessing
* Set a default socket timeout of 5 seconds in order to
  prevent various utilities from hanging indefinitely
* change various requests calls to include a 5 second
  timeout explicitly, since I don't think it uses
  socket's default timeout
* host IP changes:
  * add a new sub-module for determining IP info
  * Add netifaces support
  * populate hostip, hostfqdn, hostname in templates
* change the logging message for isrc support
* acoustid is now returning ok with empty results,
  which results in Bad Things(tm) happening, add a new
  check for that
* Fix various templates to avoid weird errors when title
  isn't present
* Fix alignment on some of the HTML templates
* Twitchbot would some times get multiple notifications
  which would then trigger multiple IRC announcements
  if there were a lot of rapid changes in succession.
  Move lastannounced to a global and throw a global lock
  around it.  :shrug:
* Add webserver test code and rework parts of webserver
  in order to make it somewhat testable
* Add pytest-asyncio to the plugins
* Twitchbot would crash if a user used command identifier
  but didn't have any badges

fixes #245 
fixes #243
partial for #238 

(Sidenote: this one should really get broken apart into multiple PRs but...)