### PR TITLE
Rework some artistextra lookups

### DIFF
--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -58,8 +58,8 @@ class Plugin(ArtistExtrasPlugin):
                 artistnum = discogs_website[0].split('/')[-1]
                 artist = self.client.artist(artistnum)
                 artistname = artist.name
-                logging.debug('Found a singular discogs artist URL using %s instead of %s', artistname,
-                              metadata['artist'])
+                logging.debug('Found a singular discogs artist URL using %s instead of %s',
+                              artistname, metadata['artist'])
 
         try:
             logging.debug('Fetching %s - %s', artistname, metadata['album'])

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -49,10 +49,20 @@ class Plugin(ArtistExtrasPlugin):
         if not self.client:
             return None
 
+        artistnum = 0
+        artistname = metadata['artist']
+        # 'https://www.discogs.com/artist/<ARTISTNUM>'
+        discogs_website = [url for url in metadata['artistwebsites'] if 'discogs' in url]
+        if len(discogs_website) == 1:
+            artistnum = discogs_website[0].split('/')[-1]
+            artist = self.client.artist(artistnum)
+            artistname = artist.name
+            logging.debug('Found a singular discogs artist URL using %s instead of %s', artistname,
+                          metadata['artist'])
+
         try:
-            logging.debug('Fetching %s - %s', metadata['artist'], metadata['album'])
-            resultlist = self.client.search(metadata['album'],
-                                            artist=metadata['artist'],
+            logging.debug('Fetching %s - %s', artistname, metadata['album'])
+            resultlist = self.client.search(metadata['album'], artist=artistname,
                                             type='title').page(1)
         except (
                 requests.exceptions.ReadTimeout,  # pragma: no cover

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -52,13 +52,14 @@ class Plugin(ArtistExtrasPlugin):
         artistnum = 0
         artistname = metadata['artist']
         # 'https://www.discogs.com/artist/<ARTISTNUM>'
-        discogs_website = [url for url in metadata['artistwebsites'] if 'discogs' in url]
-        if len(discogs_website) == 1:
-            artistnum = discogs_website[0].split('/')[-1]
-            artist = self.client.artist(artistnum)
-            artistname = artist.name
-            logging.debug('Found a singular discogs artist URL using %s instead of %s', artistname,
-                          metadata['artist'])
+        if metadata.get('artistwebsites'):
+            discogs_website = [url for url in metadata['artistwebsites'] if 'discogs' in url]
+            if len(discogs_website) == 1:
+                artistnum = discogs_website[0].split('/')[-1]
+                artist = self.client.artist(artistnum)
+                artistname = artist.name
+                logging.debug('Found a singular discogs artist URL using %s instead of %s', artistname,
+                              metadata['artist'])
 
         try:
             logging.debug('Fetching %s - %s', artistname, metadata['album'])

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -60,7 +60,7 @@ class Plugin(ArtistExtrasPlugin):
         if not metadata.get('musicbrainzartistid'):
             return None
 
-        fnstr = nowplaying.utils.normalize(metadata['artist'])
+        #fnstr = nowplaying.utils.normalize(metadata['artist'])
         logging.debug('got musicbrainzartistid: %s', metadata['musicbrainzartistid'])
         for artistid in metadata['musicbrainzartistid']:
             artistrequest = self._fetch(apikey, artistid)

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -69,11 +69,11 @@ class Plugin(ArtistExtrasPlugin):
 
             artist = artistrequest.json()
 
-            if artist.get('name') and nowplaying.utils.normalize(artist['name']) in fnstr:
-                logging.debug("fanarttv Trusting : %s", artist['name'])
-            else:
-                logging.debug("fanarttv Not trusting: %s vs %s", artist.get('name'), fnstr)
-                continue
+            # if artist.get('name') and nowplaying.utils.normalize(artist['name']) in fnstr:
+            #     logging.debug("fanarttv Trusting : %s", artist['name'])
+            # else:
+            #     logging.debug("fanarttv Not trusting: %s vs %s", artist.get('name'), fnstr)
+            #     continue
 
             if artist.get('musicbanner') and self.config.cparser.value('fanarttv/banners',
                                                                        type=bool):

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -10,9 +10,9 @@ import requests
 import requests.exceptions
 import urllib3.exceptions
 
-import nowplaying.config
+#import nowplaying.config
 from nowplaying.artistextras import ArtistExtrasPlugin
-import nowplaying.utils
+#import nowplaying.utils
 
 
 class Plugin(ArtistExtrasPlugin):

--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -51,7 +51,6 @@ class Plugin(ArtistExtrasPlugin):
 
     def _check_artist(self, artdata):
         ''' is this actually the artist we are looking for? '''
-        found = False
         for fieldname in ['strArtist', 'strArtistAlternate']:
             if artdata.get(fieldname) and self.fnstr:
                 normalized = nowplaying.utils.normalize(artdata[fieldname])
@@ -60,7 +59,7 @@ class Plugin(ArtistExtrasPlugin):
                     return True
             logging.debug('theaudiodb not Trusting %s vs. %s', self.fnstr,
                           nowplaying.utils.normalize(artdata.get(fieldname)))
-        return found
+        return False
 
     def _handle_extradata(self, extradata, metadata, imagecache):  # pylint: disable=too-many-branches
         ''' deal with the various bits of data '''

--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -53,13 +53,13 @@ class Plugin(ArtistExtrasPlugin):
         ''' is this actually the artist we are looking for? '''
         found = False
         for fieldname in ['strArtist', 'strArtistAlternate']:
-            if artdata.get(fieldname) and nowplaying.utils.normalize(
-                    artdata[fieldname]) in self.fnstr:
-                logging.debug('theaudiodb Trusting %s: %s', fieldname, artdata[fieldname])
-                found = True
-            else:
-                logging.debug('theaudiodb not Trusting %s vs. %s', self.fnstr,
-                              nowplaying.utils.normalize(artdata.get(fieldname)))
+            if artdata.get(fieldname) and self.fnstr:
+                normalized = nowplaying.utils.normalize(artdata[fieldname])
+                if normalized and normalized in self.fnstr:
+                    logging.debug('theaudiodb Trusting %s: %s', fieldname, artdata[fieldname])
+                    return True
+            logging.debug('theaudiodb not Trusting %s vs. %s', self.fnstr,
+                          nowplaying.utils.normalize(artdata.get(fieldname)))
         return found
 
     def _handle_extradata(self, extradata, metadata, imagecache):  # pylint: disable=too-many-branches
@@ -145,13 +145,16 @@ class Plugin(ArtistExtrasPlugin):
         extradata = []
         self.fnstr = nowplaying.utils.normalize(metadata['artist'])
 
+        # if musicbrainz lookup fails, then there likely isn't
+        # data in theaudiodb that matches.
         if metadata.get('musicbrainzartistid'):
             logging.debug('got musicbrainzartistid: %s', metadata['musicbrainzartistid'])
             for mbid in metadata['musicbrainzartistid']:
                 if newdata := self.artistdatafrommbid(apikey, mbid):
                     extradata.extend(artist for artist in newdata['artists']
                                      if self._check_artist(artist))
-        if not extradata and metadata.get('artist'):
+
+        elif metadata.get('artist'):
             logging.debug('got artist')
             if artistdata := self.artistdatafromname(apikey, metadata['artist']):
                 extradata.extend(artist for artist in artistdata.get('artists')

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -189,32 +189,10 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
             return None
 
         musicbrainz = nowplaying.musicbrainz.MusicBrainzHelper(config=self.config)
-        metalist = musicbrainz.providerinfo()
-
-        addmeta = {}
-
-        if self.metadata.get('musicbrainzrecordingid'):
-            logging.debug('musicbrainz recordingid detected; attempting shortcuts')
-            if any(meta not in self.metadata for meta in metalist):
-                addmeta = musicbrainz.recordingid(self.metadata['musicbrainzrecordingid'])
-                self.metadata = recognition_replacement(config=self.config,
-                                                        metadata=self.metadata,
-                                                        addmeta=addmeta)
-        elif self.metadata.get('isrc'):
-            logging.debug('Preprocessing with musicbrainz isrc')
-            if any(meta not in self.metadata for meta in metalist):
-                addmeta = musicbrainz.isrc(self.metadata['isrc'])
-                self.metadata = recognition_replacement(config=self.config,
-                                                        metadata=self.metadata,
-                                                        addmeta=addmeta)
-        elif self.metadata.get('musicbrainzartistid'):
-            logging.debug('Preprocessing with musicbrainz artistid')
-            if any(meta not in self.metadata for meta in metalist):
-                addmeta = musicbrainz.artistids(self.metadata['musicbrainzartistid'])
-                self.metadata = recognition_replacement(config=self.config,
-                                                        metadata=self.metadata,
-                                                        addmeta=addmeta)
-
+        addmeta = musicbrainz.recognize(self.metadata)
+        self.metadata = recognition_replacement(config=self.config,
+                                                metadata=self.metadata,
+                                                addmeta=addmeta)
         return addmeta
 
     def _mb_fallback(self):

--- a/nowplaying/plugin.py
+++ b/nowplaying/plugin.py
@@ -10,7 +10,9 @@ from PySide6.QtWidgets import QWidget  # pylint: disable=import-error, no-name-i
 class WNPBasePlugin:
     ''' base class of plugins '''
 
-    def __init__(self, config=None, qsettings: t.Optional[QWidget] = None):
+    def __init__(self,
+                 config: t.Optional['nowplaying.config.ConfigFile'] = None,
+                 qsettings: t.Optional[QWidget] = None):
         self.available: bool = True
         self.plugintype: str = ''
         self.config = config

--- a/tests/test_artistextras.py
+++ b/tests/test_artistextras.py
@@ -156,7 +156,7 @@ def test_discogs_note_stripping(bootstrap):  # pylint: disable=redefined-outer-n
         mpproc = nowplaying.metadata.MetadataProcessors(config=config)
         mpproc.metadata = data
         assert 'Note:' in mpproc.metadata['artistlongbio']
-        mpproc._generate_short_bio() # pylint: disable=protected-access
+        mpproc._generate_short_bio()  # pylint: disable=protected-access
         assert 'Note:' not in mpproc.metadata['artistshortbio']
 
 

--- a/tests/test_artistextras.py
+++ b/tests/test_artistextras.py
@@ -203,16 +203,8 @@ def test_badmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
                 'musicbrainzartistid': ['xyz']
             },
             imagecache=imagecaches[pluginname])
-        if pluginname == 'theaudiodb':
-            assert data['artistfanarturls']
-            assert data['artistlongbio']
-            assert data['artistwebsites']
-            assert imagecaches[pluginname].urls['Nine Inch Nails']['artistbanner']
-            assert imagecaches[pluginname].urls['Nine Inch Nails']['artistlogo']
-            assert imagecaches[pluginname].urls['Nine Inch Nails']['artistthumb']
-        else:
-            assert not data
-            assert not imagecaches[pluginname].urls
+        assert not data
+        assert not imagecaches[pluginname].urls
 
 
 def test_onlymbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
1. discogs will now trust a musicbrainz artist location rather than do a lookup and hope for the best
2. fannarttv will trust musicbrainzids. if nothing is found for that mbid, then chances are, it doesn't have it.
3. Slight rework of theaudiodb's artist match code
4. Similar to fanarttv, trust mbid
5. In metadata lookup, use the mb->recognize directly rather than use the specific ones