### PR TITLE
Prevent systemtray going wacky on template update

### DIFF
--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -47,6 +47,10 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         }
 
         self.uihelp = None
+
+    def post_tray_init(self):
+        ''' after the systemtray is fully loaded, do this '''
+
         self.load_qtui()
 
         if not self.config.iconfile:

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -79,6 +79,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.action_pause.setEnabled(True)
         self.fix_mixmode_menu()
 
+        self.settingswindow.post_tray_init()
         self.subprocesses.start_all_processes()
 
         # Start the track notify handler


### PR DESCRIPTION
if msgbox is up before systemtray is init, systemtray never materializes