### PR TITLE
Enable building on older PySide6

### DIFF
--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -13,7 +13,7 @@ pillow==10.1.0
 pillow_avif_plugin==1.4.1
 pyacoustid==1.2.2
 pypresence==4.3.0
-PySide6==6.6.0
+PySide6<6.7.0
 requests-cache==1.1.0
 requests==2.31.0
 simpleobsws==1.4.0

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -13,7 +13,8 @@ pillow==10.1.0
 pillow_avif_plugin==1.4.1
 pyacoustid==1.2.2
 pypresence==4.3.0
-PySide6<6.7.0
+# 6.5.x's rcc is broken on macos
+pyside6<6.7.0,!=6.5.*
 requests-cache==1.1.0
 requests==2.31.0
 simpleobsws==1.4.0


### PR DESCRIPTION
Enable easier building on older macOS with older PySide6. See #966