### PR TITLE
cache verification; bug fixes

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -27,8 +27,8 @@ PYTHON_VERSION=$("${PYTHON}" --version)
 PYTHON_VERSION=${PYTHON_VERSION#* }
 IFS="." read -ra PY_VERSION <<< "${PYTHON_VERSION}"
 
-if [[ ${PY_VERSION[0]} -lt 3 ]] || [[ ${PY_VERSION[0]} -lt 4 &&   ${PY_VERSION[1]} -lt 10 ]]; then
-  echo "Building requires version Python 3.10. No guarantess if it is higher than that."
+if [[ ${PY_VERSION[0]} -ne 3 && ${PY_VERSION[1]} -ne 10 ]]; then
+  echo "Building requires version Python 3.10.  Binaries with 3.11 have been known to have issues."
   exit 1
 fi
 

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -239,7 +239,6 @@ class MetadataDB:
 
             row = cursor.fetchone()
             if not row:
-                logging.debug('No data?!?')
                 return None
 
         metadata = {data: row[data] for data in METADATALIST}

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -8,6 +8,7 @@ import pathlib
 import sys
 import sqlite3
 import time
+import traceback
 
 from watchdog.observers import Observer  # pylint: disable=import-error
 from watchdog.events import PatternMatchingEventHandler  # pylint: disable=import-error
@@ -232,10 +233,13 @@ class MetadataDB:
                 cursor.execute(
                     '''SELECT * FROM currentmeta ORDER BY id DESC LIMIT 1''')
             except sqlite3.OperationalError:
+                for line in traceback.format_exc().splitlines():
+                    logging.debug(line)
                 return None
 
             row = cursor.fetchone()
             if not row:
+                logging.debug('No data?!?')
                 return None
 
         metadata = {data: row[data] for data in METADATALIST}

--- a/nowplaying/imagecache.py
+++ b/nowplaying/imagecache.py
@@ -2,18 +2,21 @@
 # pylint: disable=invalid-name
 ''' image cache '''
 
+import asyncio
 import concurrent.futures
 import pathlib
 import random
 import sqlite3
 import threading
 import time
+import traceback
 import uuid
 
 import logging
 import logging.config
 import logging.handlers
 
+import aiosqlite
 import diskcache
 import normality
 import requests_cache
@@ -272,17 +275,22 @@ class ImageCache:
 
             dataset = cursor.fetchall()
 
-            if not dataset:
-                try:
-                    cursor.execute(
-                        '''SELECT * FROM artistsha WHERE cachekey IS NULL
- ORDER BY TIMESTAMP DESC''')
-                except sqlite3.OperationalError as error:
-                    logging.error(error)
-                    return None
+            if dataset:
+                logging.debug('banner/logo/thumbs found')
+                return dataset
 
-                dataset = cursor.fetchall()
+            try:
+                cursor.execute(
+                    '''SELECT * FROM artistsha WHERE cachekey IS NULL
+ORDER BY TIMESTAMP DESC''')
+            except sqlite3.OperationalError as error:
+                logging.error(error)
+                return None
 
+            dataset = cursor.fetchall()
+
+        if dataset:
+            logging.debug('artwork found')
         return dataset
 
     def put_db_cachekey(self, artist, url, imagetype, cachekey=None):
@@ -419,6 +427,43 @@ VALUES (?,?,?);
             return
 
         return
+
+    async def verify_cache_timer(self, stopevent):
+        ''' run verify_cache periodically '''
+        await self.verify_cache()
+        counter = 0
+        while not stopevent.is_set():
+            await asyncio.sleep(2)
+            counter += 2
+            if counter > 3600:
+                await self.verify_cache()
+                counter = 0
+
+    async def verify_cache(self):
+        ''' verify the image cache '''
+        if not self.databasefile.exists():
+            return
+
+        count = 0
+        try:
+            logging.debug('Starting image cache verification')
+            async with aiosqlite.connect(self.databasefile,
+                                         timeout=30) as connection:
+                connection.row_factory = sqlite3.Row
+                sql = 'SELECT cachekey FROM artistsha'
+                async with connection.execute(sql) as cursor:
+                    async for row in cursor:
+                        count += 1
+                        cachekey = row['cachekey']
+                        try:
+                            image = self.cache[cachekey]
+                        except KeyError:
+                            self.erase_cachekey(cachekey)
+            logging.debug('Finished image cache verification: %s images',
+                          count)
+        except:
+            for line in traceback.format_exc().splitlines():
+                logging.debug(line)
 
     def queue_process(self, logpath, maxworkers=5):
         ''' Process to download stuff in the background to avoid the GIL '''

--- a/nowplaying/imagecache.py
+++ b/nowplaying/imagecache.py
@@ -462,6 +462,8 @@ VALUES (?,?,?);
             for line in traceback.format_exc().splitlines():
                 logging.debug(line)
 
+
+        # making this two separate operations unlocks the DB
         for key in cachekeys:
             try:
                 image = self.cache[key]  # pylint: disable=unused-variable

--- a/nowplaying/imagecache.py
+++ b/nowplaying/imagecache.py
@@ -450,14 +450,18 @@ VALUES (?,?,?);
             async with aiosqlite.connect(self.databasefile,
                                          timeout=30) as connection:
                 connection.row_factory = sqlite3.Row
-                sql = 'SELECT cachekey FROM artistsha'
+                sql = 'SELECT cachekey, url FROM artistsha'
                 async with connection.execute(sql) as cursor:
                     async for row in cursor:
-                        count += 1
+                        url = row['url']
                         cachekey = row['cachekey']
+                        if url == 'STOPWNP':
+                            continue
+                        count += 1
                         try:
                             image = self.cache[cachekey]  # pylint: disable=unused-variable
                         except KeyError:
+                            logging.debug('%s/%s expired', cachekey, url )
                             self.erase_cachekey(cachekey)
             logging.debug('Finished image cache verification: %s images',
                           count)

--- a/nowplaying/imagecache.py
+++ b/nowplaying/imagecache.py
@@ -456,12 +456,12 @@ VALUES (?,?,?);
                         count += 1
                         cachekey = row['cachekey']
                         try:
-                            image = self.cache[cachekey]
+                            image = self.cache[cachekey]  # pylint: disable=unused-variable
                         except KeyError:
                             self.erase_cachekey(cachekey)
             logging.debug('Finished image cache verification: %s images',
                           count)
-        except:
+        except:   # pylint: disable=bare-except
             for line in traceback.format_exc().splitlines():
                 logging.debug(line)
 

--- a/nowplaying/imagecache.py
+++ b/nowplaying/imagecache.py
@@ -461,11 +461,11 @@ VALUES (?,?,?);
                         try:
                             image = self.cache[cachekey]  # pylint: disable=unused-variable
                         except KeyError:
-                            logging.debug('%s/%s expired', cachekey, url )
+                            logging.debug('%s/%s expired', cachekey, url)
                             self.erase_cachekey(cachekey)
             logging.debug('Finished image cache verification: %s images',
                           count)
-        except:   # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             for line in traceback.format_exc().splitlines():
                 logging.debug(line)
 

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -80,7 +80,13 @@ class TrackPoll():  # pylint: disable=too-many-instance-attributes
         task.add_done_callback(self.tasks.remove)
         self.tasks.add(task)
         if self.trackrequests:
-            task = self.loop.create_task(self.trackrequests.watch_for_respin())
+            task = self.loop.create_task(
+                self.trackrequests.watch_for_respin(self.stopevent))
+            task.add_done_callback(self.tasks.remove)
+            self.tasks.add(task)
+        if self.imagecache:
+            task = self.loop.create_task(
+                self.imagecache.verify_cache_timer(self.stopevent))
             task.add_done_callback(self.tasks.remove)
             self.tasks.add(task)
 
@@ -301,10 +307,10 @@ class TrackPoll():  # pylint: disable=too-many-instance-attributes
 
         # try to interleave downloads in-between the delay
         await self._half_delay_write()
-        self._process_imagecache()
+        await self._process_imagecache()
         self._start_artistfanartpool()
         await self._half_delay_write()
-        self._process_imagecache()
+        await self._process_imagecache()
         self._start_artistfanartpool()
 
         # checkagain
@@ -407,7 +413,7 @@ class TrackPoll():  # pylint: disable=too-many-instance-attributes
                 urllist=self.currentmeta['artistfanarturls'])
             del self.currentmeta['artistfanarturls']
 
-    def _process_imagecache(self):
+    async def _process_imagecache(self):
         if not self.currentmeta.get('artist') or self.config.cparser.value(
                 'control/beam', type=bool) or not self.config.cparser.value(
                     'artistextras/enabled', type=bool):
@@ -435,6 +441,7 @@ class TrackPoll():  # pylint: disable=too-many-instance-attributes
                     self.currentmeta[rawkey] = image
             return tryagain
 
+        await asyncio.sleep(1)
         # try to give it a bit more time if it doesn't complete the first time
         if not fillin(self):
             fillin(self)

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -441,7 +441,6 @@ class TrackPoll():  # pylint: disable=too-many-instance-attributes
                     self.currentmeta[rawkey] = image
             return tryagain
 
-        await asyncio.sleep(1)
         # try to give it a bit more time if it doesn't complete the first time
         if not fillin(self):
             fillin(self)

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -467,10 +467,10 @@ class Requests:  #pylint: disable=too-many-instance-attributes, too-many-public-
 
         return newdata
 
-    async def watch_for_respin(self):
+    async def watch_for_respin(self, stopevent):
         ''' startup a watcher to handle respins '''
         datatuple = (RESPIN_TEXT, )
-        while not self.stopevent.is_set():
+        while not stopevent.is_set():
             await asyncio.sleep(10)
             if not self.databasefile.exists():
                 continue


### PR DESCRIPTION
* make sure builds are using 3.10; 4.0.2 ARM was built with 3.11 and all sorts of weird problems occurred
* add a few more debug statements
* add an async db verify for the imagecache code since cache misses cause all sorts of weird problems
* trackrequest respin should really use trackpoll's stopevent
* prepare for async-ification of imagecache