### PR TITLE
add displayname to requests

### DIFF
--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -180,6 +180,8 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         settings.setValue(
             'weboutput/artistfanarttemplate',
             str(self.templatedir.joinpath("ws-artistfanart-nofade.htm")))
+        settings.setValue('weboutput/requestertemplate',
+                          str(self.templatedir.joinpath("ws-requests.htm")))
         settings.setValue('weboutput/httpenabled', False)
         settings.setValue('weboutput/httpport', '8899')
         settings.setValue('weboutput/once', True)

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -48,6 +48,7 @@ METADATALIST = [
     'musicbrainzalbumid',
     'musicbrainzartistid',
     'musicbrainzrecordingid',
+    'requestdisplayname',
     'requester',
     'title',
     'track',

--- a/nowplaying/resources/twitchrequests_ui.ui
+++ b/nowplaying/resources/twitchrequests_ui.ui
@@ -62,6 +62,14 @@
    </column>
    <column>
     <property name="text">
+     <string>Display Name</string>
+    </property>
+    <property name="textAlignment">
+     <set>AlignLeading|AlignVCenter</set>
+    </property>
+   </column>
+   <column>
+    <property name="text">
      <string>Playlist File</string>
     </property>
     <property name="textAlignment">

--- a/nowplaying/templates/twitchbot_track.txt
+++ b/nowplaying/templates/twitchbot_track.txt
@@ -1,2 +1,2 @@
-{% if requester %} @{{ requester }} requested {% endif %}
+{% if requester %}  This {{requestdisplayname}} track was requested by @{{ requester }}.  {% endif %}
 {% if artist %}{{ artist }} - {% endif %}"{{ title }}"

--- a/nowplaying/templates/twitchbot_trackdetail.txt
+++ b/nowplaying/templates/twitchbot_trackdetail.txt
@@ -15,3 +15,4 @@
 {% if label %} It was published by {{ label }}.{% endif %}
 {% if date %} The date is listed as {{ date }}, but that might be
  the date of the media. {% endif %}
+{% if requester %}  It was requested by @{{ requester }}.  {% endif %}

--- a/nowplaying/templates/ws-requests.htm
+++ b/nowplaying/templates/ws-requests.htm
@@ -1,0 +1,71 @@
+<!DOCTYPE HTML>
+<html>
+   <head>
+      <meta charset="utf-8" >
+      <title>Requests</title>
+      <link href="http://db.onlinewebfonts.com/c/de58fdcb98299a76fccd3c0cb4e5a6c0?family=Kabel" rel="stylesheet" type="text/css"/>
+      <style>
+         .container {
+           margin: 1px;
+           float: right;
+           font-size: 48px;
+           font-family: "Kabel";
+           text-shadow: 4px 4px #000000;
+           color: #FFF;
+         }
+         .npimage {
+           margin: 10px;
+           float: right;
+           max-height: 399px;
+           min-height: 399px;
+           width: auto;
+         }
+      </style>
+      <script src="https://code.jquery.com/jquery-3.6.1.js"></script>
+  </head>
+   <body>
+
+
+      <div class="container" id="titlecard">
+         <div class="npimage" id="requesterimage"></div>
+         <p><div id="requester"></div></p>
+      </div>
+
+      <script type = "text/javascript">
+            function start(websocketServerLocation){
+                  // Let us open a web socket
+                  var ws = new WebSocket(websocketServerLocation);
+
+                  ws.onopen = function() {
+                     console.log('ws connected');
+                  };
+
+                  ws.onmessage = function (event) {
+                     var metadata = JSON.parse(event.data);
+                     var img = document.createElement("img")
+                     console.log(metadata);
+                     if (metadata.requester) {
+                        img.src = 'data:image/png;base64,' + metadata.requesterimagebase64;
+                        img.className = "npimage"
+                        $("#requesterimage").html(img);
+                        $("#requester").html('This '+ metadata.requestdisplayname+' track ' + 'requested by '+metadata.requester+'!');
+                     } else {
+                        $("#requesterimage").html('');
+                        $("#requester").html('');
+                     }
+                  };
+
+                  ws.onclose = function(){
+                     // Try to reconnect in 5 seconds
+                     setTimeout(function(){start(websocketServerLocation)}, 5000);
+                };
+            }
+
+            if ("WebSocket" in window) {
+               start("ws://{{ hostip }}:{{ httpport }}/wsstream")
+            }
+
+      </script>
+
+   </body>
+</html>

--- a/nowplaying/utils.py
+++ b/nowplaying/utils.py
@@ -3,6 +3,7 @@
 
 from html.parser import HTMLParser
 
+import base64
 import copy
 import importlib
 import io
@@ -21,6 +22,12 @@ STRIPRELIST = [
     re.compile(r' - (?i:{0}$)'.format('|'.join(STRIPWORDLIST))),  #pylint: disable=consider-using-f-string
     re.compile(r' \[(?i:{0})\]'.format('|'.join(STRIPWORDLIST))),  #pylint: disable=consider-using-f-string
 ]
+
+TRANSPARENT_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC'\
+                  '1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAA'\
+                  'ASUVORK5CYII='
+
+TRANSPARENT_PNG_BIN = base64.b64decode(TRANSPARENT_PNG)
 
 
 class HTMLFilter(HTMLParser):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -85,6 +85,7 @@ def test_data_db1(getmetadb):  # pylint: disable=redefined-outer-name
             'title': "15 Ghosts II"
         }],
         'requester': None,
+        'requestdisplayname': None,
         'title': '15 Ghosts II',
         'track': '15',
         'track_total': None,
@@ -162,6 +163,7 @@ def test_data_db2(getmetadb):  # pylint: disable=redefined-outer-name
             'title': "Lakini's Juice"
         }],
         'requester': None,
+        'requestdisplayname': None,
         'title': 'Lakini\'s Juice',
         'track': None,
         'track_total': None,


### PR DESCRIPTION
fixes #558

* adds displayname to request bits so that DJs have a reference point to give listeners
* adds a webserver hook to put on the screen
* fixes several bugs with Generic requests so they actually work
* case insensitive search for generic
* make sure the requesterimageraw is actually an image (use transparent code)
