### PR TITLE
Set the SSL_CERT_FILE

### DIFF
--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -15,6 +15,7 @@ import nowplaying
 import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
+import nowplaying.frozen
 import nowplaying.systemtray
 import nowplaying.upgrade
 
@@ -47,12 +48,7 @@ def actualmain(beam=False):
     multiprocessing.freeze_support()
     #faulthandler.enable()
 
-    # set paths for bundled files
-    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        bundledir = getattr(sys, '_MEIPASS',
-                            os.path.abspath(os.path.dirname(__file__)))
-    else:
-        bundledir = os.path.abspath(os.path.dirname(__file__))
+    bundledir = nowplaying.frozen.frozen_init(None)
 
     QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
     qapp = QApplication(sys.argv)

--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -3,7 +3,6 @@
 #import faulthandler
 import logging
 import multiprocessing
-import os
 import socket
 import sys
 

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pathlib
 import re
+import ssl
 import sys
 import time
 
@@ -59,6 +60,8 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         logging.info('Logpath: %s', self.logpath)
         logging.info('Templates: %s', self.templatedir)
         logging.info('Bundle: %s', ConfigFile.BUNDLEDIR)
+        logging.debug('SSL_CERT_FILE=%s', os.environ.get('SSL_CERT_FILE'))
+        logging.debug('SSL CA FILE=%s', ssl.get_default_verify_paths().cafile)
 
         if sys.platform == "win32":
             self.qsettingsformat = QSettings.IniFormat

--- a/nowplaying/frozen.py
+++ b/nowplaying/frozen.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+''' handle frozen entry points '''
+
+import os
+import ssl
+import sys
+
+
+def frozen_init(bundledir):
+    ''' do some frozen handling '''
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        if not bundledir:
+            bundledir = getattr(sys, '_MEIPASS',
+                                os.path.abspath(os.path.dirname(__file__)))
+        #
+        # Under PyInstaller, always use our CA File
+        #
+        # See https://github.com/pyinstaller/pyinstaller/issues/7229 and related issues
+        #
+        if ssl.get_default_verify_paths().cafile is None:
+            os.environ['SSL_CERT_FILE'] = os.path.join(
+                sys._MEIPASS,  # pylint: disable=protected-access
+                'certifi',
+                'cacert.pem')
+    elif not bundledir:
+        bundledir = os.path.abspath(os.path.dirname(__file__))
+    return bundledir

--- a/nowplaying/processes/beamsender.py
+++ b/nowplaying/processes/beamsender.py
@@ -26,6 +26,7 @@ from aiohttp import ClientSession
 import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
+import nowplaying.frozen
 import nowplaying.trackrequests
 import nowplaying.version
 
@@ -350,12 +351,7 @@ def start(stopevent=None, bundledir=None, testmode=False):
     if sys.platform == 'win32':
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-    if not bundledir:
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            bundledir = getattr(sys, '_MEIPASS',
-                                os.path.abspath(os.path.dirname(__file__)))
-        else:
-            bundledir = os.path.abspath(os.path.dirname(__file__))
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
 
     if testmode:
         nowplaying.bootstrap.set_qt_names(appname='testsuite')

--- a/nowplaying/processes/discordbot.py
+++ b/nowplaying/processes/discordbot.py
@@ -21,6 +21,7 @@ import discord
 import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
+import nowplaying.frozen
 import nowplaying.utils
 import nowplaying.version
 
@@ -176,12 +177,7 @@ def start(stopevent, bundledir, testmode=False):  #pylint: disable=unused-argume
     ''' multiprocessing start hook '''
     threading.current_thread().name = 'DiscordBot'
 
-    if not bundledir:
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            bundledir = getattr(sys, '_MEIPASS',
-                                os.path.abspath(os.path.dirname(__file__)))
-        else:
-            bundledir = os.path.abspath(os.path.dirname(__file__))
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
 
     if testmode:
         nowplaying.bootstrap.set_qt_names(appname='testsuite')

--- a/nowplaying/processes/obsws.py
+++ b/nowplaying/processes/obsws.py
@@ -5,7 +5,6 @@
 import asyncio
 import logging
 import logging.config
-import pathlib
 import sys
 import threading
 
@@ -21,6 +20,7 @@ logging.config.dictConfig({
 import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
+import nowplaying.frozen
 import nowplaying.utils
 
 
@@ -181,12 +181,7 @@ def start(stopevent, bundledir, testmode=False):  #pylint: disable=unused-argume
     ''' multiprocessing start hook '''
     threading.current_thread().name = 'obsws'
 
-    if not bundledir:
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            bundledir = getattr(sys, '_MEIPASS',
-                                pathlib.Path(__file__).resolve().parent)
-        else:
-            bundledir = pathlib.Path(__file__).resolve().parent
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
 
     if testmode:
         nowplaying.bootstrap.set_qt_names(appname='testsuite')

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -13,6 +13,7 @@ import sys
 
 import nowplaying.config
 import nowplaying.db
+import nowplaying.frozen
 import nowplaying.imagecache
 import nowplaying.inputs
 import nowplaying.metadata
@@ -437,12 +438,7 @@ def start(stopevent, bundledir, testmode=False):  #pylint: disable=unused-argume
     ''' multiprocessing start hook '''
     threading.current_thread().name = 'TrackPoll'
 
-    if not bundledir:
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            bundledir = getattr(sys, '_MEIPASS',
-                                pathlib.Path(__file__).resolve().parent)
-        else:
-            bundledir = pathlib.Path(__file__).resolve().parent
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
 
     if testmode:
         nowplaying.bootstrap.set_qt_names(appname='testsuite')

--- a/nowplaying/processes/twitchbot.py
+++ b/nowplaying/processes/twitchbot.py
@@ -14,6 +14,7 @@ import sys
 import threading
 
 import nowplaying.bootstrap
+import nowplaying.frozen
 import nowplaying.twitch
 
 # 1. create a bot account, be sure to enable multiple logins per email
@@ -42,12 +43,7 @@ def start(stopevent, bundledir, testmode=False):  #pylint: disable=unused-argume
     ''' multiprocessing start hook '''
     threading.current_thread().name = 'TwitchBot'
 
-    if not bundledir:
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            bundledir = getattr(sys, '_MEIPASS',
-                                os.path.abspath(os.path.dirname(__file__)))
-        else:
-            bundledir = os.path.abspath(os.path.dirname(__file__))
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
 
     if testmode:
         nowplaying.bootstrap.set_qt_names(appname='testsuite')

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -36,6 +36,7 @@ logging.config.dictConfig({
 import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
+import nowplaying.frozen
 import nowplaying.imagecache
 import nowplaying.utils
 
@@ -524,12 +525,7 @@ def start(stopevent=None, bundledir=None, testmode=False):
     ''' multiprocessing start hook '''
     threading.current_thread().name = 'WebServer'
 
-    if not bundledir:
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            bundledir = getattr(sys, '_MEIPASS',
-                                os.path.abspath(os.path.dirname(__file__)))
-        else:
-            bundledir = os.path.abspath(os.path.dirname(__file__))
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
 
     if testmode:
         nowplaying.bootstrap.set_qt_names(appname='testsuite')


### PR DESCRIPTION
fixes #614 

The core problem is that ssl context gets different values based upon the OS vs. python version used to build the executables vs. what certifi will do.  The fix here is to always point to the certifi version if the library versions (effectively) don't match.

This patch works on OS X.  Need to test Windows yet.