### PR TITLE
rework wikidata and mb delays

### DIFF
--- a/nowplaying/artistextras/wikimedia.py
+++ b/nowplaying/artistextras/wikimedia.py
@@ -34,14 +34,14 @@ class Plugin(ArtistExtrasPlugin):
     def _get_page(self, entity, lang):
         logging.debug("Processing %s", entity)
         try:
-            page = wptools.page(wikibase=entity, lang=lang, silent=True)
+            page = wptools.page(wikibase=entity, lang=lang, silent=True, timeout=5)
             page.get()
         except Exception:  # pylint: disable=broad-except
             page = None
             if self.config.cparser.value('wikimedia/bio_iso_en_fallback',
                                          type=bool) and lang != 'en':
                 try:
-                    page = wptools.page(wikibase=entity, lang='en', silent=True)
+                    page = wptools.page(wikibase=entity, lang='en', silent=True, timeout=5)
                     page.get()
                 except Exception as err:  # pylint: disable=broad-except
                     page = None

--- a/nowplaying/musicbrainz.py
+++ b/nowplaying/musicbrainz.py
@@ -19,8 +19,8 @@ from nowplaying.utils import normalize_text, normalize, artist_name_variations
 
 REMIX_RE = re.compile(r'^\s*(.*)\s+[\(\[].*[\)\]]$')
 
-musicbrainzngs.musicbrainz._max_retries = 1  # pylint: disable=protected-access
-musicbrainzngs.musicbrainz._timeout = 30  # pylint: disable=protected-access
+musicbrainzngs.musicbrainz._max_retries = 2  # pylint: disable=protected-access
+musicbrainzngs.musicbrainz._timeout = 15  # pylint: disable=protected-access
 # WNP (typically) has large lulls between 2-3 calls that need to happen
 # quickly. so double the rate of calls to speed things up but still
 # keep a rate limiter in case the DJ is doing something stupid
@@ -45,7 +45,7 @@ class MusicBrainzHelper():
     ''' handler for NowPlaying '''
 
     def __init__(self, config=None):
-        logging.getLogger('musicbrainzngs').setLevel(logging.CRITICAL + 1)
+        logging.getLogger('musicbrainzngs').setLevel(logging.INFO)
         if config:
             self.config = config
         else:


### PR DESCRIPTION
## Summary by Sourcery

Reduce MusicBrainz timeouts and increase retries. Reduce Wikipedia timeouts and add logging.

Enhancements:
- Reduce the timeout for MusicBrainz queries from 30 seconds to 15 seconds and increase the maximum number of retries from 1 to 2 to improve responsiveness.
- Reduce the timeout for Wikipedia queries to 5 seconds and enable logging to improve debugging and error handling.