### PR TITLE
Move trackpoll to a dedicated process

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,9 @@
 
 import logging
 import os
+import pathlib
 import sys
+import tempfile
 
 import psutil
 import pytest
@@ -45,12 +47,15 @@ def getroot(pytestconfig):
 @pytest.fixture
 def bootstrap(getroot):  # pylint: disable=redefined-outer-name
     ''' bootstrap a configuration '''
-    bundledir = os.path.join(getroot, 'nowplaying')
-    nowplaying.bootstrap.set_qt_names(appname='testsuite')
-    config = nowplaying.config.ConfigFile(bundledir=bundledir, testmode=True)
-    config.cparser.setValue('acoustidmb/enabled', False)
-    config.cparser.sync()
-    yield config
+    with tempfile.TemporaryDirectory() as newpath:
+        bundledir = pathlib.Path(getroot).joinpath('nowplaying')
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+        config = nowplaying.config.ConfigFile(bundledir=bundledir,
+                                              logpath=newpath,
+                                              testmode=True)
+        config.cparser.setValue('acoustidmb/enabled', False)
+        config.cparser.sync()
+        yield config
 
 
 #
@@ -78,20 +83,20 @@ def clear_old_testsuite():
                        QCoreApplication.applicationName())
     config.clear()
     config.sync()
-    filename = config.fileName()
+    filename = pathlib.Path(config.fileName())
     del config
-    if os.path.exists(filename):
-        os.unlink(filename)
+    if filename.exists():
+        filename.unlink()
     reboot_macosx_prefs()
-    if os.path.exists(filename):
-        os.unlink(filename)
+    if filename.exists():
+        filename.unlink()
     reboot_macosx_prefs()
-    if os.path.exists(filename):
+    if filename.exists():
         logging.error('Still exists, wtf?')
     yield filename
-    if os.path.exists(filename):
-        os.unlink(filename)
+    if filename.exists():
+        filename.unlink()
     reboot_macosx_prefs()
-    if os.path.exists(filename):
-        os.unlink(filename)
+    if filename.exists():
+        filename.unlink()
     reboot_macosx_prefs()

--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -64,7 +64,7 @@ def main():
     logging.getLogger().setLevel(config.loglevel)
     logging.captureWarnings(True)
     tray = nowplaying.systemtray.Tray()  # pylint: disable=unused-variable
-    icon = QIcon(config.iconfile)
+    icon = QIcon(str(config.iconfile))
     qapp.setWindowIcon(icon)
     exitval = qapp.exec_()
     logging.info('shutting down v%s',

--- a/nowplaying/inputs/json.py
+++ b/nowplaying/inputs/json.py
@@ -62,6 +62,7 @@ class Plugin(InputPlugin):
             self.config.cparser.value('jsoninput/filename'))
 
         if not filepath.exists():
+            logging.debug('%s does not exist', filepath)
             return {}
 
         try:

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -49,7 +49,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods
 
         if not self.config.iconfile:
             self.tray.cleanquit()
-        self.qtui.setWindowIcon(QIcon(self.iconfile))
+        self.qtui.setWindowIcon(QIcon(str(self.iconfile)))
 
     def load_qtui(self):
         ''' load the base UI and wire it up '''
@@ -57,11 +57,11 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods
         def _load_ui(name):
             ''' load a UI file into a widget '''
             loader = QUiLoader()
-            path = os.path.join(self.config.uidir, f'{name}_ui.ui')
-            if not os.path.exists(path):
+            path = self.config.uidir.joinpath(f'{name}_ui.ui')
+            if not path.exists():
                 return None
 
-            ui_file = QFile(path)
+            ui_file = QFile(str(path))
             ui_file.open(QFile.ReadOnly)
             try:
                 qwidget = loader.load(ui_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ''' misc nowplaying.config tests '''
 
-import os
+import pathlib
 
 from PySide6.QtCore import QCoreApplication, QStandardPaths  # pylint: disable=no-name-in-module
 
@@ -20,7 +20,7 @@ def test_reset1(bootstrap):
 
 def test_reset2(getroot):
     ''' test config.reset via init '''
-    bundledir = os.path.join(getroot, 'nowplaying')
+    bundledir = pathlib.Path(getroot).joinpath('nowplaying')
     nowplaying.bootstrap.set_qt_names(appname='testsuite')
     config = nowplaying.config.ConfigFile(bundledir=bundledir, testmode=True)
     config.cparser.setValue('acoustidmb/enabled', False)
@@ -66,9 +66,12 @@ def test_get1(bootstrap):
     assert not config.initialized
     assert config.loglevel == 'DEBUG'
     assert not config.notif
-    assert config.txttemplate == os.path.join(
-        QStandardPaths.standardLocations(QStandardPaths.DocumentsLocation)[0],
-        QCoreApplication.applicationName(), 'templates', 'basic-plain.txt')
+    assert config.txttemplate == str(
+        pathlib.Path(
+            QStandardPaths.standardLocations(
+                QStandardPaths.DocumentsLocation)[0],
+            QCoreApplication.applicationName()).joinpath(
+                'templates', 'basic-plain.txt'))
 
     config.cparser.setValue('settings/initialized', True)
     config.cparser.setValue('settings/loglevel', 'invalid1')
@@ -87,6 +90,6 @@ def test_get1(bootstrap):
 
 def test_bundledir(getroot, bootstrap):
     ''' test config.getbundledir '''
-    bundledir = os.path.join(getroot, 'nowplaying')
+    bundledir = pathlib.Path(getroot).joinpath('nowplaying')
     config = bootstrap
     assert bundledir == config.getbundledir()

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -23,7 +23,10 @@ def getwebserver(bootstrap):
         config.templatedir = os.path.join(newpath, 'templates')
         bundledir = config.getbundledir()
         webprocess = multiprocessing.Process(target=nowplaying.webserver.start,
-                                             args=(bundledir, newpath))
+                                             args=(
+                                                 bundledir,
+                                                 newpath,
+                                             ))
         webprocess.start()
         time.sleep(1)
         yield config, metadb, webprocess


### PR DESCRIPTION
This patch is a big one:

1. TrackPoll is now started via a multiprocessing.Process instead of a QThread. It is very very similar to how Twitchbot and Webserver are handled so should allows us to switch this over to asyncio now.  As a result, all Qt bits have been removed from that execution path, minus configuration bits of course.
2. Notify is now down via QFileWatcher with the same protections needed for the Twitchbot. This functionality was Qt signal/slot, but can no longer be due to needing to remove the Qt loop from TrackPoll.
3. In many places, os.path -> pathlib
4. pause is now handled via a special entry in the config file.  Before it was a Qt signal/slot combo.


Some Todos for later PRs:
1. Clean up systemtray to use less instances vars now that everything is a process.
2. Finish adding more test code to trackpoll, since a lot of it had to be removed.
3. There are certainly places where the timings are out of whack.  Need to spend some effort on cleaning those up.  There isn't much point in doing that until the asyncio code goes in since that change the timings.
