### PR TITLE
rework the apicache bits for testing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,27 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%  # Allow 5% drop in overall coverage
+        base: auto
+    patch:
+      default:
+        target: 70%  # Require 70% coverage on new code
+        threshold: 10%  # Allow 10% variance on patch coverage
+        base: auto
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/"
+  - "nowplaying/vendor/"
+  - "nowplaying/__pyinstaller/"
+  - "venv/"
+  - "build/"
+  - "docs/"
+  - "htmlcov/"

--- a/.github/workflows/ghpages-test.yaml
+++ b/.github/workflows/ghpages-test.yaml
@@ -11,6 +11,8 @@ jobs:
 
   build_docs_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container: debian:stable-slim
 
     steps:

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -14,6 +14,8 @@ on: [push]  # yamllint disable-line rule:truthy
 jobs:
   pyinstaller-macos:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: icu
         run: |
@@ -43,6 +45,8 @@ jobs:
 
   pyinstaller-win:
     runs-on: windows-2019
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,6 +22,8 @@ env:
 jobs:
   testing-macos:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -88,6 +90,8 @@ jobs:
 
   testing-win:
     runs-on: windows-2019
+    permissions:
+      contents: read
     steps:
       - run: Set-MpPreference -DisableRealtimeMonitoring $true
         shell: powershell
@@ -147,6 +151,8 @@ jobs:
 
   testing-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python: ["3.10", "3.11"]
@@ -247,6 +253,9 @@ jobs:
       - testing-win
       - testing-linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ except Exception as exc:  # pylint: disable=broad-exception-caught
 Each artistextras plugin should have comprehensive test coverage including:
 
 1. **API Call Count Tests** - Verify caching works (1 API call, 2+ downloads)
-2. **Cache Consistency Tests** - Verify repeated calls return identical data  
+2. **Cache Consistency Tests** - Verify repeated calls return identical data
 3. **Error Handling Tests** - Malformed responses, timeouts, HTTP errors
 4. **Input Validation Tests** - Invalid metadata, malformed URLs, edge cases
 5. **DJ Performance Tests** - Rapid track changes, memory stability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,33 @@ Key testing patterns:
 - `asyncio_default_fixture_loop_scope = "function"` for proper async test
   isolation
 
+**Test Architecture and Shared Utilities:**
+
+- Shared test utilities in `tests/utils_artistextras.py` for artistextras plugin testing
+- Centralized pytest.mark.skipif decorators for API key requirements:
+  - `skip_no_discogs_key`, `skip_no_fanarttv_key`, `skip_no_theaudiodb_key`, `skip_no_acoustid_key`
+- Reusable cache testing helpers: `run_cache_consistency_test()`, `run_api_call_count_test()`, `run_failure_cache_test()`
+- Standard plugin configuration helpers: `configureplugins()`, `configuresettings()`
+
+**Reliability Testing for DJ Critical Components:**
+
+Since most DJs rely on Discogs for metadata, comprehensive reliability testing is essential:
+
+- **Error handling tests**: Network timeouts, HTTP errors, malformed responses
+- **Input validation tests**: Special characters, Unicode, long strings, edge cases
+- **Live performance scenarios**: Rapid track changes, timeout recovery, memory stability
+- **DJ-specific genre testing**: Electronic music with symbols (µ-Ziq), featuring artists, international accents
+- **Configuration validation**: Performance vs visual configs commonly used by DJs
+- **Cache failure scenarios**: Corrupted data handling, TTL expiration, cleanup on errors
+
+**Testing Best Practices:**
+
+- Always run `pylint` after adding new tests to maintain code quality
+- Use proper import organization (all imports at top of file, not inline)
+- Mock external API calls to test error conditions reliably
+- Test both happy path and failure scenarios for production reliability
+- Use meaningful test names that clearly indicate what scenario is being tested
+
 ### Development Notes
 
 - Qt6/PySide6 is used for the GUI framework

--- a/conftest.py
+++ b/conftest.py
@@ -153,3 +153,18 @@ async def temp_api_cache():
             # Properly close the cache to prevent event loop warnings
             if hasattr(cache, 'close'):
                 await cache.close()
+
+
+@pytest.fixture(autouse=True)
+def auto_temp_api_cache_for_artistextras(request, temp_api_cache):  # pylint: disable=redefined-outer-name
+    """Automatically use temp API cache for artistextras tests to prevent random CI failures."""
+    # Only auto-apply to artistextras tests, not apicache tests
+    if 'test_artistextras' in request.module.__name__:
+        original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
+        nowplaying.apicache.set_cache_instance(temp_api_cache)
+        try:
+            yield
+        finally:
+            nowplaying.apicache.set_cache_instance(original_cache)
+    else:
+        yield

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -238,6 +238,11 @@ class Plugin(ArtistExtrasPlugin):
             logging.debug('artist or album is empty, skipping')
             return None
 
+        # imagecacheartist is required for processing metadata/images
+        if not metadata.get('imagecacheartist'):
+            logging.debug('imagecacheartist is missing, skipping')
+            return None
+
         if not self.client and not self._setup_client():
             logging.error('No discogs apikey or client setup failed.')
             return None

--- a/tests/test_artistextras_core.py
+++ b/tests/test_artistextras_core.py
@@ -3,9 +3,10 @@
 
 import logging
 import os
-import typing as t
 
 import pytest
+
+from utils_artistextras import configureplugins, configuresettings
 
 
 PLUGINS = ['wikimedia']
@@ -16,49 +17,6 @@ if os.environ.get('FANARTTV_API_KEY'):
     PLUGINS.append('fanarttv')
 if os.environ.get('THEAUDIODB_API_KEY'):
     PLUGINS.append('theaudiodb')
-
-
-class FakeImageCache:  # pylint: disable=too-few-public-methods
-    ''' a fake ImageCache that just keeps track of urls '''
-
-    def __init__(self):
-        self.urls = {}
-
-    def fill_queue(
-            self,
-            config=None,  # pylint: disable=unused-argument
-            identifier: str = None,
-            imagetype: str = None,
-            srclocationlist: t.List[str] = None):
-        ''' just keep track of what was picked '''
-        if not self.urls.get(identifier):
-            self.urls[identifier] = {}
-        self.urls[identifier][imagetype] = srclocationlist
-
-
-def configureplugins(config):
-    ''' configure plugins '''
-    imagecaches = {}
-    plugins = {}
-    for pluginname in PLUGINS:
-        imagecaches[pluginname] = FakeImageCache()
-        plugins[pluginname] = config.pluginobjs['artistextras'][
-            f'nowplaying.artistextras.{pluginname}']
-    return imagecaches, plugins
-
-
-def configuresettings(pluginname, cparser):
-    ''' configure each setting '''
-    for key in [
-            'banners',
-            'bio',
-            'enabled',
-            'fanart',
-            'logos',
-            'thumbnails',
-            'websites',
-    ]:
-        cparser.setValue(f'{pluginname}/{key}', True)
 
 
 @pytest.fixture

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -463,8 +463,10 @@ async def test_discogs_artist_name_variations(bootstrap, artist_name, test_id):
             logging.info('Successfully processed artist variation: %s (%s)', artist_name, test_id)
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        pytest.fail(f'Discogs plugin raised exception for artist variation "{artist_name}" ({test_id}): {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+        pytest.fail(
+            f'Discogs plugin raised exception for artist variation "{artist_name}" '
+            f'({test_id}): {exc}. Plugins must handle all errors gracefully for live performance.'
+        )
 
 
 @pytest.mark.parametrize("test_urls,test_id", [
@@ -508,8 +510,10 @@ async def test_discogs_website_url_parsing(bootstrap, test_urls, test_id):
         logging.info('URL test case (%s) handled gracefully: %s', test_id, test_urls)
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        pytest.fail(f'Discogs plugin raised exception for URL test case "{test_urls}" ({test_id}): {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+        pytest.fail(
+            f'Discogs plugin raised exception for URL test case "{test_urls}" ({test_id}): {exc}. '
+            f'Plugins must handle all errors gracefully for live performance.'
+        )
 
 
 # Configuration State Validation Tests

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 ''' test artistextras discogs plugin '''
+# pylint: disable=too-many-lines
+# Large file justified by comprehensive DJ-critical reliability testing
 
 import asyncio
 import logging

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -1,27 +1,26 @@
 #!/usr/bin/env python3
 ''' test artistextras discogs plugin '''
 
+import asyncio
 import logging
 import os
 
 import pytest
+from aiohttp import ClientResponseError
 
-from test_artistextras_core import (
-    configureplugins,
-    configuresettings
-)
+from utils_artistextras import (configureplugins, configuresettings, skip_no_discogs_key)
 
 import nowplaying.metadata  # pylint: disable=import-error
 import nowplaying.apicache  # pylint: disable=import-error
+import nowplaying.discogsclient  # pylint: disable=import-error
 
 
 @pytest.mark.asyncio
+@skip_no_discogs_key
 async def test_discogs_note_stripping(bootstrap):
     ''' test note stripping in discogs bio '''
 
     config = bootstrap
-    if not os.environ.get('DISCOGS_API_KEY'):
-        pytest.skip("Discogs API key not available")
 
     configuresettings('discogs', config.cparser)
     config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
@@ -45,12 +44,11 @@ async def test_discogs_note_stripping(bootstrap):
 
 
 @pytest.mark.asyncio
+@skip_no_discogs_key
 async def test_discogs_weblocation1(bootstrap):
     ''' test discogs web location lookup '''
 
     config = bootstrap
-    if not os.environ.get('DISCOGS_API_KEY'):
-        pytest.skip("Discogs API key not available")
 
     configuresettings('discogs', config.cparser)
     config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
@@ -66,12 +64,9 @@ async def test_discogs_weblocation1(bootstrap):
             'artist':
             'Prince and The Revolution',
             'artistwebsites': [
-                'https://www.discogs.com/artist/271351',
-                'https://www.discogs.com/artist/28795',
-                'https://www.discogs.com/artist/293637',
-                'https://www.discogs.com/artist/342899',
-                'https://www.discogs.com/artist/79903',
-                'https://www.discogs.com/artist/571633',
+                'https://www.discogs.com/artist/271351', 'https://www.discogs.com/artist/28795',
+                'https://www.discogs.com/artist/293637', 'https://www.discogs.com/artist/342899',
+                'https://www.discogs.com/artist/79903', 'https://www.discogs.com/artist/571633',
                 'https://www.discogs.com/artist/96774'
             ],
             'imagecacheartist':
@@ -82,59 +77,48 @@ async def test_discogs_weblocation1(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_discogs_apicache_usage(bootstrap, temp_api_cache):
+@skip_no_discogs_key
+async def test_discogs_apicache_usage(bootstrap):
     ''' test that discogs plugin uses apicache for API calls '''
 
     config = bootstrap
-    if not os.environ.get('DISCOGS_API_KEY'):
-        pytest.skip("Discogs API key not available")
 
-    # Use the properly initialized temporary cache
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(temp_api_cache)
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
 
-    try:
-        configuresettings('discogs', config.cparser)
-        config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
-        imagecaches, plugins = configureplugins(config)
+    plugin = plugins['discogs']
 
-        plugin = plugins['discogs']
+    # Test with album search (discogs searches by album+artist)
+    metadata_with_album = {
+        'album': 'The Downward Spiral',
+        'artist': 'Nine Inch Nails',
+        'imagecacheartist': 'nineinchnails'
+    }
 
-        # Test with album search (discogs searches by album+artist)
-        metadata_with_album = {
-            'album': 'The Downward Spiral',
-            'artist': 'Nine Inch Nails',
-            'imagecacheartist': 'nineinchnails'
-        }
+    # First call - should hit API and cache result
+    result1 = await plugin.download_async(metadata_with_album.copy(),
+                                          imagecache=imagecaches['discogs'])
 
-        # First call - should hit API and cache result
-        result1 = await plugin.download_async(metadata_with_album.copy(),
-                                             imagecache=imagecaches['discogs'])
+    # Second call - should use cached result
+    result2 = await plugin.download_async(metadata_with_album.copy(),
+                                          imagecache=imagecaches['discogs'])
 
-        # Second call - should use cached result
-        result2 = await plugin.download_async(metadata_with_album.copy(),
-                                             imagecache=imagecaches['discogs'])
+    # Both results should be consistent (either both None or both have data)
+    assert (result1 is None) == (result2 is None)
 
-        # Both results should be consistent (either both None or both have data)
-        assert (result1 is None) == (result2 is None)
-
-        if result1:  # Only test if we got data back
-            logging.info('Discogs API call successful, caching verified')
-            # Should return the same metadata structure
-            assert result1 == result2
-
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    if result1:  # Only test if we got data back
+        logging.info('Discogs API call successful, caching verified')
+        # Should return the same metadata structure
+        assert result1 == result2
 
 
 @pytest.mark.asyncio
+@skip_no_discogs_key
 async def test_discogs_website_lookup_cache(bootstrap):
     ''' test discogs website lookup path with caching (different from search path) '''
 
     config = bootstrap
-    if not os.environ.get('DISCOGS_API_KEY'):
-        pytest.skip("Discogs API key not available")
 
     configuresettings('discogs', config.cparser)
     config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
@@ -152,11 +136,11 @@ async def test_discogs_website_lookup_cache(bootstrap):
 
     # First call - should hit API and cache result (website lookup path)
     result1 = await plugin.download_async(metadata_with_websites.copy(),
-                                         imagecache=imagecaches['discogs'])
+                                          imagecache=imagecaches['discogs'])
 
     # Second call - should use cached result (tests _artist_async_cached)
     result2 = await plugin.download_async(metadata_with_websites.copy(),
-                                         imagecache=imagecaches['discogs'])
+                                          imagecache=imagecaches['discogs'])
 
     # Both results should be consistent
     assert (result1 is None) == (result2 is None)
@@ -171,12 +155,11 @@ async def test_discogs_website_lookup_cache(bootstrap):
 
 
 @pytest.mark.asyncio
+@skip_no_discogs_key
 async def test_discogs_artist_duplicates(bootstrap):
     ''' test discogs handling of artists with duplicate names like "Madonna" '''
 
     config = bootstrap
-    if not os.environ.get('DISCOGS_API_KEY'):
-        pytest.skip("Discogs API key not available")
 
     configuresettings('discogs', config.cparser)
     config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
@@ -202,19 +185,19 @@ async def test_discogs_artist_duplicates(bootstrap):
 
     # Madonna 1: Like a Virgin - first call (API)
     result1a = await plugin.download_async(metadata_madonna1.copy(),
-                                          imagecache=imagecaches['discogs'])
+                                           imagecache=imagecaches['discogs'])
 
     # Madonna 2: Red - first call (API)
     result2a = await plugin.download_async(metadata_madonna2.copy(),
-                                          imagecache=imagecaches['discogs'])
+                                           imagecache=imagecaches['discogs'])
 
     # Madonna 1: Like a Virgin - second call (should use cache)
     result1b = await plugin.download_async(metadata_madonna1.copy(),
-                                          imagecache=imagecaches['discogs'])
+                                           imagecache=imagecaches['discogs'])
 
     # Madonna 2: Red - second call (should use cache)
     result2b = await plugin.download_async(metadata_madonna2.copy(),
-                                          imagecache=imagecaches['discogs'])
+                                           imagecache=imagecaches['discogs'])
 
     # Verify caching works for both artist+album combinations
     assert (result1a is None) == (result1b is None)
@@ -242,3 +225,998 @@ async def test_discogs_artist_duplicates(bootstrap):
                      'cache working regardless of data found')
 
     # Test passes if caching works correctly for both duplicate artist scenarios
+
+
+# Error Handling and Network Resilience Tests
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_timeout_handling(bootstrap):
+    ''' test handling of API timeouts and network errors '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Mock the client to simulate timeout
+    original_search = plugin.client.search_async if plugin.client else None
+
+    async def mock_timeout(*args, **kwargs):  # pylint: disable=unused-argument
+        raise asyncio.TimeoutError("Simulated timeout")
+
+    if plugin.client:
+        plugin.client.search_async = mock_timeout
+
+        try:
+            # Should handle timeout gracefully and return None
+            result = await plugin.download_async(
+                {
+                    'album': 'Test Album',
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should return None on timeout, not raise exception
+            assert result is None
+            logging.info('Discogs timeout handled gracefully')
+
+        finally:
+            # Restore original method
+            if original_search:
+                plugin.client.search_async = original_search
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_http_error_handling(bootstrap):
+    ''' test handling of various HTTP error codes '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Test various HTTP error scenarios
+    error_codes = [401, 404, 429, 500, 503]
+
+    for error_code in error_codes:
+        logging.debug('Testing HTTP error code: %d', error_code)
+
+        # Mock the client to simulate HTTP errors
+        original_search = plugin.client.search_async if plugin.client else None
+
+        def make_mock_http_error(status_code):
+
+            async def mock_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+                raise ClientResponseError(request_info=None,
+                                          history=(),
+                                          status=status_code,
+                                          message=f"HTTP {status_code}")
+
+            return mock_http_error
+
+        if plugin.client:
+            plugin.client.search_async = make_mock_http_error(error_code)
+
+            try:
+                # Should handle HTTP errors gracefully and return None
+                result = await plugin.download_async(
+                    {
+                        'album': 'Test Album',
+                        'artist': 'Test Artist',
+                        'imagecacheartist': 'testartist'
+                    },
+                    imagecache=imagecaches['discogs'])
+
+                # Should return None on HTTP error, not raise exception
+                assert result is None
+                logging.info('Discogs HTTP %d error handled gracefully', error_code)
+
+            finally:
+                # Restore original method
+                if original_search:
+                    plugin.client.search_async = original_search
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_malformed_json_handling(bootstrap):
+    ''' test handling of malformed JSON responses '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Mock the client to return malformed data
+    original_search = plugin.client.search_async if plugin.client else None
+
+    async def mock_malformed_response(*args, **kwargs):  # pylint: disable=unused-argument
+        # Return malformed response that would break normal processing
+        class MalformedResponse:  # pylint: disable=too-few-public-methods
+            """Mock malformed response for testing."""
+
+            def __init__(self):
+                self.results = None  # This should break normal processing
+
+            def page(self, page_num):  # pylint: disable=unused-argument
+                """Return self for compatibility."""
+                return self
+
+            def __iter__(self):
+                return iter([])
+
+        return MalformedResponse()
+
+    if plugin.client:
+        plugin.client.search_async = mock_malformed_response
+
+        try:
+            # Should handle malformed response gracefully
+            result = await plugin.download_async(
+                {
+                    'album': 'Test Album',
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should return None on malformed response, not crash
+            assert result is None
+            logging.info('Discogs malformed JSON response handled gracefully')
+
+        finally:
+            # Restore original method
+            if original_search:
+                plugin.client.search_async = original_search
+
+
+# Input Validation and Edge Case Tests
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_malformed_metadata_input(bootstrap):
+    ''' test handling of malformed input metadata '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Test various malformed metadata inputs
+    malformed_inputs = [
+        {},  # Empty dict
+        {
+            'artist': None,
+            'album': 'Test'
+        },  # None values
+        {
+            'artist': '',
+            'album': ''
+        },  # Empty strings
+        {
+            'artist': 'A' * 1000,
+            'album': 'B' * 1000
+        },  # Very long strings
+        {
+            'artist': 'Test\x00Artist',
+            'album': 'Test\x00Album'
+        },  # Null bytes
+        {
+            'artist': '<script>alert("xss")</script>',
+            'album': 'Test'
+        },  # XSS attempt
+        {
+            'artist': 'Björk',
+            'album': 'Homogénic'
+        },  # Unicode characters
+        {
+            'artist': 'AC/DC',
+            'album': 'Back in Black'
+        },  # Special characters
+    ]
+
+    for i, metadata in enumerate(malformed_inputs):
+        logging.debug('Testing malformed input %d: %s', i, metadata)
+
+        try:
+            # Should handle malformed input gracefully
+            result = await plugin.download_async(metadata, imagecache=imagecaches['discogs'])
+
+            # Should return None or valid data, not crash
+            assert result is None or isinstance(result, dict)
+            logging.info('Malformed input %d handled gracefully', i)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Log but don't fail test - some edge cases might raise exceptions
+            logging.warning('Malformed input %d raised exception: %s', i, exc)
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_artist_name_variations(bootstrap):
+    ''' test artist name variation handling '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Test various artist name variations
+    artist_variations = [
+        'Madonna',  # Basic name
+        'Madonna feat. Justin Timberlake',  # Featuring
+        'Madonna featuring Justin Timberlake',  # Full featuring
+        'Madonna & Justin Timberlake',  # Ampersand
+        'Madonna and Justin Timberlake',  # And
+        'Madonna (Artist)',  # Parentheses
+        'madonna',  # Lowercase
+        'MADONNA',  # Uppercase
+        'The Beatles',  # With article
+        'Beatles, The',  # Inverted article
+    ]
+
+    for artist in artist_variations:
+        logging.debug('Testing artist variation: %s', artist)
+
+        try:
+            result = await plugin.download_async(
+                {
+                    'artist': artist,
+                    'album': 'Test Album',
+                    'imagecacheartist': 'testartist'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should handle all variations without crashing
+            assert result is None or isinstance(result, dict)
+            if result:
+                logging.info('Successfully processed artist variation: %s', artist)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Artist variation "%s" raised exception: %s', artist, exc)
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_website_url_parsing(bootstrap):
+    ''' test website URL parsing edge cases '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Test various malformed/edge case URLs
+    url_test_cases = [
+        # Malformed Discogs URLs
+        ['https://www.discogs.com/artist/'],  # Missing ID
+        ['https://www.discogs.com/artist/abc'],  # Non-numeric ID
+        ['https://discogs.com/artist/123456'],  # Missing www
+        ['http://www.discogs.com/artist/123456'],  # HTTP instead of HTTPS
+        ['https://www.discogs.com/artist/123456?param=value'],  # With query params
+        ['https://www.discogs.com/artist/123456#fragment'],  # With fragment
+        # Non-Discogs URLs
+        ['https://www.spotify.com/artist/123'],  # Non-Discogs URL
+        ['https://musicbrainz.org/artist/123'],  # MusicBrainz URL
+        ['not-a-url'],  # Invalid URL format
+        [''],  # Empty URL
+    ]
+
+    for urls in url_test_cases:
+        logging.debug('Testing URLs: %s', urls)
+
+        try:
+            result = await plugin.download_async(
+                {
+                    'artist': 'Test Artist',
+                    'album': 'Test Album',
+                    'imagecacheartist': 'testartist',
+                    'artistwebsites': urls
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should handle malformed URLs gracefully
+            assert result is None or isinstance(result, dict)
+            logging.info('URL test case handled gracefully: %s', urls)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('URL test case "%s" raised exception: %s', urls, exc)
+
+
+# Configuration State Validation Tests
+
+
+def test_discogs_invalid_api_key_format(bootstrap):
+    ''' test behavior with invalid API key formats '''
+
+    config = bootstrap
+
+    # Test various invalid API key formats
+    invalid_keys = [
+        '',  # Empty string
+        None,  # None value
+        'invalid-key',  # Too short
+        'k' * 1000,  # Too long
+        'key with spaces',  # Contains spaces
+        'key\nwith\nnewlines',  # Contains newlines
+        '<script>alert("xss")</script>',  # XSS attempt
+    ]
+
+    for i, invalid_key in enumerate(invalid_keys):
+        logging.debug('Testing invalid API key %d: %s', i, repr(invalid_key))
+
+        configuresettings('discogs', config.cparser)
+        if invalid_key is not None:
+            config.cparser.setValue('discogs/apikey', invalid_key)
+        else:
+            # Test None by not setting the key at all
+            config.cparser.remove('discogs/apikey')
+
+        _, plugins = configureplugins(config)
+
+        plugin = plugins['discogs']
+
+        # Should handle invalid API key gracefully
+        apikey = plugin._get_apikey()  # pylint: disable=protected-access
+        if invalid_key == '' or invalid_key is None:
+            # Empty or None keys should be rejected
+            assert apikey is None
+            assert not plugin._setup_client()  # pylint: disable=protected-access
+        else:
+            # Non-empty invalid keys may still be accepted by client setup
+            # but should not crash the plugin
+            assert apikey == invalid_key
+            # Client setup may succeed or fail, but shouldn't crash
+            try:
+                setup_result = plugin._setup_client()  # pylint: disable=protected-access
+                logging.info('Invalid API key %d setup result: %s', i, setup_result)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logging.info('Invalid API key %d caused setup exception: %s', i, exc)
+
+        logging.info('Invalid API key %d handled gracefully', i)
+
+
+def test_discogs_selective_feature_disabling(bootstrap):
+    ''' test plugin behavior when specific features are disabled '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', 'test-key')
+
+    # Test various feature combination scenarios
+    feature_combinations = [
+        {
+            'bio': True,
+            'fanart': False,
+            'thumbnails': False
+        },  # Bio only
+        {
+            'bio': False,
+            'fanart': True,
+            'thumbnails': False
+        },  # Fanart only
+        {
+            'bio': False,
+            'fanart': False,
+            'thumbnails': True
+        },  # Thumbnails only
+        {
+            'bio': True,
+            'fanart': True,
+            'thumbnails': False
+        },  # Bio + fanart
+        {
+            'bio': False,
+            'fanart': False,
+            'thumbnails': False
+        },  # Nothing enabled
+        {
+            'bio': True,
+            'fanart': True,
+            'thumbnails': True
+        },  # Everything enabled
+    ]
+
+    for i, features in enumerate(feature_combinations):
+        logging.debug('Testing feature combination %d: %s', i, features)
+
+        # Set feature flags
+        config.cparser.setValue('discogs/bio', features['bio'])
+        config.cparser.setValue('discogs/fanart', features['fanart'])
+        config.cparser.setValue('discogs/thumbnails', features['thumbnails'])
+
+        _, plugins = configureplugins(config)
+        plugin = plugins['discogs']
+
+        # Client setup should still work regardless of feature flags
+        if plugin._get_apikey():  # pylint: disable=protected-access
+            setup_result = plugin._setup_client()  # pylint: disable=protected-access
+            # Setup may fail with invalid test key, but shouldn't crash
+            logging.info('Feature combination %d setup result: %s', i, setup_result)
+
+
+# Cache Failure Scenario Tests
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_cache_corruption_handling(bootstrap):
+    ''' test handling of corrupted cache data '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Mock the cache to return corrupted data
+    original_cached_fetch = nowplaying.apicache.cached_fetch
+
+    async def mock_corrupted_cache(*args, **kwargs):  # pylint: disable=unused-argument
+        # Return corrupted data that would break normal processing
+        return {'corrupted': 'data', 'invalid': True}
+
+    # Test with corrupted cache
+    nowplaying.apicache.cached_fetch = mock_corrupted_cache
+
+    try:
+        # Should handle corrupted cache gracefully
+        result = await plugin.download_async(
+            {
+                'album': 'Test Album',
+                'artist': 'Test Artist',
+                'imagecacheartist': 'testartist'
+            },
+            imagecache=imagecaches['discogs'])
+
+        # Should return None or valid data, not crash
+        assert result is None or isinstance(result, dict)
+        logging.info('Discogs corrupted cache handled gracefully')
+
+    finally:
+        # Restore original cache function
+        nowplaying.apicache.cached_fetch = original_cached_fetch
+
+
+# Search Result Edge Case Tests
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_empty_search_results(bootstrap):
+    ''' test handling of empty search results '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Mock the client to return empty search results
+    original_search = plugin.client.search_async if plugin.client else None
+
+    async def mock_empty_results(*args, **kwargs):  # pylint: disable=unused-argument
+
+        class EmptySearchResult:  # pylint: disable=too-few-public-methods
+            """Mock empty search result for testing."""
+
+            def __init__(self):
+                self.results = []
+
+            def page(self, page_num):  # pylint: disable=unused-argument
+                """Return self for compatibility."""
+                return self
+
+            def __iter__(self):
+                return iter([])
+
+        return EmptySearchResult()
+
+    if plugin.client:
+        plugin.client.search_async = mock_empty_results
+
+        try:
+            # Should handle empty results gracefully
+            result = await plugin.download_async(
+                {
+                    'album': 'Nonexistent Album',
+                    'artist': 'Nonexistent Artist',
+                    'imagecacheartist': 'nonexistent'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should return None for empty results
+            assert result is None
+            logging.info('Discogs empty search results handled gracefully')
+
+        finally:
+            # Restore original method
+            if original_search:
+                plugin.client.search_async = original_search
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_missing_artist_data(bootstrap):
+    ''' test handling of releases without proper artist data '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Mock the client to return results with missing artist data
+    original_search = plugin.client.search_async if plugin.client else None
+
+    async def mock_missing_artist_data(*args, **kwargs):  # pylint: disable=unused-argument
+        models = nowplaying.discogsclient.Models
+
+        class MissingArtistSearchResult:  # pylint: disable=too-few-public-methods
+            """Mock search result with missing artist data for testing."""
+
+            def __init__(self):
+                # Create a release with missing/malformed artist data
+                release_data = {
+                    'id': 123456,
+                    'title': 'Test Album',
+                    'artists': []  # Empty artists list
+                }
+                release = models.Release(release_data)
+                release.artists = []  # Explicitly empty
+                self.results = [release]
+
+            def page(self, page_num):  # pylint: disable=unused-argument
+                """Return self for compatibility."""
+                return self
+
+            def __iter__(self):
+                return iter(self.results)
+
+        return MissingArtistSearchResult()
+
+    if plugin.client:
+        plugin.client.search_async = mock_missing_artist_data
+
+        try:
+            # Should handle missing artist data gracefully
+            result = await plugin.download_async(
+                {
+                    'album': 'Test Album',
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should return None or valid data, not crash
+            assert result is None or isinstance(result, dict)
+            logging.info('Discogs missing artist data handled gracefully')
+
+        finally:
+            # Restore original method
+            if original_search:
+                plugin.client.search_async = original_search
+
+
+# DJ-Specific Reliability Tests
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_rapid_track_changes(bootstrap):
+    ''' test handling of rapid consecutive API calls (typical during DJ sets) '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Simulate rapid track changes during a DJ set
+    tracks = [
+        {
+            'artist': 'Daft Punk',
+            'album': 'Random Access Memories',
+            'imagecacheartist': 'daftpunk1'
+        },
+        {
+            'artist': 'Justice',
+            'album': 'Cross',
+            'imagecacheartist': 'justice1'
+        },
+        {
+            'artist': 'Moderat',
+            'album': 'II',
+            'imagecacheartist': 'moderat1'
+        },
+        {
+            'artist': 'Burial',
+            'album': 'Untrue',
+            'imagecacheartist': 'burial1'
+        },
+        {
+            'artist': 'Four Tet',
+            'album': 'There Is Love In You',
+            'imagecacheartist': 'fourtet1'
+        },
+    ]
+
+    # Simulate rapid-fire requests (common when DJs are mixing quickly)
+    tasks = []
+    for track in tracks:
+        task = asyncio.create_task(plugin.download_async(track, imagecache=imagecaches['discogs']))
+        tasks.append(task)
+
+    try:
+        # All requests should complete without errors
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Verify no exceptions were raised
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logging.warning('Track %d raised exception: %s', i, result)
+            else:
+                # Should return None or valid data, not crash
+                assert result is None or isinstance(result, dict)
+
+        logging.info('Discogs handled %d rapid track changes successfully', len(tracks))
+
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logging.error('Rapid track changes test failed: %s', exc)
+        # Don't fail the test - log the issue for investigation
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_common_dj_genres(bootstrap):
+    ''' test reliability with common DJ music genres and special characters '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Common DJ genres with challenging artist names
+    dj_tracks = [
+        # Electronic/EDM with special characters
+        {
+            'artist': 'Aphex Twin',
+            'album': 'Selected Ambient Works',
+            'imagecacheartist': 'aphextwin'
+        },
+        {
+            'artist': 'µ-Ziq',
+            'album': 'Lunatic Harness',
+            'imagecacheartist': 'uziq'
+        },
+        {
+            'artist': 'Squarepusher',
+            'album': 'Go Plastic',
+            'imagecacheartist': 'squarepusher'
+        },
+
+        # Hip-hop with featuring artists
+        {
+            'artist': 'Kanye West feat. Jay-Z',
+            'album': 'Watch the Throne',
+            'imagecacheartist': 'kanyejay'
+        },
+        {
+            'artist': 'Wu-Tang Clan',
+            'album': 'Enter the Wu-Tang',
+            'imagecacheartist': 'wutang'
+        },
+
+        # House/Techno with numbers and symbols
+        {
+            'artist': '2 Many DJs',
+            'album': 'As Heard on Radio Soulwax',
+            'imagecacheartist': '2manydjs'
+        },
+        {
+            'artist': 'LCD Soundsystem',
+            'album': 'Sound of Silver',
+            'imagecacheartist': 'lcdsoundsystem'
+        },
+
+        # International artists with accents
+        {
+            'artist': 'Röyksopp',
+            'album': 'Melody A.M.',
+            'imagecacheartist': 'royksopp'
+        },
+        {
+            'artist': 'Sigur Rós',
+            'album': 'Ágætis byrjun',
+            'imagecacheartist': 'sigurros'
+        },
+    ]
+
+    for i, track in enumerate(dj_tracks):
+        logging.debug('Testing DJ track %d: %s - %s', i, track['artist'], track['album'])
+
+        try:
+            result = await plugin.download_async(track, imagecache=imagecaches['discogs'])
+
+            # Should handle all DJ music without crashing
+            assert result is None or isinstance(result, dict)
+            if result:
+                logging.info('Successfully processed DJ track: %s', track['artist'])
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('DJ track "%s" raised exception: %s', track['artist'], exc)
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_live_performance_timeout_recovery(bootstrap):
+    ''' test timeout recovery during live performance (critical for DJs) '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Mock intermittent timeouts (simulating network issues during live sets)
+    original_search = plugin.client.search_async if plugin.client else None
+    call_count = 0
+
+    async def mock_intermittent_timeout(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+        # Simulate timeout on first call, success on second
+        if call_count == 1:
+            raise asyncio.TimeoutError("Simulated network issue")
+        # Return to original behavior for subsequent calls
+        if original_search:
+            return await original_search(*args, **kwargs)
+        return None
+
+    if plugin.client:
+        plugin.client.search_async = mock_intermittent_timeout
+
+        try:
+            # First call should timeout
+            result1 = await plugin.download_async(
+                {
+                    'artist': 'Test Artist',
+                    'album': 'Test Album',
+                    'imagecacheartist': 'testartist1'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Should handle timeout gracefully
+            assert result1 is None
+
+            # Second call should work (network recovered)
+            result2 = await plugin.download_async(
+                {
+                    'artist': 'Test Artist 2',
+                    'album': 'Test Album 2',
+                    'imagecacheartist': 'testartist2'
+                },
+                imagecache=imagecaches['discogs'])
+
+            # Plugin should continue working after timeout recovery
+            assert result2 is None or isinstance(result2, dict)
+            logging.info('Discogs recovered from timeout during live performance simulation')
+
+        finally:
+            # Restore original method
+            if original_search:
+                plugin.client.search_async = original_search
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_memory_usage_stability(bootstrap):
+    ''' test memory stability during extended DJ sets '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Simulate a long DJ set with many track lookups
+    base_tracks = [
+        {
+            'artist': 'Daft Punk',
+            'album': 'Discovery'
+        },
+        {
+            'artist': 'Justice',
+            'album': 'Cross'
+        },
+        {
+            'artist': 'Moderat',
+            'album': 'Moderat'
+        },
+    ]
+
+    # Create many variations to test memory usage
+    tracks = []
+    for i in range(20):  # Simulate 20 tracks in a set
+        for base_track in base_tracks:
+            track = base_track.copy()
+            track['imagecacheartist'] = f"{base_track['artist'].lower().replace(' ', '')}{i}"
+            tracks.append(track)
+
+    successful_lookups = 0
+
+    for i, track in enumerate(tracks):
+        try:
+            result = await plugin.download_async(track, imagecache=imagecaches['discogs'])
+
+            # Should handle all requests without memory issues
+            assert result is None or isinstance(result, dict)
+            if result:
+                successful_lookups += 1
+
+            # Log progress every 10 tracks
+            if (i + 1) % 10 == 0:
+                logging.info('Processed %d tracks, %d successful lookups', i + 1,
+                             successful_lookups)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Track %d raised exception: %s', i, exc)
+
+    logging.info('Memory stability test completed: %d/%d tracks processed successfully',
+                 successful_lookups, len(tracks))
+
+
+def test_discogs_configuration_validation_for_djs(bootstrap):
+    ''' test configuration scenarios important for DJ reliability '''
+
+    config = bootstrap
+
+    # Test scenarios DJs commonly encounter
+    dj_config_scenarios = [
+        # Minimal config (bio only for performance)
+        {
+            'bio': True,
+            'fanart': False,
+            'thumbnails': False,
+            'websites': False
+        },
+
+        # Visual-heavy config (for streaming DJs)
+        {
+            'bio': False,
+            'fanart': True,
+            'thumbnails': True,
+            'websites': False
+        },
+
+        # Balanced config (most common)
+        {
+            'bio': True,
+            'fanart': True,
+            'thumbnails': False,
+            'websites': True
+        },
+
+        # Everything disabled (fallback mode)
+        {
+            'bio': False,
+            'fanart': False,
+            'thumbnails': False,
+            'websites': False
+        },
+    ]
+
+    for i, scenario in enumerate(dj_config_scenarios):
+        logging.debug('Testing DJ config scenario %d: %s', i, scenario)
+
+        configuresettings('discogs', config.cparser)
+        config.cparser.setValue('discogs/apikey', 'test-key-for-validation')
+
+        # Apply scenario settings
+        for setting, value in scenario.items():
+            config.cparser.setValue(f'discogs/{setting}', value)
+
+        _, plugins = configureplugins(config)
+        plugin = plugins['discogs']
+
+        # Plugin should initialize successfully in all DJ scenarios
+        assert plugin is not None
+        assert hasattr(plugin, '_get_apikey')
+        assert hasattr(plugin, '_setup_client')
+
+        logging.info('DJ config scenario %d validated successfully', i)
+
+
+@pytest.mark.asyncio
+@skip_no_discogs_key
+async def test_discogs_api_call_count(bootstrap):
+    ''' test that discogs plugin makes only one API call when cache is used '''
+
+    config = bootstrap
+    configuresettings('discogs', config.cparser)
+    config.cparser.setValue('discogs/apikey', os.environ['DISCOGS_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['discogs']
+
+    # Test with known artist and album
+    metadata = {
+        'artist': 'Daft Punk',
+        'album': 'Random Access Memories',
+        'imagecacheartist': 'daftpunk'
+    }
+
+    # Mock the actual Discogs client API call to count calls
+    original_search = plugin.client.search_async if plugin.client else None
+    api_call_count = 0
+
+    async def mock_search_async(*args, **kwargs):
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug('Mock Discogs API call #%d', api_call_count)
+        # Call the original method to get real data
+        if original_search:
+            return await original_search(*args, **kwargs)
+        return None
+
+    if plugin.client:
+        plugin.client.search_async = mock_search_async
+
+        try:
+            # First call - should hit API and cache result
+            result1 = await plugin.download_async(metadata.copy(),
+                                                  imagecache=imagecaches['discogs'])
+
+            # Verify one API call was made
+            assert api_call_count == 1, (
+                f'Expected 1 API call after first download, got {api_call_count}'
+            )
+
+            # Second call - should use cached result, no additional API call
+            result2 = await plugin.download_async(metadata.copy(),
+                                                  imagecache=imagecaches['discogs'])
+
+            # Verify still only one API call was made (cache hit)
+            assert api_call_count == 1, (
+                f'Expected 1 API call after second download (cache hit), got {api_call_count}'
+            )
+
+            # Both results should be consistent
+            assert (result1 is None) == (result2 is None)
+            if result1:  # Only test if we got data back
+                logging.info('Discogs API cache verified: 1 API call for 2 downloads')
+                assert result1 == result2
+            else:
+                logging.info('Discogs API cache test completed - '
+                             'cache working regardless of data found')
+
+        finally:
+            # Restore the original method
+            if original_search:
+                plugin.client.search_async = original_search

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -442,8 +442,8 @@ async def test_discogs_malformed_metadata_input(bootstrap):
             logging.info('Malformed input %d handled gracefully', i)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            # Log but don't fail test - some edge cases might raise exceptions
-            logging.warning('Malformed input %d raised exception: %s', i, exc)
+            pytest.fail(f'Discogs plugin raised exception for malformed input {i}: {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -490,7 +490,8 @@ async def test_discogs_artist_name_variations(bootstrap):
                 logging.info('Successfully processed artist variation: %s', artist)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Artist variation "%s" raised exception: %s', artist, exc)
+            pytest.fail(f'Discogs plugin raised exception for artist variation "{artist}": {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -539,7 +540,8 @@ async def test_discogs_website_url_parsing(bootstrap):
             logging.info('URL test case handled gracefully: %s', urls)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('URL test case "%s" raised exception: %s', urls, exc)
+            pytest.fail(f'Discogs plugin raised exception for URL test case "{urls}": {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 # Configuration State Validation Tests
@@ -590,7 +592,8 @@ def test_discogs_invalid_api_key_format(bootstrap):
                 setup_result = plugin._setup_client()  # pylint: disable=protected-access
                 logging.info('Invalid API key %d setup result: %s', i, setup_result)
             except Exception as exc:  # pylint: disable=broad-exception-caught
-                logging.info('Invalid API key %d caused setup exception: %s', i, exc)
+                pytest.fail(f'Discogs plugin raised exception for invalid API key {i}: {exc}. '
+                           f'Plugins must handle all errors gracefully for live performance.')
 
         logging.info('Invalid API key %d handled gracefully', i)
 
@@ -885,8 +888,8 @@ async def test_discogs_rapid_track_changes(bootstrap):
         logging.info('Discogs handled %d rapid track changes successfully', len(tracks))
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logging.error('Rapid track changes test failed: %s', exc)
-        # Don't fail the test - log the issue for investigation
+        pytest.fail(f'Discogs plugin raised exception during rapid track changes: {exc}. '
+                   f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -969,7 +972,8 @@ async def test_discogs_common_dj_genres(bootstrap):
                 logging.info('Successfully processed DJ track: %s', track['artist'])
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('DJ track "%s" raised exception: %s', track['artist'], exc)
+            pytest.fail(f'Discogs plugin raised exception for DJ track "{track["artist"]}": {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -1088,7 +1092,8 @@ async def test_discogs_memory_usage_stability(bootstrap):
                              successful_lookups)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Track %d raised exception: %s', i, exc)
+            pytest.fail(f'Discogs plugin raised exception for memory test track {i}: {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
     logging.info('Memory stability test completed: %d/%d tracks processed successfully',
                  successful_lookups, len(tracks))

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -1,244 +1,81 @@
 #!/usr/bin/env python3
 ''' test artistextras fanarttv plugin '''
 
-import logging
 import os
 
 import pytest
 
-from test_artistextras_core import configureplugins, configuresettings
+from utils_artistextras import (
+    configureplugins, configuresettings, skip_no_fanarttv_key,
+    run_cache_consistency_test, run_api_call_count_test, run_failure_cache_test
+)
 
-import nowplaying.apicache  # pylint: disable=import-error
+
+def _setup_fanarttv_plugin(bootstrap):
+    """Set up FanartTV plugin for testing"""
+    config = bootstrap
+    configuresettings('fanarttv', config.cparser)
+    config.cparser.setValue('fanarttv/apikey', os.environ['FANARTTV_API_KEY'])
+    imagecaches, plugins = configureplugins(config)
+    return plugins['fanarttv'], imagecaches['fanarttv']
+
+
+def _get_test_metadata():
+    """Get test metadata for FanartTV (requires MBID)"""
+    return {
+        'album': 'The Downward Spiral',
+        'artist': 'Nine Inch Nails',
+        'imagecacheartist': 'nineinchnails',
+        'musicbrainzartistid': ['b7ffd2af-418f-4be2-bdd1-22f8b48613da']  # NIN's MBID
+    }
 
 
 @pytest.mark.asyncio
-async def test_fanarttv_apicache_usage(bootstrap, temp_api_cache):
+@skip_no_fanarttv_key
+async def test_fanarttv_apicache_usage(bootstrap):
     ''' test that fanarttv plugin uses apicache for API calls '''
+    plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
 
-    config = bootstrap
-    if not os.environ.get('FANARTTV_API_KEY'):
-        pytest.skip("FanartTV API key not available")
-
-    # Use the properly initialized temporary cache
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(temp_api_cache)
-
-    try:
-        configuresettings('fanarttv', config.cparser)
-        config.cparser.setValue('fanarttv/apikey', os.environ['FANARTTV_API_KEY'])
-        imagecaches, plugins = configureplugins(config)
-
-        plugin = plugins['fanarttv']
-
-        # Test with MusicBrainz ID (fanarttv requires MBID)
-        metadata_with_mbid = {
-            'album': 'The Downward Spiral',
-            'artist': 'Nine Inch Nails',
-            'imagecacheartist': 'nineinchnails',
-            'musicbrainzartistid': ['b7ffd2af-418f-4be2-bdd1-22f8b48613da']  # NIN's MBID
-        }
-
-        # First call - should hit API and cache result
-        result1 = await plugin.download_async(metadata_with_mbid.copy(),
-                                             imagecache=imagecaches['fanarttv'])
-
-        # Second call - should use cached result
-        result2 = await plugin.download_async(metadata_with_mbid.copy(),
-                                             imagecache=imagecaches['fanarttv'])
-
-        # Both results should be consistent (either both None or both have data)
-        assert (result1 is None) == (result2 is None)
-
-        if result1:  # Only test if we got data back
-            logging.info('FanartTV API call successful, caching verified')
-            # Should return the same metadata structure
-            assert result1 == result2
-
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    await run_cache_consistency_test(
+        plugin=plugin,
+        test_metadata=_get_test_metadata(),
+        imagecache=imagecache,
+        success_message='FanartTV API call successful, caching verified'
+    )
 
 
 @pytest.mark.asyncio
-async def test_fanarttv_apicache_api_call_count(bootstrap, temp_api_cache):
+@skip_no_fanarttv_key
+async def test_fanarttv_apicache_api_call_count(bootstrap):
     ''' test that fanarttv plugin makes only one API call when cache is used '''
+    plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
 
-    config = bootstrap
-    if not os.environ.get('FANARTTV_API_KEY'):
-        pytest.skip("FanartTV API key not available")
+    await run_api_call_count_test(
+        plugin=plugin,
+        test_metadata=_get_test_metadata(),
+        mock_method_name='_fetch_async',
+        imagecache=imagecache
+    )
 
-    # Use the properly initialized temporary cache
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(temp_api_cache)
-
-    try:
-        configuresettings('fanarttv', config.cparser)
-        config.cparser.setValue('fanarttv/apikey', os.environ['FANARTTV_API_KEY'])
-        imagecaches, plugins = configureplugins(config)
-
-        plugin = plugins['fanarttv']
-
-        # Test with MusicBrainz ID (fanarttv requires MBID)
-        metadata_with_mbid = {
-            'album': 'The Downward Spiral',
-            'artist': 'Nine Inch Nails',
-            'imagecacheartist': 'nineinchnails',
-            'musicbrainzartistid': ['b7ffd2af-418f-4be2-bdd1-22f8b48613da']  # NIN's MBID
-        }
-
-        # Mock the internal _fetch_async method to count API calls
-        original_fetch_async = plugin._fetch_async  # pylint: disable=protected-access
-        api_call_count = 0
-
-        async def mock_fetch_async(apikey, artistid):
-            nonlocal api_call_count
-            api_call_count += 1
-            logging.debug('Mock API call #%d for artistid: %s', api_call_count, artistid)
-            # Call the original method to get real data
-            return await original_fetch_async(apikey, artistid)
-
-        # Replace the method with our mock
-        plugin._fetch_async = mock_fetch_async  # pylint: disable=protected-access
-
-        try:
-            # First call - should hit API and cache result
-            result1 = await plugin.download_async(metadata_with_mbid.copy(),
-                                                 imagecache=imagecaches['fanarttv'])
-
-            # Verify one API call was made
-            assert api_call_count == 1, (
-                f'Expected 1 API call after first download, '
-                f'got {api_call_count}'
-            )
-
-            # Second call - should use cached result, no additional API call
-            result2 = await plugin.download_async(metadata_with_mbid.copy(),
-                                                 imagecache=imagecaches['fanarttv'])
-
-            # Verify still only one API call was made (cache hit)
-            assert api_call_count == 1, (
-                f'Expected 1 API call after second download (cache hit), '
-                f'got {api_call_count}'
-            )
-
-            # Both results should be consistent
-            assert (result1 is None) == (result2 is None)
-
-            if result1:  # Only test if we got data back
-                logging.info('FanartTV API cache verified: 1 API call for 2 downloads')
-                assert result1 == result2
-            else:
-                logging.info('FanartTV API cache test completed - '
-                           'cache working regardless of data found')
-
-        finally:
-            # Restore the original method
-            plugin._fetch_async = original_fetch_async  # pylint: disable=protected-access
-
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
 
 
 @pytest.mark.asyncio
-async def test_fanarttv_apicache_api_failure_behavior(bootstrap, temp_api_cache):
+@skip_no_fanarttv_key
+async def test_fanarttv_apicache_api_failure_behavior(bootstrap):
     ''' test that fanarttv plugin doesn't cache failed API calls '''
+    plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
 
-    config = bootstrap
-    if not os.environ.get('FANARTTV_API_KEY'):
-        pytest.skip("FanartTV API key not available")
+    # Use test metadata with invalid MBID to trigger failure
+    test_metadata = {
+        'album': 'Test Album',
+        'artist': 'Test Artist',
+        'imagecacheartist': 'testartist',
+        'musicbrainzartistid': ['invalid-mbid-that-will-fail']  # Invalid MBID
+    }
 
-    # Use the properly initialized temporary cache
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(temp_api_cache)
-
-    try:
-        configuresettings('fanarttv', config.cparser)
-        config.cparser.setValue('fanarttv/apikey', os.environ['FANARTTV_API_KEY'])
-        imagecaches, plugins = configureplugins(config)
-
-        plugin = plugins['fanarttv']
-
-        # Test with MusicBrainz ID (fanarttv requires MBID)
-        metadata_with_mbid = {
-            'album': 'Test Album',
-            'artist': 'Test Artist',
-            'imagecacheartist': 'testartist',
-            'musicbrainzartistid': [
-                'invalid-mbid-that-will-fail'  # Invalid MBID to trigger failure
-            ]
-        }
-
-        # Mock the internal _fetch_async method to simulate failures then success
-        original_fetch_async = plugin._fetch_async  # pylint: disable=protected-access
-        api_call_count = 0
-
-        async def mock_fetch_async_with_failure(apikey, artistid):  # pylint: disable=unused-argument
-            nonlocal api_call_count
-            api_call_count += 1
-            logging.debug('Mock API call #%d for artistid: %s', api_call_count, artistid)
-
-            if api_call_count == 1:
-                # First call: simulate API failure (network error, timeout, etc.)
-                logging.debug('Simulating API failure on first call')
-                return None
-            if api_call_count == 2:
-                # Second call: simulate API returning valid empty response (artist not found)
-                logging.debug('Simulating successful but empty API response on second call')
-                return {'name': 'Test Artist', 'mbid_id': artistid}
-
-            # Subsequent calls: should not happen if caching works correctly
-            logging.debug('Unexpected additional API call')
-            return {'name': 'Test Artist', 'mbid_id': artistid}
-
-        # Replace the method with our mock
-        plugin._fetch_async = mock_fetch_async_with_failure  # pylint: disable=protected-access
-
-        try:
-            # First call - API fails, should return None and NOT cache the failure
-            result1 = await plugin.download_async(metadata_with_mbid.copy(),
-                                                 imagecache=imagecaches['fanarttv'])
-
-            # Verify one API call was made and result is None (failure)
-            assert api_call_count == 1, (
-                f'Expected 1 API call after first download, '
-                f'got {api_call_count}'
-            )
-            assert result1 is None, 'Expected None result from failed API call'
-
-            # Second call - should retry API (not use cached failure), API succeeds this time
-            result2 = await plugin.download_async(metadata_with_mbid.copy(),
-                                                 imagecache=imagecaches['fanarttv'])
-
-            # Verify second API call was made (failure wasn't cached)
-            assert api_call_count == 2, (
-                f'Expected 2 API calls after second download '
-                f'(failure not cached), got {api_call_count}'
-            )
-
-            # Third call - should use cached success result, no additional API call
-            result3 = await plugin.download_async(metadata_with_mbid.copy(),
-                                                 imagecache=imagecaches['fanarttv'])
-
-            # Verify still only two API calls (success result was cached)
-            assert api_call_count == 2, (
-                f'Expected 2 API calls after third download '
-                f'(success cached), got {api_call_count}'
-            )
-
-            # Results should show the pattern: None (failure), data (success), data (cached success)
-            assert result1 is None, 'First result should be None (API failure)'
-            assert result2 == result3, (
-                'Second and third results should be identical (cached success)'
-            )
-
-            logging.info('FanartTV API failure cache behavior verified: '
-                        'failures not cached, successes cached')
-
-        finally:
-            # Restore the original method
-            plugin._fetch_async = original_fetch_async  # pylint: disable=protected-access
-
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    await run_failure_cache_test(
+        plugin=plugin,
+        test_metadata=test_metadata,
+        mock_method_name='_fetch_async',
+        imagecache=imagecache
+    )

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -425,7 +425,7 @@ async def test_wikimedia_large_content_handling(bootstrap):
     async def mock_large_content(*args, **kwargs):  # pylint: disable=unused-argument
         """Mock a large Wikipedia page response."""
 
-        class MockLargePage:
+        class MockLargePage:  # pylint: disable=too-few-public-methods
             """Mock WikiPage for large content testing."""
 
             def __init__(self):
@@ -439,7 +439,8 @@ async def test_wikimedia_large_content_handling(bootstrap):
                 }
                 self._images = ['http://example.com/image1.jpg'] * 100  # Many images
 
-            def some_method(self):
+            @staticmethod
+            def some_method():
                 """Add method to meet pylint requirement."""
                 return True
 
@@ -843,7 +844,7 @@ async def test_wikimedia_failure_cache(bootstrap):
         # Second call: simulate successful response
         logging.debug('Simulating successful Wikipedia API response on second call')
         # Return a minimal WikiPage-like object
-        class MockWikiPage:
+        class MockWikiPage:  # pylint: disable=too-few-public-methods
             """Mock WikiPage for testing."""
 
             def __init__(self):
@@ -857,7 +858,8 @@ async def test_wikimedia_failure_cache(bootstrap):
                 """Return images for compatibility."""
                 return self._images
 
-            def some_method(self):
+            @staticmethod
+            def some_method():
                 """Add method to meet pylint requirement."""
                 return True
 

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -306,8 +306,10 @@ async def test_wikimedia_missing_metadata_fields(bootstrap, metadata, test_id):
         logging.info('Missing metadata case (%s) handled gracefully', test_id)
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        pytest.fail(f'Wikimedia plugin raised exception for missing metadata case ({test_id}): {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+        pytest.fail(
+            f'Wikimedia plugin raised exception for missing metadata case ({test_id}): {exc}. '
+            f'Plugins must handle all errors gracefully for live performance.'
+        )
 
 
 # Language Handling Edge Cases
@@ -350,8 +352,10 @@ async def test_wikimedia_invalid_language_codes(bootstrap, invalid_language, tes
         logging.info('Invalid language "%s" (%s) handled gracefully', invalid_language, test_id)
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        pytest.fail(f'Wikimedia plugin raised exception for invalid language "{invalid_language}" ({test_id}): {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+        pytest.fail(
+            f'Wikimedia plugin raised exception for invalid language "{invalid_language}" '
+            f'({test_id}): {exc}. Plugins must handle all errors gracefully for live performance.'
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -1,60 +1,42 @@
 #!/usr/bin/env python3
 ''' test artistextras wikimedia plugin '''
 
+import asyncio
 import logging
+import ssl
 
 import pytest
+from aiohttp import ClientResponseError
 
-from test_artistextras_core import configureplugins, configuresettings
+from utils_artistextras import (configureplugins, configuresettings,
+                               run_cache_consistency_test)
 
 import nowplaying.apicache  # pylint: disable=import-error
+import nowplaying.wikiclient  # pylint: disable=import-error
 
 
 @pytest.mark.asyncio
-async def test_wikimedia_apicache_usage(bootstrap, temp_api_cache):
+async def test_wikimedia_apicache_usage(bootstrap):
     ''' test that wikimedia plugin uses apicache for API calls '''
 
     config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
 
-    # Use the properly initialized temporary cache
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(temp_api_cache)
+    plugin = plugins['wikimedia']
 
-    try:
-        configuresettings('wikimedia', config.cparser)
-        imagecaches, plugins = configureplugins(config)
+    # Test with Wikidata entity ID (wikimedia uses unique entity IDs for differentiation)
+    metadata_with_wikidata = {
+        'artist': 'Nine Inch Nails',
+        'imagecacheartist': 'nineinchnails',
+        'artistwebsites': ['https://www.wikidata.org/wiki/Q11647']  # NIN's Wikidata page
+    }
 
-        plugin = plugins['wikimedia']
-
-        # Test with Wikidata entity ID (wikimedia uses unique entity IDs for differentiation)
-        metadata_with_wikidata = {
-            'artist': 'Nine Inch Nails',
-            'imagecacheartist': 'nineinchnails',
-            'artistwebsites': ['https://www.wikidata.org/wiki/Q11647']  # NIN's Wikidata page
-        }
-
-        # First call - should hit API and cache result
-        result1 = await plugin.download_async(metadata_with_wikidata.copy(),
-                                             imagecache=imagecaches['wikimedia'])
-
-        # Second call - should use cached result
-        result2 = await plugin.download_async(metadata_with_wikidata.copy(),
-                                             imagecache=imagecaches['wikimedia'])
-
-        # Both results should be consistent (either both None or both have data)
-        assert (result1 is None) == (result2 is None)
-
-        if result1:  # Only test if we got data back
-            logging.info('Wikimedia API call successful, caching verified')
-            # Should return the same metadata structure
-            assert result1 == result2
-        else:
-            logging.info('Wikimedia caching test completed - '
-                         'no data found but cache working')
-
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    await run_cache_consistency_test(
+        plugin=plugin,
+        test_metadata=metadata_with_wikidata,
+        imagecache=imagecaches['wikimedia'],
+        success_message='Wikimedia API call successful, caching verified')
 
 
 @pytest.mark.asyncio
@@ -120,3 +102,805 @@ async def test_wikimedia_humantetris_de(bootstrap):
             'https://www.wikidata.org/wiki/Q60845849',
         ]}, imagecache=None)
     assert 'Human Tetris ist eine Band aus Moskau' in data.get('artistlongbio')
+
+
+# Error Handling and Network Resilience Tests
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_timeout_handling(bootstrap):
+    ''' test handling of API timeouts (Wikipedia can be slow) '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Mock the Wikipedia client to simulate timeout
+    original_get_page = nowplaying.wikiclient.get_page_async
+
+    async def mock_timeout(*args, **kwargs):
+        raise asyncio.TimeoutError("Simulated Wikipedia timeout")
+
+    nowplaying.wikiclient.get_page_async = mock_timeout
+
+    try:
+        # Should handle timeout gracefully and return None
+        result = await plugin.download_async(
+            {
+                'artist': 'Test Artist',
+                'imagecacheartist': 'testartist',
+                'artistwebsites': ['https://www.wikidata.org/wiki/Q12345']
+            },
+            imagecache=imagecaches['wikimedia'])
+
+        # Should return None or empty dict on timeout, not raise exception
+        assert result is None or result == {}
+        logging.info('Wikimedia timeout handled gracefully - result: %s', result)
+
+    finally:
+        # Restore original function
+        nowplaying.wikiclient.get_page_async = original_get_page
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_http_error_handling(bootstrap):
+    ''' test handling of various HTTP error codes from Wikipedia '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test various HTTP error scenarios
+    error_codes = [404, 429, 500, 503]
+
+    for error_code in error_codes:
+        logging.debug('Testing HTTP error code: %d', error_code)
+
+        # Mock the Wikipedia client to simulate HTTP errors
+        original_get_page = nowplaying.wikiclient.get_page_async
+
+        def make_mock_http_error(status_code):
+
+            async def mock_http_error(*args, **kwargs):
+                raise ClientResponseError(request_info=None,
+                                          history=(),
+                                          status=status_code,
+                                          message=f"HTTP {status_code}")
+
+            return mock_http_error
+
+        nowplaying.wikiclient.get_page_async = make_mock_http_error(error_code)
+
+        try:
+            # Should handle HTTP errors gracefully and return None
+            result = await plugin.download_async(
+                {
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist',
+                    'artistwebsites': ['https://www.wikidata.org/wiki/Q12345']
+                },
+                imagecache=imagecaches['wikimedia'])
+
+            # Should return None or empty dict on HTTP error, not raise exception
+            assert result is None or result == {}
+            logging.info('Wikimedia HTTP %d error handled gracefully', error_code)
+
+        finally:
+            # Restore original function
+            nowplaying.wikiclient.get_page_async = original_get_page
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_ssl_error_handling(bootstrap):
+    ''' test handling of SSL certificate errors '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Mock SSL certificate error
+    original_get_page = nowplaying.wikiclient.get_page_async
+
+    async def mock_ssl_error(*args, **kwargs):
+        raise ssl.SSLError("SSL certificate verification failed")
+
+    nowplaying.wikiclient.get_page_async = mock_ssl_error
+
+    try:
+        # Should handle SSL errors gracefully
+        result = await plugin.download_async(
+            {
+                'artist': 'Test Artist',
+                'imagecacheartist': 'testartist',
+                'artistwebsites': ['https://www.wikidata.org/wiki/Q12345']
+            },
+            imagecache=imagecaches['wikimedia'])
+
+        # Should return None or empty dict on SSL error, not crash
+        assert result is None or result == {}
+        logging.info('Wikimedia SSL error handled gracefully')
+
+    finally:
+        # Restore original function
+        nowplaying.wikiclient.get_page_async = original_get_page
+
+
+# Input Validation and URL Parsing Tests
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_malformed_urls(bootstrap):
+    ''' test handling of malformed Wikidata URLs '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test various malformed URL scenarios
+    malformed_url_cases = [
+        # Missing entity IDs
+        ['https://www.wikidata.org/wiki/'],
+        ['https://www.wikidata.org/wiki/Q'],
+
+        # Invalid entity formats
+        ['https://www.wikidata.org/wiki/Qxyz'],
+        ['https://www.wikidata.org/wiki/Q-123'],
+        ['https://www.wikidata.org/wiki/Q12.34'],
+
+        # Non-Wikidata URLs (should be ignored)
+        ['https://en.wikipedia.org/wiki/Madonna'],
+        ['https://www.discogs.com/artist/123'],
+        ['https://musicbrainz.org/artist/123'],
+
+        # Invalid URL formats
+        ['not-a-url'],
+        ['wikidata.org/Q123'],  # Missing protocol
+        [''],  # Empty string
+
+        # Mixed valid/invalid
+        ['https://www.wikidata.org/wiki/Q123', 'invalid-url'],
+    ]
+
+    for i, urls in enumerate(malformed_url_cases):
+        logging.debug('Testing malformed URLs %d: %s', i, urls)
+
+        try:
+            result = await plugin.download_async(
+                {
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist',
+                    'artistwebsites': urls
+                },
+                imagecache=imagecaches['wikimedia'])
+
+            # Should handle malformed URLs gracefully (return None or valid data)
+            assert result is None or isinstance(result, dict)
+            logging.info('Malformed URL case %d handled gracefully', i)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Malformed URL case %d raised exception: %s', i, exc)
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_missing_metadata_fields(bootstrap):
+    ''' test handling of missing or invalid metadata fields '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test various missing metadata scenarios
+    metadata_cases = [
+        {},  # Empty metadata
+        {
+            'artist': 'Test Artist'
+        },  # Missing artistwebsites
+        {
+            'artistwebsites': None
+        },  # None artistwebsites
+        {
+            'artistwebsites': []
+        },  # Empty artistwebsites list
+        {
+            'artistwebsites': ['']
+        },  # Empty string in list
+        {
+            'artistwebsites': [None]
+        },  # None in list
+    ]
+
+    for i, metadata in enumerate(metadata_cases):
+        logging.debug('Testing missing metadata %d: %s', i, metadata)
+
+        try:
+            result = await plugin.download_async(metadata, imagecache=imagecaches['wikimedia'])
+
+            # Should handle missing metadata gracefully (return None)
+            assert result is None
+            logging.info('Missing metadata case %d handled gracefully', i)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Missing metadata case %d raised exception: %s', i, exc)
+
+
+# Language Handling Edge Cases
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_invalid_language_codes(bootstrap):
+    ''' test handling of invalid language codes '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test various invalid language codes
+    invalid_languages = ['xx', 'invalid-lang', '', 'toolong', '123', 'en-US-invalid']
+
+    for lang in invalid_languages:
+        logging.debug('Testing invalid language: %s', repr(lang))
+
+        config.cparser.setValue('wikimedia/bio_iso', lang)
+        config.cparser.setValue('wikimedia/bio_iso_en_fallback', True)
+
+        try:
+            result = await plugin.download_async(
+                {
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist',
+                    'artistwebsites': ['https://www.wikidata.org/wiki/Q11647']  # Valid entity
+                },
+                imagecache=imagecaches['wikimedia'])
+
+            # Should handle invalid languages gracefully (fallback or return None)
+            assert result is None or isinstance(result, dict)
+            logging.info('Invalid language "%s" handled gracefully', lang)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Invalid language "%s" raised exception: %s', lang, exc)
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_language_fallback_chain(bootstrap):
+    ''' test complex language fallback scenarios '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test fallback chain: unsupported → en → none
+    config.cparser.setValue('wikimedia/bio_iso', 'xx')  # Unsupported language
+    config.cparser.setValue('wikimedia/bio_iso_en_fallback', True)
+
+    try:
+        result = await plugin.download_async(
+            {
+                'artist': 'Nine Inch Nails',
+                'imagecacheartist': 'nineinchnails',
+                'artistwebsites': ['https://www.wikidata.org/wiki/Q11647']
+            },
+            imagecache=imagecaches['wikimedia'])
+
+        # Should either fallback to English or return None gracefully
+        assert result is None or isinstance(result, dict)
+        if result and result.get('artistlongbio'):
+            logging.info('Language fallback to English successful')
+        else:
+            logging.info('Language fallback handled gracefully - no content available')
+
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logging.warning('Language fallback test raised exception: %s', exc)
+
+
+# Content Processing and Sanitization Tests
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_large_content_handling(bootstrap):
+    ''' test handling of very large Wikipedia articles '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Mock a very large Wikipedia response
+    original_get_page = nowplaying.wikiclient.get_page_async
+
+    async def mock_large_content(*args, **kwargs):  # pylint: disable=unused-argument
+        """Mock a large Wikipedia page response."""
+
+        class MockLargePage:
+            """Mock WikiPage for large content testing."""
+
+            def __init__(self):
+                """Initialize mock large page."""
+                self.entity = 'Q12345'
+                self.lang = 'en'
+                # Create a very large bio (simulate long Wikipedia article)
+                self.data = {
+                    'extract': 'A' * 50000,  # 50KB of text
+                    'description': 'Test artist with very long biography'
+                }
+                self._images = ['http://example.com/image1.jpg'] * 100  # Many images
+
+            def some_method(self):
+                """Add method to meet pylint requirement."""
+                return True
+
+        return MockLargePage()
+
+    nowplaying.wikiclient.get_page_async = mock_large_content
+
+    try:
+        # Should handle large content without memory issues
+        result = await plugin.download_async(
+            {
+                'artist': 'Test Artist',
+                'imagecacheartist': 'testartist',
+                'artistwebsites': ['https://www.wikidata.org/wiki/Q12345']
+            },
+            imagecache=imagecaches['wikimedia'])
+
+        # Should return valid data or None, not crash
+        assert result is None or isinstance(result, dict)
+        if result:
+            # Content should be processed/truncated appropriately
+            bio = result.get('artistlongbio', '')
+            logging.info('Large content processed, bio length: %d chars', len(bio))
+
+        logging.info('Large content handling test passed')
+
+    finally:
+        # Restore original function
+        nowplaying.wikiclient.get_page_async = original_get_page
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_malformed_content_handling(bootstrap):
+    ''' test handling of malformed content from Wikipedia '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Mock malformed Wikipedia responses
+    malformed_responses = [
+        None,  # No page returned
+        'string instead of object',  # Wrong type
+        {
+            'invalid': 'structure'
+        },  # Missing expected fields
+    ]
+
+    for i, malformed_response in enumerate(malformed_responses):
+        logging.debug('Testing malformed response %d: %s', i, type(malformed_response).__name__)
+
+        original_get_page = nowplaying.wikiclient.get_page_async
+
+        def create_mock_response(response_data):
+            async def mock_malformed_response(*args, **kwargs):  # pylint: disable=unused-argument
+                """Return mock malformed response."""
+                return response_data
+            return mock_malformed_response
+
+        mock_func = create_mock_response(malformed_response)
+
+        nowplaying.wikiclient.get_page_async = mock_func
+
+        try:
+            # Should handle malformed responses gracefully
+            result = await plugin.download_async(
+                {
+                    'artist': 'Test Artist',
+                    'imagecacheartist': 'testartist',
+                    'artistwebsites': ['https://www.wikidata.org/wiki/Q12345']
+                },
+                imagecache=imagecaches['wikimedia'])
+
+            # Should return None on malformed response, not crash
+            assert result is None
+            logging.info('Malformed response %d handled gracefully', i)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Malformed response %d raised exception: %s', i, exc)
+
+        finally:
+            # Restore original function
+            nowplaying.wikiclient.get_page_async = original_get_page
+
+
+# Configuration State Validation Tests
+
+
+def test_wikimedia_configuration_scenarios(bootstrap):
+    ''' test various Wikimedia configuration scenarios '''
+
+    config = bootstrap
+
+    # Test scenarios DJs and streamers commonly use
+    config_scenarios = [
+        # Bio-only mode (performance optimized)
+        {
+            'bio': True,
+            'fanart': False,
+            'thumbnails': False
+        },
+
+        # Images-only mode (visual streamers)
+        {
+            'bio': False,
+            'fanart': True,
+            'thumbnails': True
+        },
+
+        # Balanced mode (most common)
+        {
+            'bio': True,
+            'fanart': True,
+            'thumbnails': False
+        },
+
+        # Everything disabled (fallback mode)
+        {
+            'bio': False,
+            'fanart': False,
+            'thumbnails': False
+        },
+
+        # Everything enabled (full mode)
+        {
+            'bio': True,
+            'fanart': True,
+            'thumbnails': True
+        },
+    ]
+
+    for i, scenario in enumerate(config_scenarios):
+        logging.debug('Testing config scenario %d: %s', i, scenario)
+
+        configuresettings('wikimedia', config.cparser)
+
+        # Apply scenario settings
+        for setting, value in scenario.items():
+            config.cparser.setValue(f'wikimedia/{setting}', value)
+
+        _, plugins = configureplugins(config)
+        plugin = plugins['wikimedia']
+
+        # Plugin should initialize successfully in all scenarios
+        assert plugin is not None
+        assert hasattr(plugin, '_check_missing')
+        assert hasattr(plugin, '_get_page_cached')
+
+        logging.info('Config scenario %d validated successfully', i)
+
+
+# Performance and DJ-Critical Scenario Tests
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_rapid_entity_lookups(bootstrap):
+    ''' test handling of rapid consecutive Wikidata lookups (DJ scenario) '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Simulate rapid artist changes during a DJ set
+    artist_entities = [
+        {
+            'artist': 'Daft Punk',
+            'artistwebsites': ['https://www.wikidata.org/wiki/Q184654']
+        },
+        {
+            'artist': 'Justice',
+            'artistwebsites': ['https://www.wikidata.org/wiki/Q1191976']
+        },
+        {
+            'artist': 'Moderat',
+            'artistwebsites': ['https://www.wikidata.org/wiki/Q15982243']
+        },
+        {
+            'artist': 'Burial',
+            'artistwebsites': ['https://www.wikidata.org/wiki/Q240055']
+        },
+        {
+            'artist': 'Aphex Twin',
+            'artistwebsites': ['https://www.wikidata.org/wiki/Q126016']
+        },
+    ]
+
+    # Add common metadata fields
+    for i, entity in enumerate(artist_entities):
+        entity['imagecacheartist'] = f"artist{i}"
+
+    # Simulate rapid-fire requests
+    tasks = []
+    for entity in artist_entities:
+        task = asyncio.create_task(
+            plugin.download_async(entity, imagecache=imagecaches['wikimedia']))
+        tasks.append(task)
+
+    try:
+        # All requests should complete without errors
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Verify no exceptions were raised
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logging.warning('Entity %d raised exception: %s', i, result)
+            else:
+                # Should return None or valid data, not crash
+                assert result is None or isinstance(result, dict)
+
+        logging.info('Wikimedia handled %d rapid entity lookups successfully', len(artist_entities))
+
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logging.error('Rapid entity lookups test failed: %s', exc)
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_cache_corruption_handling(bootstrap):
+    ''' test handling of corrupted cache data '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Mock the cache to return corrupted data
+    original_cached_fetch = nowplaying.apicache.cached_fetch
+
+    async def mock_corrupted_cache(*args, **kwargs):  # pylint: disable=unused-argument
+        # Return corrupted data that would break normal processing
+        return {'corrupted': 'data', 'invalid': True, 'type': 'wikipage'}
+
+    # Test with corrupted cache
+    nowplaying.apicache.cached_fetch = mock_corrupted_cache
+
+    try:
+        # Should handle corrupted cache gracefully
+        result = await plugin.download_async(
+            {
+                'artist': 'Test Artist',
+                'imagecacheartist': 'testartist',
+                'artistwebsites': ['https://www.wikidata.org/wiki/Q12345']
+            },
+            imagecache=imagecaches['wikimedia'])
+
+        # Should return None or valid data, not crash
+        assert result is None or isinstance(result, dict)
+        logging.info('Wikimedia corrupted cache handled gracefully')
+
+    finally:
+        # Restore original cache function
+        nowplaying.apicache.cached_fetch = original_cached_fetch
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_memory_stability_long_session(bootstrap):
+    ''' test memory stability during extended DJ sessions '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Simulate a long session with many different entity lookups
+    base_entities = [
+        'Q184654',  # Daft Punk
+        'Q1191976',  # Justice
+        'Q15982243'  # Moderat
+    ]
+
+    # Create many lookup variations
+    entities = []
+    for i in range(15):  # 15 lookups per entity = 45 total
+        for entity_id in base_entities:
+            entities.append({
+                'artist': f'Artist {i}',
+                'imagecacheartist': f'artist{i}_{entity_id}',
+                'artistwebsites': [f'https://www.wikidata.org/wiki/{entity_id}']
+            })
+
+    successful_lookups = 0
+
+    for i, entity in enumerate(entities):
+        try:
+            result = await plugin.download_async(entity, imagecache=imagecaches['wikimedia'])
+
+            # Should handle all requests without memory issues
+            assert result is None or isinstance(result, dict)
+            if result:
+                successful_lookups += 1
+
+            # Log progress every 15 entities
+            if (i + 1) % 15 == 0:
+                logging.info('Processed %d entities, %d successful lookups', i + 1,
+                             successful_lookups)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logging.warning('Entity %d raised exception: %s', i, exc)
+
+    logging.info('Memory stability test completed: %d/%d entities processed successfully',
+                 successful_lookups, len(entities))
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_api_call_count(bootstrap):
+    ''' test that wikimedia plugin makes only one API call when cache is used '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test with a known entity (Nine Inch Nails)
+    metadata = {
+        'artist': 'Nine Inch Nails',
+        'imagecacheartist': 'nineinchnails',
+        'artistwebsites': ['https://www.wikidata.org/wiki/Q11647']
+    }
+
+    # Mock the actual Wikipedia API call to count calls
+    original_get_page = nowplaying.wikiclient.get_page_async
+    api_call_count = 0
+
+    async def mock_get_page_async(*args, **kwargs):
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug('Mock Wikipedia API call #%d', api_call_count)
+        # Call the original method to get real data
+        return await original_get_page(*args, **kwargs)
+
+    # Replace the method with our mock
+    nowplaying.wikiclient.get_page_async = mock_get_page_async
+
+    try:
+        # First call - should hit API and cache result
+        result1 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])
+
+        # Verify one API call was made
+        assert api_call_count == 1, (
+            f'Expected 1 API call after first download, got {api_call_count}'
+        )
+
+        # Second call - should use cached result, no additional API call
+        result2 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])
+
+        # Verify still only one API call was made (cache hit)
+        assert api_call_count == 1, (
+            f'Expected 1 API call after second download (cache hit), got {api_call_count}'
+        )
+
+        # Both results should be consistent
+        assert (result1 is None) == (result2 is None)
+        if result1:  # Only test if we got data back
+            logging.info('Wikimedia API cache verified: 1 API call for 2 downloads')
+            assert result1 == result2
+        else:
+            logging.info('Wikimedia API cache test completed - '
+                         'cache working regardless of data found')
+
+    finally:
+        # Restore the original method
+        nowplaying.wikiclient.get_page_async = original_get_page
+
+
+@pytest.mark.asyncio
+async def test_wikimedia_failure_cache(bootstrap):
+    ''' test that wikimedia plugin handles cache failures gracefully '''
+
+    config = bootstrap
+    configuresettings('wikimedia', config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins['wikimedia']
+
+    # Test with a known entity
+    metadata = {
+        'artist': 'Nine Inch Nails',
+        'imagecacheartist': 'nineinchnails',
+        'artistwebsites': ['https://www.wikidata.org/wiki/Q11647']
+    }
+
+    # Mock the Wikipedia API to simulate failures then success
+    original_get_page = nowplaying.wikiclient.get_page_async
+    api_call_count = 0
+
+    async def mock_get_page_with_failure(*args, **kwargs):  # pylint: disable=unused-argument
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug('Mock Wikipedia API call #%d', api_call_count)
+
+        if api_call_count == 1:
+            # First call: simulate API failure
+            logging.debug('Simulating Wikipedia API failure on first call')
+            return None
+        # Second call: simulate successful response
+        logging.debug('Simulating successful Wikipedia API response on second call')
+        # Return a minimal WikiPage-like object
+        class MockWikiPage:
+            """Mock WikiPage for testing."""
+
+            def __init__(self):
+                """Initialize mock WikiPage."""
+                self.entity = 'Q11647'
+                self.lang = 'en'
+                self.data = {'extract': 'Nine Inch Nails is an American industrial rock band.'}
+                self._images = []
+
+            def images(self, fields=None):  # pylint: disable=unused-argument
+                """Return images for compatibility."""
+                return self._images
+
+            def some_method(self):
+                """Add method to meet pylint requirement."""
+                return True
+
+        return MockWikiPage()
+
+    # Replace the method with our mock
+    nowplaying.wikiclient.get_page_async = mock_get_page_with_failure
+
+    try:
+        # First call - API fails, should return None and NOT cache the failure
+        result1 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])
+
+        # Verify one API call was made and result is None (failure)
+        assert api_call_count == 1, (
+            f'Expected 1 API call after first download, got {api_call_count}'
+        )
+        assert result1 == {}, 'Expected empty dict result from failed Wikipedia API call'
+
+        # Second call - should retry (not use cached failure) and succeed
+        result2 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])
+
+        # Verify second API call was made (failure wasn't cached)
+        assert api_call_count == 2, (
+            f'Expected 2 API calls after second download (retry after failure), '
+            f'got {api_call_count}'
+        )
+
+        # Should get valid result from successful second call
+        assert result2 is not None, ('Expected successful result from '
+                                     'second Wikipedia API call')
+
+        # Third call - should use cached success result, no additional API call
+        result3 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])
+
+        # Verify still only two API calls (third used cached success)
+        assert api_call_count == 2, (
+            f'Expected 2 API calls after third download (cache hit), got {api_call_count}'
+        )
+        # Results should be consistent for successful calls
+        assert result2 == result3
+        logging.info('Wikimedia cache failure test passed - '
+                     'failures not cached, successes are')
+
+    finally:
+        # Restore the original method
+        nowplaying.wikiclient.get_page_async = original_get_page

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -837,7 +837,10 @@ async def test_wikimedia_failure_cache(bootstrap):
                 """Initialize mock WikiPage."""
                 self.entity = 'Q11647'
                 self.lang = 'en'
-                self.data = {'extract': 'Nine Inch Nails is an American industrial rock band.'}
+                self.data = {
+                    'extract': 'Nine Inch Nails is an American industrial rock band.',
+                    'claims': {}  # Add claims field expected by the plugin
+                }
                 self._images = []
 
             def images(self, fields=None):  # pylint: disable=unused-argument
@@ -862,7 +865,7 @@ async def test_wikimedia_failure_cache(bootstrap):
         assert api_call_count == 1, (
             f'Expected 1 API call after first download, got {api_call_count}'
         )
-        assert result1 == {}, 'Expected empty dict result from failed Wikipedia API call'
+        assert result1 is None, 'Expected None result from failed Wikipedia API call'
 
         # Second call - should retry (not use cached failure) and succeed
         result2 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -286,7 +286,8 @@ async def test_wikimedia_malformed_urls(bootstrap):
             logging.info('Malformed URL case %d handled gracefully', i)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Malformed URL case %d raised exception: %s', i, exc)
+            pytest.fail(f'Wikimedia plugin raised exception for malformed URL case {i}: {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -330,7 +331,8 @@ async def test_wikimedia_missing_metadata_fields(bootstrap):
             logging.info('Missing metadata case %d handled gracefully', i)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Missing metadata case %d raised exception: %s', i, exc)
+            pytest.fail(f'Wikimedia plugin raised exception for missing metadata case {i}: {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 # Language Handling Edge Cases
@@ -369,7 +371,8 @@ async def test_wikimedia_invalid_language_codes(bootstrap):
             logging.info('Invalid language "%s" handled gracefully', lang)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Invalid language "%s" raised exception: %s', lang, exc)
+            pytest.fail(f'Wikimedia plugin raised exception for invalid language "{lang}": {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -403,7 +406,8 @@ async def test_wikimedia_language_fallback_chain(bootstrap):
             logging.info('Language fallback handled gracefully - no content available')
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logging.warning('Language fallback test raised exception: %s', exc)
+        pytest.fail(f'Wikimedia plugin raised exception during language fallback: {exc}. '
+                   f'Plugins must handle all errors gracefully for live performance.')
 
 
 # Content Processing and Sanitization Tests
@@ -521,7 +525,8 @@ async def test_wikimedia_malformed_content_handling(bootstrap):
             logging.info('Malformed response %d handled gracefully', i)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Malformed response %d raised exception: %s', i, exc)
+            pytest.fail(f'Wikimedia plugin raised exception for malformed response {i}: {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
         finally:
             # Restore original function
@@ -657,7 +662,8 @@ async def test_wikimedia_rapid_entity_lookups(bootstrap):
         logging.info('Wikimedia handled %d rapid entity lookups successfully', len(artist_entities))
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logging.error('Rapid entity lookups test failed: %s', exc)
+        pytest.fail(f'Wikimedia plugin raised exception during rapid entity lookups: {exc}. '
+                   f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -743,7 +749,8 @@ async def test_wikimedia_memory_stability_long_session(bootstrap):
                              successful_lookups)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logging.warning('Entity %d raised exception: %s', i, exc)
+            pytest.fail(f'Wikimedia plugin raised exception for entity {i}: {exc}. '
+                       f'Plugins must handle all errors gracefully for live performance.')
 
     logging.info('Memory stability test completed: %d/%d entities processed successfully',
                  successful_lookups, len(entities))

--- a/tests/utils_artistextras.py
+++ b/tests/utils_artistextras.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Test utilities for artistextras plugins.
+
+This module provides reusable helper functions and fixtures for testing
+artistextras plugins, particularly around API caching functionality.
+"""
+
+import logging
+import os
+import typing as t
+
+import pytest
+
+# Shared pytest.mark.skipif decorators for API key requirements
+skip_no_discogs_key = pytest.mark.skipif(
+    not os.environ.get('DISCOGS_API_KEY'),
+    reason="Discogs API key not available"
+)
+
+skip_no_fanarttv_key = pytest.mark.skipif(
+    not os.environ.get('FANARTTV_API_KEY'),
+    reason="FanartTV API key not available"
+)
+
+skip_no_theaudiodb_key = pytest.mark.skipif(
+    not os.environ.get('THEAUDIODB_API_KEY'),
+    reason="TheAudioDB API key not available"
+)
+
+skip_no_acoustid_key = pytest.mark.skipif(
+    not os.environ.get('ACOUSTID_TEST_APIKEY'),
+    reason="AcoustID test API key not available"
+)
+
+
+
+class FakeImageCache:  # pylint: disable=too-few-public-methods
+    """A fake ImageCache that just keeps track of urls"""
+
+    def __init__(self):
+        self.urls = {}
+
+    def fill_queue(
+            self,
+            config=None,  # pylint: disable=unused-argument
+            identifier: str = None,
+            imagetype: str = None,
+            srclocationlist: t.List[str] = None):
+        """Just keep track of what was picked"""
+        if not self.urls.get(identifier):
+            self.urls[identifier] = {}
+        self.urls[identifier][imagetype] = srclocationlist
+
+
+def configureplugins(config):
+    """Configure plugins for testing"""
+    plugins = ['wikimedia']
+    if os.environ.get('DISCOGS_API_KEY'):
+        plugins.append('discogs')
+    if os.environ.get('FANARTTV_API_KEY'):
+        plugins.append('fanarttv')
+    if os.environ.get('THEAUDIODB_API_KEY'):
+        plugins.append('theaudiodb')
+
+    imagecaches = {}
+    plugin_objects = {}
+    for pluginname in plugins:
+        imagecaches[pluginname] = FakeImageCache()
+        plugin_objects[pluginname] = config.pluginobjs['artistextras'][
+            f'nowplaying.artistextras.{pluginname}']
+    return imagecaches, plugin_objects
+
+
+def configuresettings(pluginname, cparser):
+    """Configure each setting for a plugin"""
+    for key in [
+            'banners',
+            'bio',
+            'enabled',
+            'fanart',
+            'logos',
+            'thumbnails',
+            'websites',
+    ]:
+        cparser.setValue(f'{pluginname}/{key}', True)
+
+
+# Cache testing helpers
+async def run_cache_consistency_test(plugin, test_metadata, imagecache=None, success_message=""):
+    """
+    Generic cache consistency test helper.
+
+    Args:
+        plugin: The plugin instance to test
+        test_metadata: Metadata dict to use for testing
+        imagecache: Image cache to use (optional)
+        success_message: Message to log on successful cache verification
+
+    Returns:
+        (result1, result2): The two results from consecutive calls
+    """
+
+    # First call - should hit API and cache result
+    result1 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+    # Second call - should use cached result
+    result2 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+    # Both results should be consistent (either both None or both have data)
+    assert (result1 is None) == (result2 is None)
+
+    if result1:  # Only test if we got data back
+        if success_message:
+            logging.info(success_message)
+        # Should return the same metadata structure
+        assert result1 == result2
+
+    return result1, result2
+
+
+async def run_api_call_count_test(plugin, test_metadata, mock_method_name, imagecache=None):
+    """
+    Generic API call count test helper with mocking.
+
+    Args:
+        plugin: The plugin instance to test
+        test_metadata: Metadata dict to use for testing
+        mock_method_name: Name of the plugin method to mock (e.g., '_fetch_async')
+        imagecache: Image cache to use (optional)
+
+    Returns:
+        api_call_count: Number of API calls made
+    """
+
+    # Mock the internal API method to count calls
+    original_method = getattr(plugin, mock_method_name)
+    api_call_count = 0
+
+    async def mock_method(*args, **kwargs):
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug('Mock API call #%d', api_call_count)
+        # Call the original method to get real data
+        return await original_method(*args, **kwargs)
+
+    # Replace the method with our mock
+    setattr(plugin, mock_method_name, mock_method)
+
+    try:
+        # First call - should hit API and cache result
+        result1 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+        # Verify one API call was made
+        assert api_call_count == 1, (
+            f'Expected 1 API call after first download, got {api_call_count}'
+        )
+
+        # Second call - should use cached result, no additional API call
+        result2 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+        # Verify still only one API call was made (cache hit)
+        assert api_call_count == 1, (
+            f'Expected 1 API call after second download (cache hit), got {api_call_count}'
+        )
+
+        # Both results should be consistent
+        assert (result1 is None) == (result2 is None)
+
+        if result1:  # Only test if we got data back
+            logging.info('API cache verified: 1 API call for 2 downloads')
+            assert result1 == result2
+        else:
+            logging.info('API cache test completed - cache working regardless of data found')
+
+    finally:
+        # Restore the original method
+        setattr(plugin, mock_method_name, original_method)
+
+    return api_call_count
+
+
+async def run_failure_cache_test(plugin, test_metadata, mock_method_name, imagecache=None):
+    """
+    Generic API failure cache behavior test helper.
+
+    Tests that failures are not cached but successes are.
+
+    Args:
+        plugin: The plugin instance to test
+        test_metadata: Metadata dict to use for testing
+        mock_method_name: Name of the plugin method to mock
+        imagecache: Image cache to use (optional)
+    """
+
+    # Mock the internal API method to simulate failures then success
+    original_method = getattr(plugin, mock_method_name)
+    api_call_count = 0
+
+    async def mock_method_with_failure(*args, **kwargs):  # pylint: disable=unused-argument
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug('Mock API call #%d', api_call_count)
+
+        if api_call_count == 1:
+            # First call: simulate API failure
+            logging.debug('Simulating API failure on first call')
+            return None
+        if api_call_count == 2:
+            # Second call: simulate successful response
+            logging.debug('Simulating successful API response on second call')
+            # Return a minimal success response - adapt based on plugin
+            return {'name': test_metadata.get('artist', 'Test Artist')}
+
+        # Subsequent calls: should not happen if caching works correctly
+        logging.debug('Unexpected additional API call')
+        return {'name': test_metadata.get('artist', 'Test Artist')}
+
+    # Replace the method with our mock
+    setattr(plugin, mock_method_name, mock_method_with_failure)
+
+    try:
+        # First call - API fails, should return None and NOT cache the failure
+        result1 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+        # Verify one API call was made and result is None (failure)
+        assert api_call_count == 1, (
+            f'Expected 1 API call after first download, got {api_call_count}'
+        )
+        assert result1 is None, 'Expected None result from failed API call'
+
+        # Second call - should retry API (not use cached failure), API succeeds this time
+        result2 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+        # Verify second API call was made (failure wasn't cached)
+        assert api_call_count == 2, (
+            f'Expected 2 API calls after second download (failure not cached), got {api_call_count}'
+        )
+
+        # Third call - should use cached success result, no additional API call
+        result3 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
+
+        # Verify still only two API calls (success result was cached)
+        assert api_call_count == 2, (
+            f'Expected 2 API calls after third download (success cached), got {api_call_count}'
+        )
+
+        # Results should show the pattern: None (failure), data (success), data (cached success)
+        assert result1 is None, 'First result should be None (API failure)'
+        assert result2 == result3, 'Second and third results should be identical (cached success)'
+
+        logging.info('API failure cache behavior verified: failures not cached, successes cached')
+
+    finally:
+        # Restore the original method
+        setattr(plugin, mock_method_name, original_method)


### PR DESCRIPTION
## Summary by Sourcery

Centralize and DRY up test infrastructure for the artistextras plugins, then massively expand and refactor tests across Discogs, Wikimedia, FanartTV, TheAudioDB, and MusicBrainz to cover caching, error handling, input validation, performance, and DJ-critical edge cases. Update plugin behavior for missing metadata, and adjust CI workflows with appropriate permissions.

Enhancements:
- Extract shared test utilities (skip decorators, FakeImageCache, helpers) into tests/utils_artistextras.py
- Add auto-applied temp API cache fixture for artistextras tests
- Improve plugin download_async fallbacks for missing fields in Discogs and Wikimedia

CI:
- Grant read permissions in GitHub Actions workflows (testing, pyinstaller, ghpages)

Documentation:
- Add .codecov.yml to enforce coverage thresholds

Tests:
- Refactor existing tests to use shared utilities and decorators
- Add comprehensive error-handling and resilience tests (timeouts, HTTP/SSL errors, malformed data) for Discogs and Wikimedia
- Introduce input-validation and URL-parsing edge case tests across all plugins
- Expand DJ-critical scenario tests (rapid lookups, memory stability, performance configurations)
- Add caching consistency, API-call-count, and failure-cache behavior tests for Discogs, FanartTV, TheAudioDB, and MusicBrainz