### PR TITLE
JRiver Media Center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Version 4.2.0 - In Progress
 
+* New input plugin for JRiver Media Center via MCWS API support.
 * Better handling of when the program is already running.
   It should help prevent some weird crashes.
 * Error logging for when wikimedia attempts to continue

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ __What's Now Playing__ is a tool written in Python to retrieve live song data fo
 streaming DJs using a variety of software, including:
 
 * [MIXXX](https://mixxx.org/)
+* [JRiver Media Center](https://jriver.com/)
 * [Serato DJ](https://serato.com/)
 * [Traktor](https://www.native-instruments.com/en/catalog/traktor/)
 * [Virtual DJ](https://www.virtualdj.com/) and other software that writes m3u files

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Welcome to What's Now Playing!
    :alt: Meerkat Logo
 
 **What's Now Playing** is a tool written in Python to retrieve the current/last played
-song in MIXXX, Serato, Traktor, Virtual DJ, and many other audio and DJ programs. It gives
+song in MIXXX, JRiver Media Center, Serato, Traktor, Virtual DJ, and many other audio and DJ programs. It gives
 you full control to use or not use whatever features you like and fully customize the
 output to match your style. You can even pretend to be a fancy music channel:
 

--- a/docs/input/index.rst
+++ b/docs/input/index.rst
@@ -11,6 +11,7 @@ Each has its own screen to configure them.
 
    djuced
    icecast
+   jriver
    m3u
    mpris2
    serato

--- a/docs/input/jriver.rst
+++ b/docs/input/jriver.rst
@@ -27,7 +27,7 @@ JRiver Configuration
 #. Check **Use Media Network to share this library**
 #. Note the **Access Key** if one is displayed (optional but recommended for security)
 #. Configure authentication if desired:
-   
+
    * Check **Require authentication for requests**
    * Set a **Username** and **Password**
 
@@ -47,7 +47,7 @@ Configuration Options
 
 Host/IP Address
   The hostname or IP address of the machine running JRiver Media Center.
-  
+
   * Use ``localhost`` or ``127.0.0.1`` if JRiver is on the same machine
   * Use the IP address (e.g., ``192.168.1.100``) for remote connections
   * IPv6 addresses are supported and will be automatically formatted correctly
@@ -133,7 +133,7 @@ Supported Track Information
 The JRiver input source provides the following track metadata:
 
 * **Artist** - Track artist name
-* **Album** - Album name  
+* **Album** - Album name
 * **Title** - Track title
 * **Duration** - Track length in seconds
 * **Filename** - Full file path (local connections only)

--- a/docs/input/jriver.rst
+++ b/docs/input/jriver.rst
@@ -1,0 +1,141 @@
+JRiver
+======
+
+JRiver Media Center is a commercial media player application that runs on Windows, Mac, and Linux.
+**What's Now Playing** connects to JRiver using the MCWS (Media Center Web Service) API to retrieve
+currently playing track information.
+
+The JRiver input source supports both local and remote connections to JRiver Media Center instances.
+For local connections, **What's Now Playing** can also retrieve the full file path of the currently
+playing track.
+
+Requirements
+------------
+
+* JRiver Media Center (version 20 or later recommended)
+* MCWS (Media Center Web Service) enabled in JRiver
+* Network connectivity between **What's Now Playing** and JRiver (if running on different machines)
+
+Setup Instructions
+------------------
+
+JRiver Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+#. Open JRiver Media Center
+#. Go to **Tools** → **Options** → **Media Network**
+#. Check **Use Media Network to share this library**
+#. Note the **Access Key** if one is displayed (optional but recommended for security)
+#. Configure authentication if desired:
+   
+   * Check **Require authentication for requests**
+   * Set a **Username** and **Password**
+
+#. Note the **Port** number (default is 52199)
+#. Click **OK** to save settings
+
+What's Now Playing Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. Open Settings from the **What's Now Playing** icon
+#. Select **Input Source** from the left-hand column
+#. Select **JRiver** from the list of available input sources
+#. Select **JRiver** from the left-hand column to configure settings
+
+Configuration Options
+---------------------
+
+Host/IP Address
+  The hostname or IP address of the machine running JRiver Media Center.
+  
+  * Use ``localhost`` or ``127.0.0.1`` if JRiver is on the same machine
+  * Use the IP address (e.g., ``192.168.1.100``) for remote connections
+  * IPv6 addresses are supported and will be automatically formatted correctly
+
+Port
+  The port number for MCWS connections (default: ``52199``)
+
+Username (Optional)
+  Username for authentication if required by JRiver
+
+Password (Optional)
+  Password for authentication if required by JRiver
+
+Access Key (Optional)
+  Access key for additional security validation if configured in JRiver
+
+Connection Types
+----------------
+
+Local Connections
+~~~~~~~~~~~~~~~~~
+
+Local connections are automatically detected for:
+
+* ``localhost``, ``127.0.0.1``, ``::1``
+* Private IP addresses (192.168.x.x, 10.x.x.x, 172.16.x.x)
+* Local domain patterns (``.local``, ``.lan``, ``.home``, ``.internal``)
+
+For local connections, **What's Now Playing** will attempt to retrieve the full file path
+of the currently playing track, which can be useful for other applications or logging.
+
+Remote Connections
+~~~~~~~~~~~~~~~~~~
+
+Remote connections are used for all other hostnames and public IP addresses.
+File paths are not retrieved for remote connections for security reasons.
+
+Testing Your Connection
+-----------------------
+
+You can test your JRiver MCWS configuration by opening a web browser and visiting:
+
+``http://[host]:[port]/MCWS/v1/Alive``
+
+For example: ``http://localhost:52199/MCWS/v1/Alive``
+
+This should return an XML response showing your JRiver server information if the connection is working correctly.
+
+Troubleshooting
+---------------
+
+Connection Failed
+~~~~~~~~~~~~~~~~~
+
+* Verify JRiver Media Center is running
+* Check that Media Network is enabled in JRiver settings
+* Ensure the correct host/IP address and port are configured
+* For remote connections, verify network connectivity and firewall settings
+
+Authentication Failed
+~~~~~~~~~~~~~~~~~~~~~~
+
+* Verify username and password are correct (if authentication is enabled)
+* Check that the access key matches (if configured)
+* Ensure authentication is properly enabled in JRiver if credentials are provided
+
+No Track Information
+~~~~~~~~~~~~~~~~~~~~
+
+* Ensure music is currently playing in JRiver
+* Check that JRiver is not paused
+* Verify the MCWS API is responding by testing the connection URL in a browser
+
+File Path Not Available
+~~~~~~~~~~~~~~~~~~~~~~~
+
+File paths are only available for local connections. Remote connections will not include
+file path information for security reasons.
+
+Supported Track Information
+---------------------------
+
+The JRiver input source provides the following track metadata:
+
+* **Artist** - Track artist name
+* **Album** - Album name  
+* **Title** - Track title
+* **Duration** - Track length in seconds
+* **Filename** - Full file path (local connections only)
+
+Additional track metadata may be available depending on how the tracks are tagged in JRiver.

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -102,7 +102,7 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
             logging.error("Cannot authenticate with JRiver server: %s", error)
             return False
 
-    async def getplayingtrack(self):
+    async def getplayingtrack(self):  # pylint: disable=too-many-branches
         ''' Get currently playing track from JRiver '''
         if not self.base_url:
             return None
@@ -113,6 +113,8 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
             params = {}
             if self.token:
                 params['Token'] = self.token
+            if self.access_key:
+                params['AccessKey'] = self.access_key
 
             async with self.session.get(url, params=params) as response:  # pylint: disable=not-async-context-manager
                 if response.status != 200:
@@ -127,7 +129,7 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
 
         try:
             tree = lxml.etree.fromstring(response_text)  # pylint: disable=c-extension-no-member
-        except Exception as error:
+        except Exception as error:  # pylint: disable=broad-except
             logging.error("Cannot parse JRiver response: %s", error)
             return None
 
@@ -202,7 +204,7 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
             local_domain_patterns = [
                 '.local',  # mDNS/Bonjour local domains (e.g., jriver.local)
                 '.lan',  # Common local network domain
-                '.home',  # Common home network domain  
+                '.home',  # Common home network domain
                 '.internal',  # Common internal network domain
             ]
             # Only return True for explicit local domain patterns
@@ -215,6 +217,8 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
             params = {'FileKey': filekey}
             if self.token:
                 params['Token'] = self.token
+            if self.access_key:
+                params['AccessKey'] = self.access_key
 
             async with self.session.get(url, params=params) as response:  # pylint: disable=not-async-context-manager
                 if response.status != 200:
@@ -280,11 +284,12 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
 
     def save_settingsui(self, qwidget):
         ''' take the settings page and save it '''
-        self.config.cparser.setValue('jriver/host', qwidget.host_lineedit.text())
-        self.config.cparser.setValue('jriver/port', qwidget.port_lineedit.text())
-        self.config.cparser.setValue('jriver/username', qwidget.username_lineedit.text())
-        self.config.cparser.setValue('jriver/password', qwidget.password_lineedit.text())
-        self.config.cparser.setValue('jriver/access_key', qwidget.access_key_lineedit.text())
+        self.config.cparser.setValue('jriver/host', qwidget.host_lineedit.text().strip())
+        self.config.cparser.setValue('jriver/port', qwidget.port_lineedit.text().strip())
+        self.config.cparser.setValue('jriver/username', qwidget.username_lineedit.text().strip())
+        self.config.cparser.setValue('jriver/password', qwidget.password_lineedit.text().strip())
+        self.config.cparser.setValue('jriver/access_key',
+                                      qwidget.access_key_lineedit.text().strip())
 
     def desc_settingsui(self, qwidget):
         ''' description '''

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+''' JRiver Media Center MCWS API plugin '''
+
+import asyncio
+import logging
+
+import aiohttp
+import lxml.etree
+
+from nowplaying.inputs import InputPlugin
+
+class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
+    ''' handler for JRiver Media Center via MCWS API '''
+
+    def __init__(self, config=None, qsettings=None):
+        super().__init__(config=config, qsettings=qsettings)
+        self.displayname = "JRiver Media Center"
+        self.host = None
+        self.port = None
+        self.username = None
+        self.password = None
+        self.access_key = None
+        self.token = None
+        self.base_url = None
+        self.session = None
+        self.mixmode = "newest"
+        self.testmode = False
+
+    async def start(self):
+        ''' Initialize the plugin and authenticate '''
+        self.host = self.config.cparser.value('jriver/host')
+        self.port = self.config.cparser.value('jriver/port', '52199')  # Default JRiver port
+        self.username = self.config.cparser.value('jriver/username')
+        self.password = self.config.cparser.value('jriver/password')
+        self.access_key = self.config.cparser.value('jriver/access_key')
+
+        if not self.host:
+            logging.error("JRiver host not configured")
+            return False
+
+        self.base_url = f"http://{self.host}:{self.port}/MCWS/v1"
+        
+        # Create aiohttp session
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5))
+
+        # Test connection and authenticate
+        if await self._test_connection() and await self._authenticate():
+            return True
+        return False
+
+    async def _test_connection(self):
+        ''' Test connection to JRiver server '''
+        try:
+            url = f"{self.base_url}/Alive"
+            async with self.session.get(url) as response:
+                if response.status == 200:
+                    response_text = await response.text()
+                    # Parse response to check access key if provided
+                    if self.access_key:
+                        tree = lxml.etree.fromstring(response_text)
+                        access_key_items = tree.xpath('//Item[@Name="AccessKey"]')
+                        if access_key_items:
+                            server_access_key = access_key_items[0].text
+                            if server_access_key != self.access_key:
+                                logging.error("Access key mismatch")
+                                return False
+                    logging.debug("JRiver server connection successful")
+                    return True
+                logging.error("JRiver server returned status %d", response.status)
+                return False
+        except Exception as error:  # pylint: disable=broad-except
+            logging.error("Cannot connect to JRiver server: %s", error)
+            return False
+
+    async def _authenticate(self):
+        ''' Authenticate with JRiver server '''
+        if not self.username or not self.password:
+            logging.debug("No username/password provided, skipping authentication")
+            return True
+
+        try:
+            url = f"{self.base_url}/Authenticate"
+            params = {
+                'Username': self.username,
+                'Password': self.password
+            }
+            async with self.session.get(url, params=params) as response:
+                if response.status == 200:
+                    response_text = await response.text()
+                    tree = lxml.etree.fromstring(response_text)
+                    token_items = tree.xpath('//Item[@Name="Token"]')
+                    if token_items:
+                        self.token = token_items[0].text
+                        logging.debug("JRiver authentication successful")
+                        return True
+                    logging.error("No token received from JRiver server")
+                    return False
+                logging.error("JRiver authentication failed with status %d", response.status)
+                return False
+        except Exception as error:  # pylint: disable=broad-except
+            logging.error("Cannot authenticate with JRiver server: %s", error)
+            return False
+
+    async def getplayingtrack(self):
+        ''' Get currently playing track from JRiver '''
+        if not self.base_url:
+            return None
+
+        await asyncio.sleep(.5)
+        try:
+            url = f"{self.base_url}/Playback/Info"
+            params = {}
+            if self.token:
+                params['Token'] = self.token
+
+            async with self.session.get(url, params=params) as response:
+                if response.status != 200:
+                    logging.error("JRiver API returned status %d", response.status)
+                    return None
+                
+                response_text = await response.text()
+
+        except Exception as error:  # pylint: disable=broad-except
+            logging.error("Cannot get playing track from JRiver: %s", error)
+            return None
+
+        try:
+            tree = lxml.etree.fromstring(response_text)
+        except Exception as error:
+            logging.error("Cannot parse JRiver response: %s", error)
+            return None
+
+        # Extract metadata from JRiver XML response
+        metadata = {}
+
+        # Parse the XML items
+        for item in tree.xpath('//Item'):
+            name = item.get('Name')
+            value = item.text
+            if name == 'Artist':
+                metadata['artist'] = value
+            elif name == 'Album':
+                metadata['album'] = value
+            elif name == 'Name':  # JRiver uses 'Name' for track title
+                metadata['title'] = value
+            elif name == 'DurationMS':
+                # Convert milliseconds to seconds
+                if value and value.isdigit():
+                    metadata['duration'] = int(value) // 1000
+
+        return metadata
+
+    async def getrandomtrack(self, playlist):
+        ''' Not implemented for JRiver MCWS '''
+        return None
+
+    async def stop(self):
+        ''' Clean up resources '''
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    def defaults(self, qsettings):
+        qsettings.setValue('jriver/host', None)
+        qsettings.setValue('jriver/port', '52199')
+        qsettings.setValue('jriver/username', None)
+        qsettings.setValue('jriver/password', None)
+        qsettings.setValue('jriver/access_key', None)
+
+    def validmixmodes(self):
+        ''' let the UI know which modes are valid '''
+        return ['newest']
+
+    def setmixmode(self, mixmode):
+        ''' set the mixmode '''
+        return 'newest'
+
+    def getmixmode(self):
+        ''' get the mixmode '''
+        return 'newest'
+
+    def connect_settingsui(self, qwidget, uihelp):
+        ''' connect jriver local dir button '''
+        self.qwidget = qwidget
+        self.uihelp = uihelp
+
+    def load_settingsui(self, qwidget):
+        ''' draw the plugin's settings page '''
+        qwidget.host_lineedit.setText(self.config.cparser.value('jriver/host') or '')
+        qwidget.port_lineedit.setText(self.config.cparser.value('jriver/port') or '52199')
+        qwidget.username_lineedit.setText(self.config.cparser.value('jriver/username') or '')
+        qwidget.password_lineedit.setText(self.config.cparser.value('jriver/password') or '')
+        qwidget.access_key_lineedit.setText(self.config.cparser.value('jriver/access_key') or '')
+
+    def save_settingsui(self, qwidget):
+        ''' take the settings page and save it '''
+        self.config.cparser.setValue('jriver/host', qwidget.host_lineedit.text())
+        self.config.cparser.setValue('jriver/port', qwidget.port_lineedit.text())
+        self.config.cparser.setValue('jriver/username', qwidget.username_lineedit.text())
+        self.config.cparser.setValue('jriver/password', qwidget.password_lineedit.text())
+        self.config.cparser.setValue('jriver/access_key', qwidget.access_key_lineedit.text())
+
+    def desc_settingsui(self, qwidget):
+        ''' description '''
+        qwidget.setText('This plugin provides support for JRiver Media Center via MCWS API. '
+                       'Configure the host/IP and port of your JRiver server. '
+                       'Username/password are optional if authentication is not required.')

--- a/nowplaying/resources/inputs_jriver_ui.ui
+++ b/nowplaying/resources/inputs_jriver_ui.ui
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>jriver_ui</class>
+ <widget class="QWidget" name="jriver_ui">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>JRiver Media Center</string>
+  </property>
+  <widget class="QLabel" name="header_label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>291</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>**JRiver Media Center Configuration**</string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::MarkdownText</enum>
+   </property>
+  </widget>
+  <widget class="QWidget" name="formLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>50</y>
+     <width>600</width>
+     <height>160</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="config_form_layout">
+    <property name="labelAlignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+    <property name="formAlignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+    </property>
+    <item row="0" column="0">
+     <widget class="QLabel" name="host_label">
+      <property name="text">
+       <string>Host/IP Address:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="host_lineedit">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="inputMethodHints">
+       <set>Qt::ImhUrlCharactersOnly</set>
+      </property>
+      <property name="placeholderText">
+       <string>e.g., 192.168.1.100 or localhost</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="port_label">
+      <property name="text">
+       <string>Port:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QLineEdit" name="port_lineedit">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="inputMethodHints">
+       <set>Qt::ImhDigitsOnly</set>
+      </property>
+      <property name="text">
+       <string>52199</string>
+      </property>
+      <property name="placeholderText">
+       <string>Default: 52199</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="username_label">
+      <property name="text">
+       <string>Username:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QLineEdit" name="username_lineedit">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="placeholderText">
+       <string>Optional - leave blank if no authentication required</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="password_label">
+      <property name="text">
+       <string>Password:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLineEdit" name="password_lineedit">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="echoMode">
+       <enum>QLineEdit::Password</enum>
+      </property>
+      <property name="placeholderText">
+       <string>Optional - leave blank if no authentication required</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="access_key_label">
+      <property name="text">
+       <string>Access Key:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLineEdit" name="access_key_lineedit">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="placeholderText">
+       <string>Optional - for additional security validation</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QTextBrowser" name="info_text">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>230</y>
+     <width>600</width>
+     <height>230</height>
+    </rect>
+   </property>
+   <property name="html">
+    <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;JRiver Media Center Setup:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1. Enable Media Network in JRiver (Tools &amp;gt; Options &amp;gt; Media Network)&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;2. Configure the port (default is 52199)&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;3. Enable authentication if desired&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Configuration Notes:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Host can be an IP address (e.g., 192.168.1.100) or hostname (e.g., localhost)&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Username and password are only required if JRiver has authentication enabled&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Access key provides additional security validation (optional)&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Testing Connection:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You can test your configuration by visiting: http://[host]:[port]/MCWS/v1/Alive&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/nowplaying/resources/inputs_jriver_ui.ui
+++ b/nowplaying/resources/inputs_jriver_ui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>JRiver Media Center</string>
+   <string>JRiver</string>
   </property>
   <widget class="QLabel" name="header_label">
    <property name="geometry">
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>**JRiver Media Center Configuration**</string>
+    <string>**JRiver Configuration**</string>
    </property>
    <property name="textFormat">
     <enum>Qt::MarkdownText</enum>

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 #
 # tests
 #
+aioresponses==0.7.7
 psutil==7.0.0
 pytest==8.3.5
 pytest-asyncio==0.26.0

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -2,18 +2,30 @@
 ''' test jriver input plugin '''
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock
 import pytest
+import pytest_asyncio
+from aioresponses import aioresponses
 
-import nowplaying.inputs.jriver # pylint: disable=import-error
+import nowplaying.inputs.jriver  # pylint: disable=import-error
 
 
-def create_mock_response(status=200, text=''):
+def create_mock_response(status, text):
     """Helper to create mock aiohttp response"""
     mock_response = AsyncMock()
     mock_response.status = status
     mock_response.text = AsyncMock(return_value=text)
     return mock_response
+
+
+@pytest_asyncio.fixture
+async def jriver_plugin_with_session():
+    """Create JRiver plugin with real aiohttp session for testing"""
+    import aiohttp
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+    plugin.session = aiohttp.ClientSession()
+    yield plugin
+    await plugin.session.close()
 
 
 @pytest.fixture
@@ -31,7 +43,7 @@ def jriver_bootstrap(bootstrap):
 
 def test_plugin_init():
     """Test plugin initialization"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     assert plugin.displayname == "JRiver Media Center"
     assert plugin.host is None
     assert plugin.port is None
@@ -41,10 +53,10 @@ def test_plugin_init():
 
 def test_plugin_defaults():
     """Test default configuration values"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     mock_qsettings = MagicMock()
     plugin.defaults(mock_qsettings)
-    
+
     mock_qsettings.setValue.assert_any_call('jriver/host', None)
     mock_qsettings.setValue.assert_any_call('jriver/port', '52199')
     mock_qsettings.setValue.assert_any_call('jriver/username', None)
@@ -54,7 +66,7 @@ def test_plugin_defaults():
 
 def test_plugin_mixmodes():
     """Test mix mode functionality"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     assert plugin.validmixmodes() == ['newest']
     assert plugin.setmixmode('any') == 'newest'
     assert plugin.getmixmode() == 'newest'
@@ -62,11 +74,11 @@ def test_plugin_mixmodes():
 
 def test_settings_ui_load(jriver_bootstrap):
     """Test loading settings into UI"""
-    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap)  # pylint: disable=no-member
     mock_qwidget = MagicMock()
-    
+
     plugin.load_settingsui(mock_qwidget)
-    
+
     mock_qwidget.host_lineedit.setText.assert_called_once_with('192.168.1.100')
     mock_qwidget.port_lineedit.setText.assert_called_once_with('52199')
     mock_qwidget.username_lineedit.setText.assert_called_once_with('testuser')
@@ -76,16 +88,16 @@ def test_settings_ui_load(jriver_bootstrap):
 
 def test_settings_ui_save(jriver_bootstrap):
     """Test saving settings from UI"""
-    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap)  # pylint: disable=no-member
     mock_qwidget = MagicMock()
     mock_qwidget.host_lineedit.text.return_value = 'localhost'
     mock_qwidget.port_lineedit.text.return_value = '12345'
     mock_qwidget.username_lineedit.text.return_value = 'newuser'
     mock_qwidget.password_lineedit.text.return_value = 'newpass'
     mock_qwidget.access_key_lineedit.text.return_value = 'newkey'
-    
+
     plugin.save_settingsui(mock_qwidget)
-    
+
     assert plugin.config.cparser.value('jriver/host') == 'localhost'
     assert plugin.config.cparser.value('jriver/port') == '12345'
     assert plugin.config.cparser.value('jriver/username') == 'newuser'
@@ -95,25 +107,27 @@ def test_settings_ui_save(jriver_bootstrap):
 
 def test_settings_ui_description():
     """Test settings UI description"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     mock_qwidget = MagicMock()
-    
+
     plugin.desc_settingsui(mock_qwidget)
-    
+
     expected_text = ('This plugin provides support for JRiver Media Center via MCWS API. '
-                    'Configure the host/IP and port of your JRiver server. '
-                    'Username/password are optional if authentication is not required.')
+                     'Configure the host/IP and port of your JRiver server. '
+                     'Username/password are optional if authentication is not required. '
+                     'For local connections, the plugin will automatically retrieve '
+                     'file paths for enhanced metadata support.')
     mock_qwidget.setText.assert_called_once_with(expected_text)
 
 
 @pytest.mark.asyncio
 async def test_start_no_host():
     """Test start() with no host configured"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     mock_config = MagicMock()
     mock_config.cparser.value.return_value = None
     plugin.config = mock_config
-    
+
     result = await plugin.start()
     assert result is False
 
@@ -121,13 +135,13 @@ async def test_start_no_host():
 @pytest.mark.asyncio
 async def test_start_success(jriver_bootstrap):
     """Test successful start() with connection and authentication"""
-    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
-    
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap)  # pylint: disable=no-member
+
     with patch.object(plugin, '_test_connection', return_value=True) as mock_test, \
          patch.object(plugin, '_authenticate', return_value=True) as mock_auth:
-        
+
         result = await plugin.start()
-        
+
         assert result is True
         assert plugin.host == '192.168.1.100'
         assert plugin.port == '52199'
@@ -142,8 +156,8 @@ async def test_start_success(jriver_bootstrap):
 @pytest.mark.asyncio
 async def test_start_connection_failure(jriver_bootstrap):
     """Test start() with connection failure"""
-    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
-    
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap)  # pylint: disable=no-member
+
     with patch.object(plugin, '_test_connection', return_value=False):
         result = await plugin.start()
         assert result is False
@@ -152,11 +166,11 @@ async def test_start_connection_failure(jriver_bootstrap):
 @pytest.mark.asyncio
 async def test_start_auth_failure(jriver_bootstrap):
     """Test start() with authentication failure"""
-    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
-    
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap)  # pylint: disable=no-member
+
     with patch.object(plugin, '_test_connection', return_value=True), \
          patch.object(plugin, '_authenticate', return_value=False):
-        
+
         result = await plugin.start()
         assert result is False
 
@@ -164,107 +178,121 @@ async def test_start_auth_failure(jriver_bootstrap):
 @pytest.mark.asyncio
 async def test_test_connection_success():
     """Test successful connection test"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.access_key = 'testkey'
-    
-    # Mock aiohttp session
-    mock_session = AsyncMock()
-    plugin.session = mock_session
-    
-    mock_response = create_mock_response(
-        status=200,
-        text='''
-        <Response Status="OK">
-            <Item Name="AccessKey">testkey</Item>
-        </Response>
-        '''
-    )
-    
-    # Set up the async context manager properly
-    mock_context_manager = AsyncMock()
-    mock_context_manager.__aenter__.return_value = mock_response
-    mock_context_manager.__aexit__.return_value = None
-    mock_session.get.return_value = mock_context_manager
-    
-    result = await plugin._test_connection()
-    assert result is True
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Alive',
+              body='''<Response Status="OK">
+                        <Item Name="AccessKey">testkey</Item>
+                      </Response>''')
+
+        result = await plugin._test_connection()
+        assert result is True
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_test_connection_wrong_access_key():
     """Test connection test with wrong access key"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.access_key = 'wrongkey'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '''
-    <Response Status="OK">
-        <Item Name="AccessKey">correctkey</Item>
-    </Response>
-    '''
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Alive',
+              body='''<Response Status="OK">
+                        <Item Name="AccessKey">correctkey</Item>
+                      </Response>''')
+
         result = await plugin._test_connection()
         assert result is False
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_test_connection_http_error():
     """Test connection test with HTTP error"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 404
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Alive', status=404)
+
         result = await plugin._test_connection()
         assert result is False
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_test_connection_network_error():
     """Test connection test with network error"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
-    
-    with patch('nowplaying.inputs.jriver.requests.get', side_effect=Exception('Connection failed')):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Alive', exception=Exception('Connection failed'))
+
         result = await plugin._test_connection()
         assert result is False
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_authenticate_success():
     """Test successful authentication"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.username = 'testuser'
     plugin.password = 'testpass'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '''
-    <Response Status="OK">
-        <Item Name="Token">abc123token</Item>
-    </Response>
-    '''
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass',
+              body='''
+              <Response Status="OK">
+                  <Item Name="Token">abc123token</Item>
+              </Response>
+              ''')
+
         result = await plugin._authenticate()
         assert result is True
         assert plugin.token == 'abc123token'
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_authenticate_no_credentials():
     """Test authentication with no credentials"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.username = None
     plugin.password = None
-    
+
     result = await plugin._authenticate()
     assert result is True  # Should succeed when no auth is needed
 
@@ -272,71 +300,80 @@ async def test_authenticate_no_credentials():
 @pytest.mark.asyncio
 async def test_authenticate_no_token():
     """Test authentication with no token in response"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.username = 'testuser'
     plugin.password = 'testpass'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '''
-    <Response Status="OK">
-    </Response>
-    '''
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass',
+              body='''
+              <Response Status="OK">
+              </Response>
+              ''')
+
         result = await plugin._authenticate()
         assert result is False
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_authenticate_http_error():
     """Test authentication with HTTP error"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.username = 'testuser'
     plugin.password = 'testpass'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 401
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass',
+              status=401)
+
         result = await plugin._authenticate()
         assert result is False
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_getplayingtrack_no_base_url():
     """Test getplayingtrack with no base URL"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = None
-    
+
     result = await plugin.getplayingtrack()
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_success():
+async def test_getplayingtrack_success(jriver_plugin_with_session):
     """Test successful getplayingtrack"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = jriver_plugin_with_session
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.token = 'testtoken'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '''
-    <Response Status="OK">
-        <Item Name="State">Playing</Item>
-        <Item Name="Artist">The Beatles</Item>
-        <Item Name="Album">Abbey Road</Item>
-        <Item Name="Name">Come Together</Item>
-        <Item Name="DurationMS">240000</Item>
-    </Response>
-    '''
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    with aioresponses() as m:
+        # aioresponses matches the URL pattern, including query parameters
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info?Token=testtoken',
+              body='''<Response Status="OK">
+                        <Item Name="State">Playing</Item>
+                        <Item Name="Artist">The Beatles</Item>
+                        <Item Name="Album">Abbey Road</Item>
+                        <Item Name="Name">Come Together</Item>
+                        <Item Name="DurationMS">240000</Item>
+                      </Response>''')
+
         result = await plugin.getplayingtrack()
-        
+
         assert result['artist'] == 'The Beatles'
         assert result['album'] == 'Abbey Road'
         assert result['title'] == 'Come Together'
@@ -346,120 +383,269 @@ async def test_getplayingtrack_success():
 @pytest.mark.asyncio
 async def test_getplayingtrack_minimal_data():
     """Test getplayingtrack with minimal data"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '''
-    <Response Status="OK">
-        <Item Name="Name">Unknown Track</Item>
-    </Response>
-    '''
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info',
+              body='''
+              <Response Status="OK">
+                  <Item Name="Name">Unknown Track</Item>
+              </Response>
+              ''')
+
         result = await plugin.getplayingtrack()
-        
+
         assert result['title'] == 'Unknown Track'
         assert result.get('artist') is None
         assert result.get('album') is None
         assert result.get('duration') is None
 
+    await plugin.session.close()
+
 
 @pytest.mark.asyncio
 async def test_getplayingtrack_http_error():
     """Test getplayingtrack with HTTP error"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 500
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info', status=500)
+
         result = await plugin.getplayingtrack()
         assert result is None
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_getplayingtrack_network_error():
     """Test getplayingtrack with network error"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
-    
-    with patch('nowplaying.inputs.jriver.requests.get', side_effect=Exception('Network error')):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info', exception=Exception('Network error'))
+
         result = await plugin.getplayingtrack()
         assert result is None
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_getplayingtrack_parse_error():
     """Test getplayingtrack with XML parse error"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = 'invalid xml content'
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info', body='invalid xml content')
+
         result = await plugin.getplayingtrack()
         assert result is None
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_getplayingtrack_with_token():
     """Test getplayingtrack includes token in request"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.token = 'mytoken123'
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '<Response Status="OK"></Response>'
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response) as mock_get:
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        # aioresponses matches the exact URL including query parameters
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123',
+              body='<Response Status="OK"></Response>')
+
         await plugin.getplayingtrack()
-        
-        # Verify token was included in the request
-        mock_get.assert_called_once()
-        call_args = mock_get.call_args
-        assert call_args[1]['params']['Token'] == 'mytoken123'
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_getplayingtrack_without_token():
     """Test getplayingtrack without token"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.token = None
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.text = '<Response Status="OK"></Response>'
-    
-    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response) as mock_get:
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        # aioresponses matches the exact URL without query parameters
+        m.get('http://localhost:52199/MCWS/v1/Playback/Info',
+              body='<Response Status="OK"></Response>')
+
         await plugin.getplayingtrack()
-        
-        # Verify no token in params
-        call_args = mock_get.call_args
-        assert 'Token' not in call_args[1]['params']
+
+    await plugin.session.close()
 
 
 @pytest.mark.asyncio
 async def test_getrandomtrack():
     """Test getrandomtrack returns None"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     result = await plugin.getrandomtrack('test')
     assert result is None
 
 
 def test_connect_settingsui():
     """Test connect_settingsui method"""
-    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     mock_qwidget = MagicMock()
     mock_uihelp = MagicMock()
-    
+
     plugin.connect_settingsui(mock_qwidget, mock_uihelp)
-    
+
     assert plugin.qwidget == mock_qwidget
     assert plugin.uihelp == mock_uihelp
+
+
+def test_is_local_connection_localhost():
+    """Test local connection detection for localhost"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+
+    plugin.host = 'localhost'
+    assert plugin._is_local_connection() is True
+
+    plugin.host = '127.0.0.1'
+    assert plugin._is_local_connection() is True
+
+    plugin.host = '::1'
+    assert plugin._is_local_connection() is True
+
+
+def test_is_local_connection_private_networks():
+    """Test local connection detection for private networks"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+
+    # Private IP ranges
+    plugin.host = '192.168.1.100'
+    assert plugin._is_local_connection() is True
+
+    plugin.host = '10.0.0.5'
+    assert plugin._is_local_connection() is True
+
+    plugin.host = '172.16.1.10'
+    assert plugin._is_local_connection() is True
+
+
+def test_is_local_connection_public_ip():
+    """Test local connection detection for public IPs"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+
+    plugin.host = '8.8.8.8'
+    assert plugin._is_local_connection() is False
+
+    plugin.host = '1.1.1.1'
+    assert plugin._is_local_connection() is False
+
+
+def test_is_local_connection_hostname():
+    """Test local connection detection for hostnames"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+
+    # Assume hostnames are local (common case for local network)
+    plugin.host = 'jriver-server'
+    assert plugin._is_local_connection() is True
+
+    plugin.host = 'media-pc.local'
+    assert plugin._is_local_connection() is True
+
+
+def test_is_local_connection_no_host():
+    """Test local connection detection with no host"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+
+    plugin.host = None
+    assert plugin._is_local_connection() is False
+
+
+@pytest.mark.asyncio
+async def test_get_filename_success(jriver_plugin_with_session):
+    """Test successful filename retrieval"""
+    plugin = jriver_plugin_with_session
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.token = 'testtoken'
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/File/GetInfo?FileKey=12345&Token=testtoken',
+              body='''<Response Status="OK">
+                        <Item Name="FileKey">12345</Item>
+                        <Item Name="Name">Come Together</Item>
+                        <Item Name="Artist">The Beatles</Item>
+                        <Item Name="Filename">C:\\Music\\The Beatles\\Abbey Road\\Come Together.mp3</Item>
+                      </Response>''')
+
+        result = await plugin._get_filename('12345')
+        assert result == 'C:\\Music\\The Beatles\\Abbey Road\\Come Together.mp3'
+
+
+@pytest.mark.asyncio
+async def test_get_filename_not_found():
+    """Test filename retrieval when no filename in response"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/File/GetInfo?FileKey=12345',
+              body='''
+              <Response Status="OK">
+                  <Item Name="FileKey">12345</Item>
+                  <Item Name="Name">Come Together</Item>
+              </Response>
+              ''')
+
+        result = await plugin._get_filename('12345')
+        assert result is None
+
+    await plugin.session.close()
+
+
+@pytest.mark.asyncio
+async def test_get_filename_http_error():
+    """Test filename retrieval with HTTP error"""
+    plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+
+    # Create real aiohttp session for testing
+    import aiohttp
+    plugin.session = aiohttp.ClientSession()
+
+    with aioresponses() as m:
+        m.get('http://localhost:52199/MCWS/v1/File/GetInfo?FileKey=12345', status=404)
+
+        result = await plugin._get_filename('12345')
+        assert result is None
+
+    await plugin.session.close()

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+''' test jriver input plugin '''
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+import nowplaying.inputs.jriver # pylint: disable=import-error
+
+
+def create_mock_response(status=200, text=''):
+    """Helper to create mock aiohttp response"""
+    mock_response = AsyncMock()
+    mock_response.status = status
+    mock_response.text = AsyncMock(return_value=text)
+    return mock_response
+
+
+@pytest.fixture
+def jriver_bootstrap(bootstrap):
+    ''' bootstrap test '''
+    config = bootstrap
+    config.cparser.setValue('jriver/host', '192.168.1.100')
+    config.cparser.setValue('jriver/port', '52199')
+    config.cparser.setValue('jriver/username', 'testuser')
+    config.cparser.setValue('jriver/password', 'testpass')
+    config.cparser.setValue('jriver/access_key', 'testkey')
+    config.cparser.sync()
+    return config
+
+
+def test_plugin_init():
+    """Test plugin initialization"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    assert plugin.displayname == "JRiver Media Center"
+    assert plugin.host is None
+    assert plugin.port is None
+    assert plugin.token is None
+    assert plugin.base_url is None
+
+
+def test_plugin_defaults():
+    """Test default configuration values"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    mock_qsettings = MagicMock()
+    plugin.defaults(mock_qsettings)
+    
+    mock_qsettings.setValue.assert_any_call('jriver/host', None)
+    mock_qsettings.setValue.assert_any_call('jriver/port', '52199')
+    mock_qsettings.setValue.assert_any_call('jriver/username', None)
+    mock_qsettings.setValue.assert_any_call('jriver/password', None)
+    mock_qsettings.setValue.assert_any_call('jriver/access_key', None)
+
+
+def test_plugin_mixmodes():
+    """Test mix mode functionality"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    assert plugin.validmixmodes() == ['newest']
+    assert plugin.setmixmode('any') == 'newest'
+    assert plugin.getmixmode() == 'newest'
+
+
+def test_settings_ui_load(jriver_bootstrap):
+    """Test loading settings into UI"""
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    mock_qwidget = MagicMock()
+    
+    plugin.load_settingsui(mock_qwidget)
+    
+    mock_qwidget.host_lineedit.setText.assert_called_once_with('192.168.1.100')
+    mock_qwidget.port_lineedit.setText.assert_called_once_with('52199')
+    mock_qwidget.username_lineedit.setText.assert_called_once_with('testuser')
+    mock_qwidget.password_lineedit.setText.assert_called_once_with('testpass')
+    mock_qwidget.access_key_lineedit.setText.assert_called_once_with('testkey')
+
+
+def test_settings_ui_save(jriver_bootstrap):
+    """Test saving settings from UI"""
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    mock_qwidget = MagicMock()
+    mock_qwidget.host_lineedit.text.return_value = 'localhost'
+    mock_qwidget.port_lineedit.text.return_value = '12345'
+    mock_qwidget.username_lineedit.text.return_value = 'newuser'
+    mock_qwidget.password_lineedit.text.return_value = 'newpass'
+    mock_qwidget.access_key_lineedit.text.return_value = 'newkey'
+    
+    plugin.save_settingsui(mock_qwidget)
+    
+    assert plugin.config.cparser.value('jriver/host') == 'localhost'
+    assert plugin.config.cparser.value('jriver/port') == '12345'
+    assert plugin.config.cparser.value('jriver/username') == 'newuser'
+    assert plugin.config.cparser.value('jriver/password') == 'newpass'
+    assert plugin.config.cparser.value('jriver/access_key') == 'newkey'
+
+
+def test_settings_ui_description():
+    """Test settings UI description"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    mock_qwidget = MagicMock()
+    
+    plugin.desc_settingsui(mock_qwidget)
+    
+    expected_text = ('This plugin provides support for JRiver Media Center via MCWS API. '
+                    'Configure the host/IP and port of your JRiver server. '
+                    'Username/password are optional if authentication is not required.')
+    mock_qwidget.setText.assert_called_once_with(expected_text)
+
+
+@pytest.mark.asyncio
+async def test_start_no_host():
+    """Test start() with no host configured"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    mock_config = MagicMock()
+    mock_config.cparser.value.return_value = None
+    plugin.config = mock_config
+    
+    result = await plugin.start()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_start_success(jriver_bootstrap):
+    """Test successful start() with connection and authentication"""
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    
+    with patch.object(plugin, '_test_connection', return_value=True) as mock_test, \
+         patch.object(plugin, '_authenticate', return_value=True) as mock_auth:
+        
+        result = await plugin.start()
+        
+        assert result is True
+        assert plugin.host == '192.168.1.100'
+        assert plugin.port == '52199'
+        assert plugin.username == 'testuser'
+        assert plugin.password == 'testpass'
+        assert plugin.access_key == 'testkey'
+        assert plugin.base_url == 'http://192.168.1.100:52199/MCWS/v1'
+        mock_test.assert_called_once()
+        mock_auth.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_start_connection_failure(jriver_bootstrap):
+    """Test start() with connection failure"""
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    
+    with patch.object(plugin, '_test_connection', return_value=False):
+        result = await plugin.start()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_start_auth_failure(jriver_bootstrap):
+    """Test start() with authentication failure"""
+    plugin = nowplaying.inputs.jriver.Plugin(config=jriver_bootstrap) # pylint: disable=no-member
+    
+    with patch.object(plugin, '_test_connection', return_value=True), \
+         patch.object(plugin, '_authenticate', return_value=False):
+        
+        result = await plugin.start()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_test_connection_success():
+    """Test successful connection test"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.access_key = 'testkey'
+    
+    # Mock aiohttp session
+    mock_session = AsyncMock()
+    plugin.session = mock_session
+    
+    mock_response = create_mock_response(
+        status=200,
+        text='''
+        <Response Status="OK">
+            <Item Name="AccessKey">testkey</Item>
+        </Response>
+        '''
+    )
+    
+    # Set up the async context manager properly
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__.return_value = mock_response
+    mock_context_manager.__aexit__.return_value = None
+    mock_session.get.return_value = mock_context_manager
+    
+    result = await plugin._test_connection()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_test_connection_wrong_access_key():
+    """Test connection test with wrong access key"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.access_key = 'wrongkey'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '''
+    <Response Status="OK">
+        <Item Name="AccessKey">correctkey</Item>
+    </Response>
+    '''
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin._test_connection()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_test_connection_http_error():
+    """Test connection test with HTTP error"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin._test_connection()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_test_connection_network_error():
+    """Test connection test with network error"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    
+    with patch('nowplaying.inputs.jriver.requests.get', side_effect=Exception('Connection failed')):
+        result = await plugin._test_connection()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_success():
+    """Test successful authentication"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.username = 'testuser'
+    plugin.password = 'testpass'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '''
+    <Response Status="OK">
+        <Item Name="Token">abc123token</Item>
+    </Response>
+    '''
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin._authenticate()
+        assert result is True
+        assert plugin.token == 'abc123token'
+
+
+@pytest.mark.asyncio
+async def test_authenticate_no_credentials():
+    """Test authentication with no credentials"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.username = None
+    plugin.password = None
+    
+    result = await plugin._authenticate()
+    assert result is True  # Should succeed when no auth is needed
+
+
+@pytest.mark.asyncio
+async def test_authenticate_no_token():
+    """Test authentication with no token in response"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.username = 'testuser'
+    plugin.password = 'testpass'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '''
+    <Response Status="OK">
+    </Response>
+    '''
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin._authenticate()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_http_error():
+    """Test authentication with HTTP error"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.username = 'testuser'
+    plugin.password = 'testpass'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin._authenticate()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_no_base_url():
+    """Test getplayingtrack with no base URL"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = None
+    
+    result = await plugin.getplayingtrack()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_success():
+    """Test successful getplayingtrack"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.token = 'testtoken'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '''
+    <Response Status="OK">
+        <Item Name="State">Playing</Item>
+        <Item Name="Artist">The Beatles</Item>
+        <Item Name="Album">Abbey Road</Item>
+        <Item Name="Name">Come Together</Item>
+        <Item Name="DurationMS">240000</Item>
+    </Response>
+    '''
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin.getplayingtrack()
+        
+        assert result['artist'] == 'The Beatles'
+        assert result['album'] == 'Abbey Road'
+        assert result['title'] == 'Come Together'
+        assert result['duration'] == 240  # 240000ms / 1000
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_minimal_data():
+    """Test getplayingtrack with minimal data"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '''
+    <Response Status="OK">
+        <Item Name="Name">Unknown Track</Item>
+    </Response>
+    '''
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin.getplayingtrack()
+        
+        assert result['title'] == 'Unknown Track'
+        assert result.get('artist') is None
+        assert result.get('album') is None
+        assert result.get('duration') is None
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_http_error():
+    """Test getplayingtrack with HTTP error"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin.getplayingtrack()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_network_error():
+    """Test getplayingtrack with network error"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    
+    with patch('nowplaying.inputs.jriver.requests.get', side_effect=Exception('Network error')):
+        result = await plugin.getplayingtrack()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_parse_error():
+    """Test getplayingtrack with XML parse error"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = 'invalid xml content'
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response):
+        result = await plugin.getplayingtrack()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_with_token():
+    """Test getplayingtrack includes token in request"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.token = 'mytoken123'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '<Response Status="OK"></Response>'
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response) as mock_get:
+        await plugin.getplayingtrack()
+        
+        # Verify token was included in the request
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert call_args[1]['params']['Token'] == 'mytoken123'
+
+
+@pytest.mark.asyncio
+async def test_getplayingtrack_without_token():
+    """Test getplayingtrack without token"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    plugin.base_url = 'http://localhost:52199/MCWS/v1'
+    plugin.token = None
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '<Response Status="OK"></Response>'
+    
+    with patch('nowplaying.inputs.jriver.requests.get', return_value=mock_response) as mock_get:
+        await plugin.getplayingtrack()
+        
+        # Verify no token in params
+        call_args = mock_get.call_args
+        assert 'Token' not in call_args[1]['params']
+
+
+@pytest.mark.asyncio
+async def test_getrandomtrack():
+    """Test getrandomtrack returns None"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    result = await plugin.getrandomtrack('test')
+    assert result is None
+
+
+def test_connect_settingsui():
+    """Test connect_settingsui method"""
+    plugin = nowplaying.inputs.jriver.Plugin() # pylint: disable=no-member
+    mock_qwidget = MagicMock()
+    mock_uihelp = MagicMock()
+    
+    plugin.connect_settingsui(mock_qwidget, mock_uihelp)
+    
+    assert plugin.qwidget == mock_qwidget
+    assert plugin.uihelp == mock_uihelp

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -176,7 +176,7 @@ async def test_start_success(jriver_bootstrap):  # pylint: disable=redefined-out
         assert plugin.host == '192.168.1.100'
         assert plugin.port == '52199'
         assert plugin.username == 'testuser'
-        assert plugin.password == 'testpass'
+        assert plugin.password == 'testpass'  # pragma: allowlist secret
         assert plugin.access_key == 'testkey'
         assert plugin.base_url == 'http://192.168.1.100:52199/MCWS/v1'
         assert plugin.session is not None  # Session should remain open on success
@@ -321,7 +321,7 @@ async def test_authenticate_success():
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.username = 'testuser'
-    plugin.password = 'testpass'
+    plugin.password = 'testpass'  # pragma: allowlist secret
 
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
@@ -359,7 +359,7 @@ async def test_authenticate_no_token():
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.username = 'testuser'
-    plugin.password = 'testpass'
+    plugin.password = 'testpass'  # pragma: allowlist secret
 
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
@@ -384,7 +384,7 @@ async def test_authenticate_http_error():
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = 'http://localhost:52199/MCWS/v1'
     plugin.username = 'testuser'
-    plugin.password = 'testpass'
+    plugin.password = 'testpass'  # pragma: allowlist secret
 
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new input plugin for JRiver Media Center that connects over MCWS, handles authentication, retrieves currently playing track metadata (including local file paths on local connections), and integrates with the application’s settings UI.

New Features:
- Add JRiver Media Center input plugin supporting connection, authentication, and track retrieval via the MCWS API
- Detect and format IPv6 addresses and determine local connections for filename resolution
- Integrate plugin settings into the UI with configurable host, port, credentials, and access key

Enhancements:
- Provide Qt UI resource file for JRiver plugin configuration

Build:
- Include aioresponses and lxml in test requirements

Tests:
- Add comprehensive tests for plugin initialization, settings UI load/save, connection/auth flows, playback info parsing, filename retrieval, host formatting, and local connection detection