### PR TITLE
theaudiodb calls HTMLfilter improperly

### DIFF
--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -24,13 +24,13 @@ class Plugin(ArtistExtrasPlugin):
 
     def __init__(self, config=None, qsettings=None):
         super().__init__(config=config, qsettings=qsettings)
-        self.htmlfilter = nowplaying.utils.HTMLFilter()
         self.fnstr = None
         self.there = re.compile('(?i)^the ')
 
     def _filter(self, text):
-        self.htmlfilter.feed(text)
-        return self.htmlfilter.text
+        htmlfilter = nowplaying.utils.HTMLFilter()
+        htmlfilter.feed(text)
+        return htmlfilter.text
 
     @staticmethod
     def _fetch(apikey, api):


### PR DESCRIPTION
Now that HTMLFilter is fixed (#539 ) , theaudiodb doesn't call it in a thread-safe manner. so fix that.