### PR TITLE
mixed in key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   ISRC codes and artist IDs where previously only the last value was captured.
 * Enhanced multi-value field handling across all audio formats (MP3, FLAC, M4A, AIFF)
   with automatic detection and splitting of delimited metadata values.
+* Various HTTP timeout fixes.
+* Added support for MixedInKey's oddball JSON key format.
 
 * Internal changes:
   * Upgrade to Python 3.11.

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import base64
+import binascii
 import copy
 import json
 import logging
@@ -515,15 +516,15 @@ class TinyTagRunner:  # pylint: disable=too-few-public-methods
 
             # Try to parse as JSON
             key_data = json.loads(decoded_str)
-            if isinstance(key_data, dict) and 'key' in key_data:
+            if isinstance(key_data, dict) and 'key' in key_data and key_data['key'] is not None:
                 return key_data['key']
-        except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError):
             pass
 
         # If not base64/JSON, try direct JSON parsing
         try:
             key_data = json.loads(key_str)
-            if isinstance(key_data, dict) and 'key' in key_data:
+            if isinstance(key_data, dict) and 'key' in key_data and key_data['key'] is not None:
                 return key_data['key']
         except (json.JSONDecodeError, TypeError):
             pass

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -725,7 +725,7 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
 
 @pytest.mark.parametrize("input_value,expected_output", [
     # Base64 encoded JSON (MixedInKey format)
-    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==',  # pragma: allowlist secret
+    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==',  # pragma: allowlist secret  # pylint: disable=line-too-long
      '4A'),
     # Direct JSON
     ('{"algorithm":94,"key":"9B","source":"mixedinkey"}', '9B'),

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -721,3 +721,35 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
             '''SELECT COUNT(cachekey) FROM identifiersha WHERE imagetype="front_cover"''')
         row = cursor.fetchone()[0]
         assert row > 1
+
+
+def test_decode_musical_key():
+    """Test the _decode_musical_key method handles various key formats."""
+    from nowplaying.metadata import TinyTagRunner  # pylint: disable=import-outside-toplevel
+
+    # Test base64 encoded JSON (MixedInKey format)
+    b64_json = 'eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ=='
+    result = TinyTagRunner._decode_musical_key(b64_json)  # pylint: disable=protected-access
+    assert result == '4A'
+
+    # Test direct JSON
+    json_str = '{"algorithm":94,"key":"9B","source":"mixedinkey"}'
+    result = TinyTagRunner._decode_musical_key(json_str)  # pylint: disable=protected-access
+    assert result == '9B'
+
+    # Test simple string key
+    result = TinyTagRunner._decode_musical_key('Am')  # pylint: disable=protected-access
+    assert result == 'Am'
+
+    # Test another simple key
+    result = TinyTagRunner._decode_musical_key('C#m')  # pylint: disable=protected-access
+    assert result == 'C#m'
+
+    # Test None/empty values
+    assert TinyTagRunner._decode_musical_key(None) is None  # pylint: disable=protected-access
+    assert TinyTagRunner._decode_musical_key('') is None  # pylint: disable=protected-access
+    assert TinyTagRunner._decode_musical_key('   ') == ''  # pylint: disable=protected-access
+
+    # Test malformed base64/JSON - should return original string
+    result = TinyTagRunner._decode_musical_key('not-base64-or-json')  # pylint: disable=protected-access
+    assert result == 'not-base64-or-json'

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -725,7 +725,8 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
 
 @pytest.mark.parametrize("input_value,expected_output", [
     # Base64 encoded JSON (MixedInKey format)
-    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==', '4A'),  # pragma: allowlist secret
+    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==',  # pragma: allowlist secret
+     '4A'),
     # Direct JSON
     ('{"algorithm":94,"key":"9B","source":"mixedinkey"}', '9B'),
     # Simple string keys
@@ -747,7 +748,7 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
     ('InRlc3Qgc3RyaW5nIg==', 'InRlc3Qgc3RyaW5nIg=='),  # "test string"
     # Valid base64 that decodes to JSON object missing 'key' field
     ('eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0=',  # pragma: allowlist secret
-     'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0='),
+     'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0='),  # pragma: allowlist secret
     # Direct JSON without 'key' field
     ('{"algorithm":94,"source":"mixedinkey"}', '{"algorithm":94,"source":"mixedinkey"}'),
     # Direct JSON array

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -725,7 +725,7 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
 
 @pytest.mark.parametrize("input_value,expected_output", [
     # Base64 encoded JSON (MixedInKey format)
-    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==', '4A'),
+    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==', '4A'),  # pragma: allowlist secret
     # Direct JSON
     ('{"algorithm":94,"key":"9B","source":"mixedinkey"}', '9B'),
     # Simple string keys
@@ -746,7 +746,8 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
     # Valid base64 that decodes to non-object JSON (string)
     ('InRlc3Qgc3RyaW5nIg==', 'InRlc3Qgc3RyaW5nIg=='),  # "test string"
     # Valid base64 that decodes to JSON object missing 'key' field
-    ('eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0=', 'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0='),
+    ('eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0=',  # pragma: allowlist secret
+     'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0='),
     # Direct JSON without 'key' field
     ('{"algorithm":94,"source":"mixedinkey"}', '{"algorithm":94,"source":"mixedinkey"}'),
     # Direct JSON array
@@ -754,11 +755,10 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
     # Direct JSON string
     ('"test string"', '"test string"'),
     # JSON with null key value
-    ('{"algorithm":94,"key":null,"source":"mixedinkey"}', '{"algorithm":94,"key":null,"source":"mixedinkey"}'),
+    ('{"algorithm":94,"key":null,"source":"mixedinkey"}',
+     '{"algorithm":94,"key":null,"source":"mixedinkey"}'),
 ])
 def test_decode_musical_key(input_value, expected_output):
     """Test the _decode_musical_key method handles various key formats."""
-    from nowplaying.metadata import TinyTagRunner  # pylint: disable=import-outside-toplevel
-
-    result = TinyTagRunner._decode_musical_key(input_value)  # pylint: disable=protected-access
+    result = nowplaying.metadata.TinyTagRunner._decode_musical_key(input_value)  # pylint: disable=protected-access
     assert result == expected_output


### PR DESCRIPTION
## Summary by Sourcery

Add support for parsing and decoding MixedInKey's JSON-based musical key metadata and integrate it into the metadata extraction workflow.

New Features:
- Introduce `_decode_musical_key` to extract key values from MixedInKey’s JSON or base64-encoded formats.

Enhancements:
- Hook musical key decoding into both extra field handling and TinyTag-based tag processing.

Documentation:
- Update CHANGELOG to note added support for MixedInKey’s oddball JSON key format.

Tests:
- Add parameterized tests for `_decode_musical_key` covering JSON objects, base64 payloads, simple strings, and edge cases.