### PR TITLE
Remove unused Twitch v5 API stuff

### DIFF
--- a/nowplaying/twitchbot.py
+++ b/nowplaying/twitchbot.py
@@ -106,7 +106,6 @@ class TwitchBot(irc.bot.SingleServerIRCBot):  # pylint: disable=too-many-instanc
                                   finalize=self._finalize,
                                   trim_blocks=True)
 
-
     def _setup_timer(self):
         self.watcher = self.metadb.watcher()
         self.watcher.start(customhandler=self._announce_track)


### PR DESCRIPTION
fixes #276

The code currently doesn't use the Twitch REST API so just remove it for now to avoid the "v5 is going away" email.