### PR TITLE
Switch to a,t,f for playingtrack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ htmlcov/
 .pytest_cache
 NowPlaying*.zip
 nowplaying/version.py.old
+NowPlaying.egg-info

--- a/nowplaying/inputs/m3u.py
+++ b/nowplaying/inputs/m3u.py
@@ -19,7 +19,7 @@ from nowplaying.exceptions import PluginVerifyError
 class Plugin(InputPlugin):
     ''' handler for NowPlaying '''
 
-    metadata = {'artist': None, 'title': None, 'filename': None}
+    metadata = {}
 
     def __init__(self, config=None, m3udir=None, qsettings=None):
         super().__init__(config=config, qsettings=qsettings)
@@ -32,6 +32,10 @@ class Plugin(InputPlugin):
         self.event_handler = None
         self.observer = None
         self.qwidget = None
+        self._reset_meta()
+
+    def _reset_meta(self):  #pylint: disable=no-self-use
+        Plugin.metadata = {'artist': None, 'title': None, 'filename': None}
 
     def _setup_watcher(self):
         ''' set up a custom watch on the m3u dir so meta info
@@ -91,6 +95,7 @@ class Plugin(InputPlugin):
         # file is empty so ignore it
         if os.stat(filename).st_size == 0:
             logging.debug('%s is empty, ignoring for now.', filename)
+            self._reset_meta()
             return
 
         content = self._read_track_default(filename)
@@ -99,6 +104,7 @@ class Plugin(InputPlugin):
                       content)
 
         if not content:
+            self._reset_meta()
             return
 
         found = None
@@ -121,6 +127,7 @@ class Plugin(InputPlugin):
 
         if not found:
             logging.error('Cannot find or decode %s', content)
+            self._reset_meta()
             return
 
         logging.debug('Used %s and found %s', encoding, found)
@@ -136,7 +143,7 @@ class Plugin(InputPlugin):
 
         # just in case called without calling start...
         self._setup_watcher()
-        return None, Plugin.metadata['filename']
+        return None, None, Plugin.metadata['filename']
 
     def getplayingmetadata(self):  #pylint: disable=no-self-use
         ''' wrapper to call getplayingmetadata '''

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -240,7 +240,10 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                     if addmeta:
                         self._recognition_replacement(addmeta)
                 except Exception as error:  # pylint: disable=broad-except
-                    logging.debug('%s threw exception %s', plugin, error)
+                    logging.debug('%s threw exception %s',
+                                  plugin,
+                                  error,
+                                  exc_info=True)
 
 
 def main():

--- a/nowplaying/recognition/acoustidmb.py
+++ b/nowplaying/recognition/acoustidmb.py
@@ -97,9 +97,9 @@ class Plugin(RecognitionPlugin):
 
     def _read_acoustid_tuples(self, results):  # pylint: disable=too-many-branches, too-many-statements, too-many-locals
         fnstr = self._simplestring(self.acoustidmd['filename'])
-        if 'artist' in self.acoustidmd:
+        if 'artist' in self.acoustidmd and self.acoustidmd['artist']:
             fnstr = fnstr + self._simplestring(self.acoustidmd['artist'])
-        if 'title' in self.acoustidmd:
+        if 'title' in self.acoustidmd and self.acoustidmd['title']:
             fnstr = fnstr + self._simplestring(self.acoustidmd['title'])
 
         lastscore = 0

--- a/nowplaying/recognition/theaudiodb.py
+++ b/nowplaying/recognition/theaudiodb.py
@@ -82,6 +82,8 @@ class Plugin(RecognitionPlugin):
     def artistdatafromname(self, artist):
         ''' get artist data from name '''
         metadata = {}
+        if not artist:
+            return None
         urlart = requests.utils.requote_uri(artist)
         data = self._fetch(f'search.php?s={urlart}')
         if not data or 'artists' not in data or not data['artists']:

--- a/nowplaying/twitchbot.py
+++ b/nowplaying/twitchbot.py
@@ -29,7 +29,6 @@ import sys
 import textwrap
 import threading
 import time
-import traceback
 
 import irc.bot
 import jinja2
@@ -350,8 +349,8 @@ class TwitchBotHandler():
                 pass
             except Exception as error:  # pylint: disable=broad-except
                 logging.error('TwitchBot threw exception after forever: %s',
-                              error)
-                logging.error(traceback.print_stack())
+                              error,
+                              exc_info=True)
             finally:
                 if self.server:
                     self.server.shutdown()

--- a/nowplaying/webserver.py
+++ b/nowplaying/webserver.py
@@ -12,7 +12,6 @@ import string
 import sys
 import threading
 import time
-import traceback
 import weakref
 
 import requests
@@ -380,8 +379,7 @@ def start(bundledir, testdir=None):
     try:
         webserver = WebHandler(databasefile, testmode=testmode)  # pylint: disable=unused-variable
     except Exception as error:  #pylint: disable=broad-except
-        logging.error('Webserver crashed: %s', error)
-        logging.error(traceback.print_stack())
+        logging.error('Webserver crashed: %s', error, exc_info=True)
         sys.exit(1)
     sys.exit(0)
 

--- a/tests/test_acrcloud.py
+++ b/tests/test_acrcloud.py
@@ -43,7 +43,7 @@ def test_15ghosts2_orig(getacrcloudplugin, getroot):  # pylint: disable=redefine
     })
     assert metadata['album'] == 'Ghosts I-IV'
     assert metadata['artist'] == 'Nine Inch Nails'
-    assert metadata['label'] == 'The Null Corporation'
+    assert metadata['label'] in ['The Null Corporation', 'UMG - FAB']
     assert metadata['title'] == '15 Ghosts II'
     assert metadata[
         'musicbrainzrecordingid'] == 'e0632d22-f355-41dd-ae01-9bcd87aaacf6'

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -57,11 +57,12 @@ def test_nom3u(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     plugin.stop()
     time.sleep(5)
     assert artist is None
     assert title is None
+    assert filename is None
 
 
 def test_emptym3u(m3u_bootstrap):  # pylint: disable=redefined-outer-name
@@ -74,11 +75,12 @@ def test_emptym3u(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     plugin.stop()
     time.sleep(5)
     assert artist is None
     assert title is None
+    assert filename is None
 
 
 def test_emptym3u2(m3u_bootstrap):  # pylint: disable=redefined-outer-name
@@ -93,11 +95,12 @@ def test_emptym3u2(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     plugin = nowplaying.inputs.m3u.Plugin(config=config)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     plugin.stop()
     time.sleep(5)
     assert artist is None
     assert title is None
+    assert filename is None
 
 
 def test_no2newm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-name
@@ -105,20 +108,22 @@ def test_no2newm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-n
     config = m3u_bootstrap
     mym3udir = config.cparser.value('m3u/directory')
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     plugin.start()
     time.sleep(5)
     assert artist is None
     assert title is None
+    assert filename is None
 
-    filename = os.path.join(getroot, 'tests', 'audio',
-                            '15_Ghosts_II_64kb_orig.mp3')
+    testmp3 = os.path.join(getroot, 'tests', 'audio',
+                           '15_Ghosts_II_64kb_orig.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u')
-    write_m3u(m3ufile, filename)
+    write_m3u(m3ufile, testmp3)
     time.sleep(1)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
-    assert '15_Ghosts_II_64kb_orig.mp3' in title
+    assert title is None
+    assert testmp3 == filename
     plugin.stop()
     time.sleep(5)
 
@@ -130,16 +135,17 @@ def test_noencodingm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-ou
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
 
-    filename = os.path.join(getroot, 'tests', 'audio',
-                            '15_Ghosts_II_64kb_orig.mp3')
+    testmp3 = os.path.join(getroot, 'tests', 'audio',
+                           '15_Ghosts_II_64kb_orig.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u')
-    write_m3u8(m3ufile, filename)
+    write_m3u8(m3ufile, testmp3)
     time.sleep(1)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
-    assert '15_Ghosts_II_64kb_orig.mp3' in title
+    assert title is None
+    assert testmp3 == filename
     plugin.stop()
     time.sleep(5)
 
@@ -151,16 +157,15 @@ def test_encodingm3u(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
     plugin.start()
     time.sleep(5)
-    filename = os.path.join(getroot, 'tests', 'audio',
-                            '15_Ghosts_II_64kb_füllytâgged.mp3')
+    testmp3 = os.path.join(getroot, 'tests', 'audio',
+                           '15_Ghosts_II_64kb_füllytâgged.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u')
-    write_m3u(m3ufile, filename)
+    write_m3u(m3ufile, testmp3)
     time.sleep(1)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
-    assert '15_Ghosts_II_64kb_füllytâgged.mp3' in title
-    assert 'tests' in title
-    assert 'audio' in title
+    assert title is None
+    assert testmp3 == filename
     plugin.stop()
     time.sleep(5)
 
@@ -172,20 +177,20 @@ def test_no2newm3u8(m3u_bootstrap, getroot):  # pylint: disable=redefined-outer-
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
+    assert filename is None
 
-    filename = os.path.join(getroot, 'tests', 'audio',
-                            '15_Ghosts_II_64kb_füllytâgged.mp3')
+    testmp3 = os.path.join(getroot, 'tests', 'audio',
+                           '15_Ghosts_II_64kb_füllytâgged.mp3')
     m3ufile = os.path.join(mym3udir, 'test.m3u8')
-    write_m3u8(m3ufile, filename)
+    write_m3u8(m3ufile, testmp3)
     time.sleep(1)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
-    assert '15_Ghosts_II_64kb_füllytâgged.mp3' in title
-    assert 'tests' in title
-    assert 'audio' in title
+    assert title is None
+    assert testmp3 == filename
     plugin.stop()
     time.sleep(5)
 
@@ -197,20 +202,22 @@ def test_m3urelative(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
+    assert filename is None
 
-    filename = os.path.join('fakedir', '15_Ghosts_II_64kb_orig.mp3')
+    testmp3 = os.path.join('fakedir', '15_Ghosts_II_64kb_orig.mp3')
     pathlib.Path(os.path.join(mym3udir, 'fakedir')).mkdir(parents=True,
                                                           exist_ok=True)
-    pathlib.Path(os.path.join(mym3udir, filename)).touch()
+    pathlib.Path(os.path.join(mym3udir, testmp3)).touch()
     m3ufile = os.path.join(mym3udir, 'test.m3u8')
-    write_m3u(m3ufile, filename)
+    write_m3u(m3ufile, testmp3)
     time.sleep(1)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
-    assert filename in title
+    assert title is None
+    assert testmp3 in filename
 
     plugin.stop()
     time.sleep(5)
@@ -223,16 +230,18 @@ def test_m3ustream(m3u_bootstrap):  # pylint: disable=redefined-outer-name
     plugin = nowplaying.inputs.m3u.Plugin(config=config, m3udir=mym3udir)
     plugin.start()
     time.sleep(5)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
+    assert filename is None
 
     m3ufile = os.path.join(mym3udir, 'test.m3u')
     write_m3u(m3ufile, 'http://somecooltrack')
     time.sleep(1)
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     assert artist is None
     assert title is None
+    assert filename is None
 
     plugin.stop()
     time.sleep(5)

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -72,20 +72,22 @@ def test_serato_remote2(getseratoplugin, getroot, httpserver):  # pylint: disabl
     plugin.config.cparser.setValue('serato/url',
                                    httpserver.url_for('/index.html'))
     plugin.config.cparser.sync()
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
 
     assert artist == 'Chris McClenney'
     assert title == 'Tuning Up'
+    assert filename is None
 
 
 @pytest.mark.seratosettings(datadir='serato-2.4-mac', mixmode='oldest')
 def test_serato24_mac_oldest(getseratoplugin):  # pylint: disable=redefined-outer-name
     ''' automated integration test '''
     plugin = getseratoplugin
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     metadata = plugin.getplayingmetadata()
     assert artist == 'LĪVE'
     assert title == 'Take My Anthem'
+    assert filename == '/Users/aw/Music/songs/LĪVE/Mental Jewelry/08 Take My Anthem.mp3'
     expected = {
         'album': 'Mental Jewelry',
         'artist': artist,
@@ -106,10 +108,11 @@ def test_serato24_mac_oldest(getseratoplugin):  # pylint: disable=redefined-oute
 def test_serato24_mac_newest(getseratoplugin):  # pylint: disable=redefined-outer-name
     ''' automated integration test '''
     plugin = getseratoplugin
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     metadata = plugin.getplayingmetadata()
     assert artist == 'LĪVE'
     assert title == 'Lakini\'s Juice'
+    assert filename == "/Users/aw/Music/songs/LĪVE/Secret Samadhi/02 Lakini's Juice.mp3"
     expected = {
         'album': 'Secret Samadhi',
         'artist': artist,
@@ -130,10 +133,11 @@ def test_serato24_mac_newest(getseratoplugin):  # pylint: disable=redefined-oute
 def test_serato25_win_oldest(getseratoplugin):  # pylint: disable=redefined-outer-name
     ''' automated integration test '''
     plugin = getseratoplugin
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     metadata = plugin.getplayingmetadata()
     assert artist == 'Broke For Free'
     assert title == 'Night Owl'
+    assert filename == 'C:\\Users\\aw\\Music\\Broke For Free - Night Owl.mp3'
     expected = {
         'album':
         'Directionless EP',
@@ -162,10 +166,11 @@ def test_serato25_win_oldest(getseratoplugin):  # pylint: disable=redefined-oute
 def test_serato25_win_newest(getseratoplugin):  # pylint: disable=redefined-outer-name
     ''' automated integration test '''
     plugin = getseratoplugin
-    (artist, title) = plugin.getplayingtrack()
+    (artist, title, filename) = plugin.getplayingtrack()
     metadata = plugin.getplayingmetadata()
     assert artist == 'Bio Unit'
     assert title == 'Heaven'
+    assert filename == 'C:\\Users\\aw\\Music\\Bio Unit - Heaven.mp3'
     expected = {
         'album': 'Ampex',
         'artist': artist,


### PR DESCRIPTION
* After a bit of playing with audio recognition, it
  is very clear that getplayingtrack needs to return
  the filename as a separate thing
* Remove traceback and just use exc_info for logging
  exceptions
* handle the case where MPRIS2 only gives us a filename
  as the title
* handle the case where artist is None in theaudiodb
* handle the case where we are missing data in acoustidmb