### PR TITLE
fix crash when windows beam is used

### DIFF
--- a/nowplaying/processes/beamsender.py
+++ b/nowplaying/processes/beamsender.py
@@ -347,6 +347,9 @@ def start(stopevent=None, bundledir=None, testmode=False):
     ''' multiprocessing start hook '''
     threading.current_thread().name = 'BeamSender'
 
+    if sys.platform == 'win32':
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
     if not bundledir:
         if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
             bundledir = getattr(sys, '_MEIPASS',


### PR DESCRIPTION
beam on windows is still failing for me but at least it doesn't crash anymore?