### PR TITLE
Doc and template updates

### DIFF
--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -1,8 +1,3 @@
-.. Now Playing documentation master file, created by
-   sphinx-quickstart on Sat May 29 21:24:23 2021.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Gallery of Templates
 ====================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,10 @@
-.. Now Playing documentation master file, created by
-   sphinx-quickstart on Sat May 29 21:24:23 2021.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to Now Playing's documentation!
 =======================================
 
 **Now Playing** is a tool written in Python to retrieve the current/last played song in Serato DJ,
-Virtual DJ and other software that writes M3U files, or MPRIS2-compatible software. It allows you
-to generate titles such as this one:
+Virtual DJ and other software that writes M3U files, or MPRIS2-compatible software. It gives you full
+control to use or not use whatever features you like, as well as fully customize the output to match
+your style. You can even pretend to be a fancy music channel:
 
 .. image:: gallery/images/mtv-with-cover.png
    :target: gallery/images/mtv-with-cover.png
@@ -19,7 +15,7 @@ Checkout the `gallery <gallery.html>`_ to see more examples!
 Compiled, standalone versions are available for:
 
 * Windows
-* macOS (10.13/High Sierra to 10.15/Catalina)
+* macOS
 
 For everyone else, you will need to build and install locally.  See `Developers <developers.html>`_ below.
 
@@ -28,22 +24,17 @@ For everyone else, you will need to build and install locally.  See `Developers 
    :caption: Contents:
 
    installation
-   gallery
+   quickstart
    upgrading
    usage
    settings
-   input/m3u
-   input/mpris2
-   input/serato
-   output/obswebsocket
-   output/twitchbot
-   output/webserver
+   input/index
+   output/index
    recognition/index
-   recognition/acrcloud
-   recognition/acoustidmb
    templatevariables
    developers
    comparisons
+   gallery
 
 Indices and tables
 ==================

--- a/docs/input/index.rst
+++ b/docs/input/index.rst
@@ -1,0 +1,13 @@
+Source
+======
+
+In order for Now Playing to work, it needs to know what is being used to play music.  In the UI, this setting
+is called the Source.  There are many sources available and each has its own screen to configure them.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   m3u
+   mpris2
+   serato

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,10 @@
 Installation
 ============
 
+These directions cover the basic downloading and installation of the core funcionality.
+Music `recognition <recognition/index.html>`_ requires additional software to be installed.  Please see
+the plug-in specific page on those requirements.
+
 Linux
 -----
 
@@ -50,7 +54,7 @@ Windows
   run from (i.e., ``C:\Program Files``).
 
 *Important note for Windows users*
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Microsoft has beefed up Windows security and you may now get prompted about an unsigned
-binary.  Click on 'More Info' and then 'Run Anyway' to launch Now Playing.
+* Microsoft has beefed up Windows security and you may now get prompted about an unsigned
+  binary.  Click on 'More Info' and then 'Run Anyway' to launch Now Playing.

--- a/docs/output/index.rst
+++ b/docs/output/index.rst
@@ -1,0 +1,12 @@
+Outputs
+=======
+
+Now Playing can send song details to a variety of different systems, including just plain file output.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   obswebsocket
+   twitchbot
+   webserver

--- a/docs/output/webserver.rst
+++ b/docs/output/webserver.rst
@@ -1,6 +1,15 @@
 Webserver
 =========
 
+**Now Playing**\ has a built-in web server that allows for a wide variety of customization and
+deployments, including complex ones involving multiple hosts.  In general, the files in
+`templates` should be treated as examples; copy them to new names and modify until
+you are happy.  Change the font, change the output order, do whatever it is you need to do.
+
+It is *recommend* to use one of the WebSocket examples as your starting point as they
+are generally more predictable. They update when the song updates vs. the
+others that use a timer to check for updates.  See more about WebSockets below.
+
 Installation
 ------------
 
@@ -75,7 +84,8 @@ WebSockets
 ----------
 
 New with version 3.0.0 is a continual feed via WebSockets. The feed is a JSON-formatted stream that
-will get an update on every title change.  To connect, use the URL ``ws://hostname:port/wsstream``
+will get an update on every title change.  To connect, use the URL ``ws://hostname:port/wsstream``.
+The files that begin with `ws-` in the `templates` directory use WebSockets.
 
 Variables set should match what is on the `Templates <../templatevariables.html>`_ page. Be aware that
 values may be null.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,16 @@
+Quickstart
+==========
+
+Here are the steps to get a basic installation working:
+
+#. Download and install the binaries using the directions found in `Installation <installation.html>`_
+#. Launch the application
+#. It should bring up the `Settings <settings.html>`_
+#. Configure a File to Write.
+#. Configure a `Source <input/index.html>`_
+#. Save
+#. Bring up your DJ software and play a song.
+#. The file you picked to write should now have the song contents a few seconds after the DJ software updates its files. (Virtual DJ has a default 45 second delay, Serato updates on deck update.)
+
+
+At this point, you are ready to customize via `Templates <templates.html>`_ and enable other features!

--- a/docs/recognition/acrcloud.rst
+++ b/docs/recognition/acrcloud.rst
@@ -18,7 +18,9 @@ of the biggest in the world.
 You can learn more and sign up for ACRCloud's commercial services at https://www.acrcloud.com .
 
 
-This feature is only available on Linux and Mac OS X.
+In order for this feature to work on Windows, you will need to install the
+`Windows Runtime Library <https://github.com/acrcloud/acrcloud_sdk_python#windows-runtime-library>`.
+Linux and Mac OS X users do not need any extra software installed.
 
 
 Instructions

--- a/docs/recognition/index.rst
+++ b/docs/recognition/index.rst
@@ -1,8 +1,3 @@
-.. Now Playing documentation master file, created by
-   sphinx-quickstart on Sat May 29 21:24:23 2021.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Music Recognition
 =================
 
@@ -18,7 +13,13 @@ This feature may have some significant impacts on Now Playing's general performa
 * Extra time will be required in order to all of this extra work, adding delays to
   the display.
 
-The results of the music recognition feature are constantly being improved. However, they
-will never be perfect and will still likely provide surprising results.  The more information
-in the actual music files, the better the results.
+The results of the music recognition feature are constantly being improved. However, such
+technologies will never be perfect and will still likely provide surprising results.
+The more information in the actual music files, the better the results.
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   acrcloud
+   acoustidmb

--- a/docs/templatevariables.rst
+++ b/docs/templatevariables.rst
@@ -60,6 +60,14 @@ Support Variables
      - Local filename of the media
    * - genre
      - Genre of the song
+   * - hostip
+     - IP address of the machine running Now Playing
+   * - hostfqdn
+     - Fully qualified hostname of the machine running Now Playing
+   * - hostname
+     - Short hostname of the machine running Now Playing
+   * - httpport
+     - Port number that is running the web server
    * - key
      - Key of the song
    * - label
@@ -94,13 +102,13 @@ Undefined
 When rendering templates, Now Playing will set any undefined variables to the empty string.
 Instead of having to render a template as:
 
-.. code-block:: jinja2
+.. code-block:: jinja
 
   {% if variable is defined and variable is not none and variable|length %}
 
 This can be short-cut to:
 
-.. code-block:: jinja2
+.. code-block:: jinja
 
   {% if variable %}
 

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -44,6 +44,8 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
 
     def _process_hostmeta(self):
         ''' add the host metadata so other subsystems can use it '''
+        if self.config.cparser.value('weboutput/httpenabled', type=bool):
+            self.metadata['httpport'] = self.config.cparser.value('weboutput/httpport', type=int)
         hostmeta = nowplaying.hostmeta.gethostmeta()
         for key, value in hostmeta.items():
             self.metadata[key] = value

--- a/nowplaying/templates/ws-mtv-cover-fade.htm
+++ b/nowplaying/templates/ws-mtv-cover-fade.htm
@@ -59,6 +59,8 @@
                         $("#artist").html(metadata.artist);
                         $("#album").html(metadata.album);
                         $("#label").html(metadata.label);
+                        $('#titlecard').delay(2000).fadeIn(2000);
+                        $('#titlecard').delay(10000).fadeOut(2000);
                      } else {
                         $("#cover").html('');
                         $("#title").html('');
@@ -75,7 +77,7 @@
             }
 
             if ("WebSocket" in window) {
-               start("ws://localhost:8899/wsstream")
+               start("ws://{{ hostip }}:{{ hostport }}/wsstream")
             }
 
       </script>

--- a/nowplaying/templates/ws-mtv-cover-nofade.htm
+++ b/nowplaying/templates/ws-mtv-cover-nofade.htm
@@ -59,8 +59,6 @@
                         $("#artist").html(metadata.artist);
                         $("#album").html(metadata.album);
                         $("#label").html(metadata.label);
-                        $('#titlecard').delay(2000).fadeIn(2000);
-                        $('#titlecard').delay(10000).fadeOut(2000);
                      } else {
                         $("#cover").html('');
                         $("#title").html('');
@@ -77,7 +75,7 @@
             }
 
             if ("WebSocket" in window) {
-               start("ws://localhost:8899/wsstream")
+               start("ws://{{ hostip }}:{{ hostport }}/wsstream")
             }
 
       </script>

--- a/nowplaying/templates/ws-mtv-nofade.htm
+++ b/nowplaying/templates/ws-mtv-nofade.htm
@@ -62,7 +62,7 @@
             }
 
             if ("WebSocket" in window) {
-               start("ws://localhost:8899/wsstream")
+               start("ws://{{ hostip }}:{{ hostport }}/wsstream")
             }
 
       </script>


### PR DESCRIPTION
1. Change the websocket files to be template'd
2. Rename the websocket files to start with ws- to make it obvious.
3. Add a new Quickstart section to the docs
4. Make section starts for input, output, and recog; take out direct links from main index
5. Various clarifications.
6. Add directions on getting ACRCloud working on Windows.
7. Document httpport, hostip, hostfqdn
8. Change template format from jinja2 to jinja so that pygments will pick it up