### PR TITLE
upgrade pyside6

### DIFF
--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -14,7 +14,7 @@ pillow_avif_plugin==1.4.6
 pyacoustid==1.2.2
 pypresence==4.3.0
 # 6.5.x's rcc is broken on macos
-pyside6!=6.5.*,<6.8.0
+pyside6!=6.5.*,<6.9.0
 requests-cache==1.2.1
 requests==2.32.3
 simpleobsws==1.4.0


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update the runtime requirements to use PySide6.