### PR TITLE
Title should be valid before stripping

### DIFF
--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -66,7 +66,8 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
 
     def _strip_identifiers(self):
 
-        if self.config.cparser.value('settings/stripextras', type=bool):
+        if self.config.cparser.value('settings/stripextras',
+                                     type=bool) and self.metadata.get('title'):
             trackname = self.metadata['title']
             for index in STRIPRELIST:
                 trackname = index.sub('', trackname)


### PR DESCRIPTION
fixes #448 

I'm not sure _how_ title is empty when it hits that, but it is clearly possible so protect against it.