### PR TITLE
Strip OVM and make acoustid use the stripper

### DIFF
--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import re
 import string
 import sys
 import textwrap
@@ -15,12 +14,6 @@ import nowplaying.hostmeta
 import nowplaying.vendor.audio_metadata
 from nowplaying.vendor.audio_metadata.formats.mp4_tags import MP4FreeformDecoders
 import nowplaying.vendor.tinytag
-
-STRIPWORDLIST = ['clean', 'dirty', 'explicit']
-STRIPRELIST = [
-    re.compile(r' \((?i:{0})\)'.format('|'.join(STRIPWORDLIST))),  #pylint: disable=consider-using-f-string
-    re.compile(r' - (?i:{0}$)'.format('|'.join(STRIPWORDLIST)))  #pylint: disable=consider-using-f-string
-]
 
 
 class MetadataProcessors:  # pylint: disable=too-few-public-methods
@@ -68,11 +61,8 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
 
         if self.config.cparser.value('settings/stripextras',
                                      type=bool) and self.metadata.get('title'):
-            trackname = self.metadata['title']
-            for index in STRIPRELIST:
-                trackname = index.sub('', trackname)
-            if len(trackname) > 0:
-                self.metadata['title'] = trackname
+            self.metadata['title'] = nowplaying.utils.titlestripper_basic(
+                self.metadata['title'])
 
     def _uniqlists(self):
         lists = ['artistwebsites', 'isrc', 'musicbrainzartistid']

--- a/nowplaying/recognition/acoustidmb.py
+++ b/nowplaying/recognition/acoustidmb.py
@@ -114,12 +114,18 @@ class Plugin(RecognitionPlugin):
 
     def _read_acoustid_tuples(self, metadata, results):  # pylint: disable=too-many-branches, too-many-statements, too-many-locals
         fnstr = nowplaying.utils.normalize(metadata['filename'])
-        artistnstr = ''
-        titlenstr = ''
-        if metadata.get('artist'):
-            artistnstr = nowplaying.utils.normalize(metadata['artist'])
-        if metadata.get('title'):
-            titlenstr = nowplaying.utils.normalize(metadata['title'])
+        artist = metadata.get('artist')
+        title = metadata.get('title')
+        if artist and title and artist in title and len(artist) > 3:
+            title = title.replace(artist, '')
+        title = nowplaying.utils.titlestripper_basic(title)
+        artistnstr = nowplaying.utils.normalize(artist)
+        titlenstr = nowplaying.utils.normalize(title)
+
+        if not artistnstr:
+            artistnstr = ''
+        if not titlenstr:
+            titlenstr = ''
 
         completenstr = fnstr + artistnstr + titlenstr
 

--- a/nowplaying/utils.py
+++ b/nowplaying/utils.py
@@ -3,17 +3,26 @@
 
 from html.parser import HTMLParser
 
+import copy
 import importlib
 import io
 import logging
 import pkgutil
 import os
+import re
 
 import jinja2
 import normality
 import PIL.Image
 
 import nowplaying.metadata
+
+STRIPWORDLIST = ['clean', 'dirty', 'explicit', 'official music video']
+STRIPRELIST = [
+    re.compile(r' \((?i:{0})\)'.format('|'.join(STRIPWORDLIST))),  #pylint: disable=consider-using-f-string
+    re.compile(r' - (?i:{0}$)'.format('|'.join(STRIPWORDLIST))),  #pylint: disable=consider-using-f-string
+    re.compile(r' \[(?i:{0})\]'.format('|'.join(STRIPWORDLIST))),  #pylint: disable=consider-using-f-string
+]
 
 
 class HTMLFilter(HTMLParser):
@@ -218,3 +227,15 @@ def normalize(crazystring):
     if len(crazystring) < 4:
         return 'TEXT IS TOO SMALL IGNORE'
     return normality.normalize(crazystring).replace(' ', '')
+
+
+def titlestripper_basic(title):
+    ''' Basic title removal '''
+    if not title:
+        return None
+    trackname = copy.deepcopy(title)
+    for index in STRIPRELIST:
+        trackname = index.sub('', trackname)
+    if len(trackname) == 0:
+        trackname = copy.deepcopy(title)
+    return trackname

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,3 +73,99 @@ def test_songsubst_towindows(bootstrap):
     config.cparser.setValue('quirks/slashmode', 'toback')
     location = nowplaying.utils.songpathsubst(config, '/Music/Band/Song')
     assert location == 'Z:\\Music\\Band\\Song'
+
+
+def test_basicstrip_explicitdash():
+    ''' automated integration test '''
+    metadata = {'title': 'Test - Explicit'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test - Explicit'
+    assert title == 'Test'
+
+
+def test_basicstrip_dirtydash():
+    ''' automated integration test '''
+    metadata = {'title': 'Test - Dirty'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test - Dirty'
+    assert title == 'Test'
+
+
+def test_basicstrip_cleandash():
+    ''' automated integration test '''
+    metadata = {'title': 'Test - Clean'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test - Clean'
+    assert title == 'Test'
+
+
+def test_basicstrip_noclean():
+    ''' automated integration test '''
+    metadata = {'title': 'Clean'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Clean'
+    assert title == 'Clean'
+
+
+def test_basicstrip_cleanparens():
+    ''' automated integration test '''
+    metadata = {'title': 'Test (Clean)'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test (Clean)'
+    assert title == 'Test'
+
+
+def test_basicstrip_cleansquareb():
+    ''' automated integration test '''
+    metadata = {'title': 'Test [Clean]'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test [Clean]'
+    assert title == 'Test'
+
+
+def test_basicstrip_cleanextraparens():
+    ''' automated integration test '''
+    metadata = {'title': 'Test (Clean) (Single Mix)'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test (Clean) (Single Mix)'
+    assert title == 'Test (Single Mix)'
+
+
+def test_basicstrip_ovm1():
+    ''' automated integration test '''
+    metadata = {'title': 'Test (Clean) (Official Music Video)'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test (Clean) (Official Music Video)'
+    assert title == 'Test'
+
+
+def test_basicstrip_ovm2():
+    ''' automated integration test '''
+    metadata = {'title': 'Test (Clean) [official music video]'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Test (Clean) [official music video]'
+    assert title == 'Test'
+
+
+def test_basicstrip_ovm3():
+    ''' automated integration test '''
+    metadata = {'title': 'Clean [official music video]'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Clean [official music video]'
+    assert title == 'Clean'
+
+
+def test_basicstrip_doubleclean():
+    ''' automated integration test '''
+    metadata = {'title': 'Clean - Clean'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Clean - Clean'
+    assert title == 'Clean'
+
+
+def test_basicstrip_ovm4():
+    ''' automated integration test '''
+    metadata = {'title': 'Clean - Official Music Video'}
+    title = nowplaying.utils.titlestripper_basic(metadata['title'])
+    assert metadata['title'] == 'Clean - Official Music Video'
+    assert title == 'Clean'


### PR DESCRIPTION
fixes #476 and a few other bugs:

* Move the basic stripping code to utils so that other things may call it
* Add [] in addition to the already existing () as text containers
* Add 'Official Music Video'
* Makes sure acoustid always uses this for local processing since those extra tags confuse the heck out of it