### PR TITLE
Add Kick streaming platform support and wikiclient batch processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## Version 4.2.0 - In Progress
 
+* **NEW: Kick.com Integration** - Initial support for Kick.com streaming platform:
+  * OAuth2 authentication with Kick.com
+  * Template-based track announcements to chat
+  * Smart message splitting at sentence and word boundaries
+  * Support for `{{ startnewmessage }}` template tag for multi-part messages
+  * NLTK-powered intelligent message splitting preserving full content
+  * Interactive chat commands and user permissions coming soon
 * New input plugin for JRiver Media Center via MCWS API support.
 * FIXED: Windows subprocess shutdown errors (BrokenPipeError [WinError 232])
   that occurred when multiprocessing.Manager() closed pipes before subprocesses finished.
@@ -15,6 +22,10 @@
 * Error logging for when wikimedia attempts to continue
   but the program doesn't handle it.
 * A few minor template changes.
+* **Enhanced Twitch Chat** - Improved message handling:
+  * NLTK-powered intelligent message splitting at sentence and word boundaries
+  * Preserves full message content by splitting long messages into multiple parts
+  * Enhanced `{{ startnewmessage }}` support with automatic overflow splitting
 * Twitch scope has changed and may request new permissions.
 * Twitch scope is no longer saved in the configuration to allow
   for a future update to the Twitch code.

--- a/analyze_audio_metadata.py
+++ b/analyze_audio_metadata.py
@@ -180,20 +180,15 @@ def compare_metadata(tinytag_data: dict, audio_metadata_data: dict) -> dict[str,
 def main():
     """Main analysis function."""
     parser = argparse.ArgumentParser(
-        description='Analyze audio metadata using tinytag and audio_metadata libraries'
-    )
-    parser.add_argument(
-        '--audio-dir',
-        type=Path,
-        default=None,
-        help='Directory containing audio files to analyze (default: ./tests/audio)'
-    )
-    parser.add_argument(
-        '--output-file',
-        type=Path,
-        default=None,
-        help='Output JSON file path (default: ./metadata_analysis_results.json)'
-    )
+        description='Analyze audio metadata using tinytag and audio_metadata libraries')
+    parser.add_argument('--audio-dir',
+                        type=Path,
+                        default=None,
+                        help='Directory containing audio files to analyze (default: ./tests/audio)')
+    parser.add_argument('--output-file',
+                        type=Path,
+                        default=None,
+                        help='Output JSON file path (default: ./metadata_analysis_results.json)')
 
     args = parser.parse_args()
 
@@ -229,8 +224,8 @@ def main():
         result['comparison'] = compare_metadata(result['tinytag'], result['audio_metadata'])
 
         tinytag_field_count = len([k for k in result['tinytag'] if not k.endswith('_info')])
-        audio_metadata_field_count = len([k for k in result['audio_metadata']
-                                         if not k.endswith('_info')])
+        audio_metadata_field_count = len(
+            [k for k in result['audio_metadata'] if not k.endswith('_info')])
         print(f"  - TinyTag fields: {tinytag_field_count}")
         print(f"  - audio_metadata fields: {audio_metadata_field_count}")
         if 'error' in result['tinytag']:

--- a/docs/output/index.rst
+++ b/docs/output/index.rst
@@ -9,6 +9,7 @@ Outputs
 
    textoutput
    discord
+   kickbot
    obswebsocket
    twitchbot
    webserver

--- a/docs/output/kickbot.rst
+++ b/docs/output/kickbot.rst
@@ -1,0 +1,73 @@
+KickBot
+=======
+
+**What's Now Playing** integrates with Kick.com to provide chat bot functionality with track announcements.
+
+Kick Chat Support
+------------------
+
+The current Kick integration supports:
+
+* **Track Announcements**: Automatic announcements when tracks change
+* **Template-based Messages**: Rich formatting with metadata variables
+* **Smart Message Splitting**: Intelligent splitting of long messages
+
+**Coming Soon**: Interactive chat commands and user input processing.
+
+Authentication
+--------------
+
+To use Kick.com integration, you'll need to set up OAuth2 authentication with your Kick account.
+
+#. Go to the Kick Developer Portal to register **What's Now Playing** as an application.
+#. Create a new OAuth2 application and note down:
+
+   * Client ID
+   * Client Secret
+   * Redirect URI (typically ``http://localhost:8899/kickredirect``)
+
+#. Scopes Requested should include the following for current and future features:
+
+   * Read user information (including email address) - ``user:read``
+   * Write to chat feed - ``chat:write``
+   * Subscribe to events (read chat feed, follows, subscribes, gifts) - ``events:subscribe``
+
+#. In **What's Now Playing** settings:
+
+   * Enter your Client ID and Client Secret
+   * Set your Kick channel name
+   * Configure the Redirect URI
+   * Click "Authenticate with Kick" to complete OAuth2 setup
+
+Template Features
+-----------------
+
+Kick templates support powerful formatting features:
+
+* **Template Variables**: All standard metadata variables (``{{ artist }}``, ``{{ title }}``, etc.)
+* **Message Splitting**: Use ``{{ startnewmessage }}`` to split long announcements across multiple messages
+* **Smart Splitting**: Messages longer than 500 characters are automatically split at sentence or word boundaries using NLTK
+
+Example announcement template::
+
+    {% if artist %}{{ artist }} - {% endif %}"{{ title }}"
+    {% if album %} from {{ album }}{% endif %}
+    {{ startnewmessage }}
+    {% if artistshortbio %}{{ artistshortbio }}{% endif %}
+
+Configuration
+-------------
+
+#. Enable Kick chat in the Kick settings tab
+#. Configure your OAuth2 credentials
+#. Set up your announcement template
+#. Configure announcement delay if needed
+#. Test the connection with the "Authenticate with Kick" button
+
+Current Limitations
+-------------------
+
+* **Chat Commands**: Interactive commands are not yet implemented (coming soon)
+* **Permissions**: User permission system will be added with command support
+
+The Kick integration uses the same intelligent message splitting technology as the enhanced Twitch integration, ensuring that long messages with rich metadata are delivered in full while respecting platform limits.

--- a/example_cache_usage.py
+++ b/example_cache_usage.py
@@ -65,13 +65,11 @@ async def demo_cached_fetch():
     # First call - cache miss
     print("\n1. First cached_fetch call (cache miss):")
     start_time = time.time()
-    data = await nowplaying.apicache.cached_fetch(
-        provider='demo',
-        artist_name='Deadmau5',
-        endpoint='artist_bio',
-        fetch_func=lambda: fetch_artist_bio('Deadmau5'),
-        ttl_seconds=300
-    )
+    data = await nowplaying.apicache.cached_fetch(provider='demo',
+                                                  artist_name='Deadmau5',
+                                                  endpoint='artist_bio',
+                                                  fetch_func=lambda: fetch_artist_bio('Deadmau5'),
+                                                  ttl_seconds=300)
     elapsed = time.time() - start_time
     print(f"   ⏱️  Time: {elapsed:.2f}s")
     print(f"   📄 Data: {data}")
@@ -79,13 +77,11 @@ async def demo_cached_fetch():
     # Second call - cache hit
     print("\n2. Second cached_fetch call (cache hit):")
     start_time = time.time()
-    data = await nowplaying.apicache.cached_fetch(
-        provider='demo',
-        artist_name='Deadmau5',
-        endpoint='artist_bio',
-        fetch_func=lambda: fetch_artist_bio('Deadmau5'),
-        ttl_seconds=300
-    )
+    data = await nowplaying.apicache.cached_fetch(provider='demo',
+                                                  artist_name='Deadmau5',
+                                                  endpoint='artist_bio',
+                                                  fetch_func=lambda: fetch_artist_bio('Deadmau5'),
+                                                  ttl_seconds=300)
     elapsed = time.time() - start_time
     print(f"   ⏱️  Time: {elapsed:.2f}s")
     print(f"   📄 Data: {data}")

--- a/nowplaying/apicache.py
+++ b/nowplaying/apicache.py
@@ -162,11 +162,7 @@ class APIResponseCache:
 
     @staticmethod
     async def _process_cache_hit(  # pylint: disable=too-many-arguments
-            data: str,
-            provider: str,
-            artist_name: str,
-            endpoint: str,
-            expires_at: int,
+            data: str, provider: str, artist_name: str, endpoint: str, expires_at: int,
             current_time: int) -> t.Optional[dict]:
         """Process a cache hit and return the deserialized data."""
         try:

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -51,19 +51,20 @@ class Plugin(ArtistExtrasPlugin):
         """Cached version of discogs search_async."""
 
         async def fetch_func():
-            result = await self.client.search_async(album_title, artist=artist_name,
-                                                   search_type=search_type)
+            result = await self.client.search_async(album_title,
+                                                    artist=artist_name,
+                                                    search_type=search_type)
             # Convert to JSON-serializable format for caching
             if hasattr(result, 'results'):
                 return {
-                    'results': [
-                        {
-                            'type': 'release' if isinstance(r, models.Release) else 'unknown',
-                            'data': r.data if hasattr(r, 'data') else r,
-                            'artists': [a.data if hasattr(a, 'data') else a
-                                       for a in getattr(r, 'artists', [])]
-                        } for r in result.results
-                    ]
+                    'results': [{
+                        'type':
+                        'release' if isinstance(r, models.Release) else 'unknown',
+                        'data':
+                        r.data if hasattr(r, 'data') else r,
+                        'artists':
+                        [a.data if hasattr(a, 'data') else a for a in getattr(r, 'artists', [])]
+                    } for r in result.results]
                 }
             return result
 
@@ -80,6 +81,7 @@ class Plugin(ArtistExtrasPlugin):
             # Create a mock search result with reconstructed Release objects
             class MockSearchResult:  # pylint: disable=too-few-public-methods
                 """Mock search result with reconstructed Release objects."""
+
                 def __init__(self, results):
                     self.results = []
                     for item in results:
@@ -87,8 +89,9 @@ class Plugin(ArtistExtrasPlugin):
                             # Reconstruct Release object
                             release = models.Release(item['data'])
                             # Reconstruct artist objects
-                            release.artists = [models.Artist(artist_data)
-                                              for artist_data in item['artists']]
+                            release.artists = [
+                                models.Artist(artist_data) for artist_data in item['artists']
+                            ]
                             self.results.append(release)
 
                 def page(self, page_num):  # pylint: disable=unused-argument

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -97,8 +97,8 @@ class Plugin(ArtistExtrasPlugin):
         """Process and queue artist images from FanartTV data."""
         identifier = metadata['imagecacheartist']
         # Process banners
-        if (artist_data.get('musicbanner') and
-            self.config.cparser.value('fanarttv/banners', type=bool)):
+        if (artist_data.get('musicbanner')
+                and self.config.cparser.value('fanarttv/banners', type=bool)):
             self._queue_images(artist_data['musicbanner'], identifier, 'artistbanner', imagecache)
 
         # Process logos (prefer HD, fallback to regular)
@@ -108,16 +108,16 @@ class Plugin(ArtistExtrasPlugin):
                 self._queue_images(logo_data, identifier, 'artistlogo', imagecache)
 
         # Process thumbnails
-        if (artist_data.get('artistthumb') and
-            self.config.cparser.value('fanarttv/thumbnails', type=bool)):
+        if (artist_data.get('artistthumb')
+                and self.config.cparser.value('fanarttv/thumbnails', type=bool)):
             self._queue_images(artist_data['artistthumb'], identifier, 'artistthumbnail',
                                imagecache)
 
         # Process fanart backgrounds
-        if (self.config.cparser.value('fanarttv/fanart', type=bool) and
-            artist_data.get('artistbackground')):
-            self._process_fanart_backgrounds(artist_data['artistbackground'], metadata,
-                                              identifier, imagecache)
+        if (self.config.cparser.value('fanarttv/fanart', type=bool)
+                and artist_data.get('artistbackground')):
+            self._process_fanart_backgrounds(artist_data['artistbackground'], metadata, identifier,
+                                             imagecache)
 
     def _queue_images(self, image_list, identifier, image_type, imagecache):
         """Queue images sorted by popularity (likes)."""

--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -95,8 +95,8 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
 
     def _extract_bio_data(self, extradata, metadata):
         ''' Extract biography data from TheAudioDB response '''
-        if (metadata.get('artistlongbio') or
-            not self.config.cparser.value('theaudiodb/bio', type=bool)):
+        if (metadata.get('artistlongbio')
+                or not self.config.cparser.value('theaudiodb/bio', type=bool)):
             return ''
 
         lang1 = self.config.cparser.value('theaudiodb/bio_iso')
@@ -129,18 +129,24 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
         ''' Handle image data from TheAudioDB response '''
         self._queue_single_image(artdata, metadata, imagecache, 'strArtistBanner',
                                  'artistbannerraw', 'artistbanner', 'banners')
-        self._queue_single_image(artdata, metadata, imagecache, 'strArtistLogo',
-                                 'artistlogoraw', 'artistlogo', 'logos')
+        self._queue_single_image(artdata, metadata, imagecache, 'strArtistLogo', 'artistlogoraw',
+                                 'artistlogo', 'logos')
         self._queue_single_image(artdata, metadata, imagecache, 'strArtistThumb',
                                  'artistthumbnailraw', 'artistthumbnail', 'thumbnails')
         self._handle_fanart_data(artdata, metadata, imagecache)
 
-    def _queue_single_image(self, artdata, metadata, imagecache, source_key, # pylint: disable=too-many-arguments
-                           metadata_key, image_type, config_key):
+    def _queue_single_image(  # pylint: disable=too-many-arguments
+            self,
+            artdata,
+            metadata,
+            imagecache,
+            source_key,
+            metadata_key,
+            image_type,
+            config_key):
         ''' Queue a single image type from TheAudioDB data '''
-        if (metadata.get(metadata_key)
-            or not artdata.get(source_key)
-            or not self.config.cparser.value(f'theaudiodb/{config_key}', type=bool)):
+        if (metadata.get(metadata_key) or not artdata.get(source_key)
+                or not self.config.cparser.value(f'theaudiodb/{config_key}', type=bool)):
             return
 
         imagecache.fill_queue(config=self.config,
@@ -181,8 +187,8 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
 
             corrected_artist = artdata['strArtist']
             if corrected_artist != metadata['artist']:
-                logging.debug('TheAudioDB corrected artist name: %s -> %s',
-                              metadata['artist'], corrected_artist)
+                logging.debug('TheAudioDB corrected artist name: %s -> %s', metadata['artist'],
+                              corrected_artist)
                 metadata['artist'] = corrected_artist
             break
 
@@ -211,6 +217,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
         # Cache individual artist by their unique TheAudioDB ID
         async def fetch_func():
             return artist_data  # Already have the data, just cache it
+
         return await nowplaying.apicache.cached_fetch(
             provider='theaudiodb',
             artist_name=artist_name,

--- a/nowplaying/artistextras/wikimedia.py
+++ b/nowplaying/artistextras/wikimedia.py
@@ -72,6 +72,7 @@ class Plugin(ArtistExtrasPlugin):
             # Create a mock WikiPage with the cached data
             class MockWikiPage:  # pylint: disable=too-few-public-methods
                 """Mock WikiPage with cached data."""
+
                 def __init__(self, entity, lang, data, images):
                     self.entity = entity
                     self.lang = lang
@@ -82,15 +83,10 @@ class Plugin(ArtistExtrasPlugin):
                     """Return images with specified fields."""
                     if fields is None:
                         return self._images
-                    return [{k: img.get(k) for k in fields if k in img}
-                            for img in self._images]
+                    return [{k: img.get(k) for k in fields if k in img} for img in self._images]
 
-            return MockWikiPage(
-                cached_result['entity'],
-                cached_result['lang'],
-                cached_result['data'],
-                cached_result['images']
-            )
+            return MockWikiPage(cached_result['entity'], cached_result['lang'],
+                                cached_result['data'], cached_result['images'])
 
         return cached_result
 
@@ -128,9 +124,10 @@ class Plugin(ArtistExtrasPlugin):
 
         return page
 
-    async def download_async(self,  # pylint: disable=too-many-branches,too-many-locals
-                             metadata=None,
-                             imagecache: "nowplaying.imagecache.ImageCache" = None):
+    async def download_async(   # pylint: disable=too-many-branches,too-many-locals
+            self,
+            metadata=None,
+            imagecache: "nowplaying.imagecache.ImageCache" = None):
         ''' async download content '''
 
         async def _get_bio_async():
@@ -153,8 +150,9 @@ class Plugin(ArtistExtrasPlugin):
         try:  # pylint: disable=too-many-nested-blocks
             # Safely handle artistwebsites - filter out None/empty values
             artist_websites = metadata.get('artistwebsites', [])
-            wikidata_websites = [url for url in artist_websites
-                               if url and isinstance(url, str) and 'wikidata' in url]
+            wikidata_websites = [
+                url for url in artist_websites if url and isinstance(url, str) and 'wikidata' in url
+            ]
             if not wikidata_websites:
                 logging.debug('no wikidata entity')
                 return None

--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -69,9 +69,8 @@ def setuplogging(logdir=None, logname='debug.log', rotate=False):
         logfhandler.doRollover()
 
     logging.basicConfig(
-        format=
-        '%(asctime)s %(levelname)s %(process)d %(processName)s/%(threadName)s '
-        + '%(module)s:%(funcName)s:%(lineno)d %(message)s',
+        format='%(asctime)s %(levelname)s %(process)d %(processName)s/%(threadName)s ' +
+        '%(module)s:%(funcName)s:%(lineno)d %(message)s',
         datefmt='%Y-%m-%dT%H:%M:%S%z',
         handlers=[logfhandler],
         level=logging.DEBUG)

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -20,7 +20,6 @@ import nowplaying.artistextras
 import nowplaying.inputs
 import nowplaying.pluginimporter
 import nowplaying.recognition
-import nowplaying.utils
 import nowplaying.version  # pylint: disable=no-name-in-module,import-error
 
 
@@ -136,6 +135,32 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
                              QCoreApplication.organizationName(),
                              QCoreApplication.applicationName())
 
+        self._defaults_artistextras(settings)
+        self._defaults_recognition(settings)
+        self._defaults_general_settings(settings)
+        self._defaults_output(settings)
+        self._defaults_chat_services(settings)
+        self._defaults_quirks(settings)
+        self._defaults_plugins(settings)
+
+    def _initial_plugins(self):
+
+        self.plugins['inputs'] = nowplaying.pluginimporter.import_plugins(nowplaying.inputs)
+        if self.beam and self.plugins['inputs']['nowplaying.inputs.beam']:
+            del self.plugins['inputs']['nowplaying.inputs.beam']
+        self.pluginobjs['inputs'] = {}
+        self.plugins['recognition'] = nowplaying.pluginimporter.import_plugins(
+            nowplaying.recognition)
+        self.pluginobjs['recognition'] = {}
+
+        if not self.beam:
+            self.plugins['artistextras'] = nowplaying.pluginimporter.import_plugins(
+                nowplaying.artistextras)
+            self.pluginobjs['artistextras'] = {}
+
+    @staticmethod
+    def _defaults_artistextras(settings):
+        ''' default values for artist extras '''
         settings.setValue('artistextras/enabled', True)
         for field in ['banners', 'logos', 'thumbnails']:
             settings.setValue(f'artistextras/{field}', 2)
@@ -152,17 +177,23 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         settings.setValue('artistextras/coverfornothumbs', True)
         settings.setValue('artistextras/nocoverfallback', 'none')
 
+    @staticmethod
+    def _defaults_recognition(settings):
+        ''' default values for recognition '''
         settings.setValue('recognition/replacetitle', False)
         settings.setValue('recognition/replaceartist', False)
-
         settings.setValue('setlist/enabled', False)
 
+    def _defaults_general_settings(self, settings):
+        ''' default values for general settings '''
         settings.setValue('settings/delay', '1.0')
         settings.setValue('settings/initialized', False)
         settings.setValue('settings/loglevel', self.loglevel)
         settings.setValue('settings/notif', self.notif)
         settings.setValue('settings/stripextras', False)
 
+    def _defaults_output(self, settings):
+        ''' default values for output settings '''
         settings.setValue('textoutput/file', None)
         settings.setValue('textoutput/txttemplate', self.txttemplate)
         settings.setValue('textoutput/clearonstartup', True)
@@ -192,28 +223,20 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         settings.setValue('weboutput/httpport', '8899')
         settings.setValue('weboutput/once', True)
 
+    def _defaults_chat_services(self, settings):
+        ''' default values for chat services '''
         settings.setValue('twitchbot/enabled', False)
+        settings.setValue('kick/enabled', False)
+        settings.setValue('kick/chat', False)
+        settings.setValue('kick/announce', str(self.templatedir.joinpath("kickbot_track.txt")))
+        settings.setValue('kick/announcedelay', 1.0)
 
+    @staticmethod
+    def _defaults_quirks(settings):
+        ''' default values for quirks '''
         settings.setValue('quirks/pollingobserver', False)
         settings.setValue('quirks/filesubst', False)
         settings.setValue('quirks/slashmode', 'nochange')
-
-        self._defaults_plugins(settings)
-
-    def _initial_plugins(self):
-
-        self.plugins['inputs'] = nowplaying.pluginimporter.import_plugins(nowplaying.inputs)
-        if self.beam and self.plugins['inputs']['nowplaying.inputs.beam']:
-            del self.plugins['inputs']['nowplaying.inputs.beam']
-        self.pluginobjs['inputs'] = {}
-        self.plugins['recognition'] = nowplaying.pluginimporter.import_plugins(
-            nowplaying.recognition)
-        self.pluginobjs['recognition'] = {}
-
-        if not self.beam:
-            self.plugins['artistextras'] = nowplaying.pluginimporter.import_plugins(
-                nowplaying.artistextras)
-            self.pluginobjs['artistextras'] = {}
 
     def _defaults_plugins(self, settings):
         ''' configure the defaults for plugins '''

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -297,7 +297,7 @@ class Plugin(InputPlugin):  #pylint: disable=too-many-instance-attributes
         self.config.cparser.setValue('jriver/username', qwidget.username_lineedit.text().strip())
         self.config.cparser.setValue('jriver/password', qwidget.password_lineedit.text().strip())
         self.config.cparser.setValue('jriver/access_key',
-                                      qwidget.access_key_lineedit.text().strip())
+                                     qwidget.access_key_lineedit.text().strip())
 
     def desc_settingsui(self, qwidget):
         ''' description '''

--- a/nowplaying/inputs/serato.py
+++ b/nowplaying/inputs/serato.py
@@ -571,8 +571,8 @@ class SeratoHandler():  #pylint: disable=too-many-instance-attributes
         for track_div in track_divs[:3]:  # Check first 3 tracks
             text_content = track_div.text_content()
             # Look for "Artist - Title" pattern
-            if ((match := re.search(r'([^-\n]+)\s*-\s*([^-\n]+)', text_content)) and
-                    len(match[0].strip()) > 10):  # Reasonable length
+            if ((match := re.search(r'([^-\n]+)\s*-\s*([^-\n]+)', text_content))
+                    and len(match[0].strip()) > 10):  # Reasonable length
                 result = match[0].strip()
                 logging.debug("Method 3 success: Text pattern matching")
                 return result
@@ -584,8 +584,8 @@ class SeratoHandler():  #pylint: disable=too-many-instance-attributes
         all_text = tree.xpath('//text()[contains(., " - ")]')
         for text in all_text:
             cleaned = text.strip()
-            if (len(cleaned) > 10 and
-                not any(skip in cleaned.lower() for skip in ['copyright', 'serato', 'playlist'])):
+            if (len(cleaned) > 10 and not any(skip in cleaned.lower()
+                                              for skip in ['copyright', 'serato', 'playlist'])):
                 logging.debug("Method 4 success: Text fallback search")
                 return cleaned
         return None

--- a/nowplaying/kick/__init__.py
+++ b/nowplaying/kick/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+''' kick module '''

--- a/nowplaying/kick/chat.py
+++ b/nowplaying/kick/chat.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+''' handle kick chat '''
+
+import asyncio
+import datetime
+import logging
+import pathlib
+from typing import Any
+
+import aiohttp
+import jinja2
+
+from PySide6.QtCore import QCoreApplication, QStandardPaths  # pylint: disable=no-name-in-module
+
+import nowplaying.config
+import nowplaying.db
+import nowplaying.kick.oauth2
+import nowplaying.utils
+
+LASTANNOUNCED: dict[str, str | None] = {'artist': None, 'title': None}
+SPLITMESSAGETEXT = '****SPLITMESSSAGEHERE****'
+KICK_MESSAGE_LIMIT = 500  # Character limit for Kick messages
+
+
+class KickChat:  # pylint: disable=too-many-instance-attributes
+    ''' handle kick chat '''
+
+    def __init__(self,
+                 config: nowplaying.config.ConfigFile | None = None,
+                 stopevent: asyncio.Event | None = None) -> None:
+        self.config = config
+        self.stopevent = stopevent or asyncio.Event()
+        self.watcher: Any = None
+        self.metadb: nowplaying.db.MetadataDB = nowplaying.db.MetadataDB()
+        self.templatedir = pathlib.Path(
+            QStandardPaths.standardLocations(QStandardPaths.DocumentsLocation)[0]).joinpath(
+                QCoreApplication.applicationName(), 'templates')
+        self.jinja2: jinja2.Environment = self.setup_jinja2(self.templatedir)
+        self.jinja2ann: jinja2.Environment = self.setup_jinja2(self.templatedir)
+        self.anndir: pathlib.Path | None = None
+        self.oauth: nowplaying.kick.oauth2.KickOAuth2 | None = None
+        self.tasks: set[asyncio.Task[Any]] = set()
+        self.starttime: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
+        self.timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=60)
+        self.authenticated: bool = False
+        self._watcher_lock: asyncio.Lock = asyncio.Lock()
+        self._watcher_running: bool = False
+
+        # Kick API endpoints
+        self.api_base: str = "https://api.kick.com/public/v1"
+
+    async def _authenticate(self) -> bool:
+        ''' authenticate with kick using stored tokens '''
+        if not self.oauth:
+            self.oauth = nowplaying.kick.oauth2.KickOAuth2(self.config)
+
+        # Check if we have valid tokens
+        access_token, refresh_token = self.oauth.get_stored_tokens()
+        if access_token:
+            # Validate the token
+            validation_result = await self.oauth.validate_token(access_token)
+            if validation_result:
+                self.authenticated = True
+                logging.info('Kick chat authentication successful')
+                return True
+
+            if refresh_token:
+                # Try to refresh the token
+                try:
+                    await self.oauth.refresh_access_token(refresh_token)
+                    self.authenticated = True
+                    logging.info('Kick chat token refreshed successfully')
+                    return True
+                except Exception as error:# pylint: disable=broad-exception-caught
+                    logging.warning('Failed to refresh Kick token: %s', error)
+
+        logging.error('No valid Kick tokens available for chat')
+        return False
+
+    async def _send_message(self, message: str) -> bool:
+        ''' send a message to kick chat using official API '''
+        logging.info('Attempting to send message to Kick chat: "%s"', message)
+
+        if not self.authenticated:
+            logging.error('Cannot send message: not authenticated')
+            return False
+
+        access_token, _ = self.oauth.get_stored_tokens()
+        if not access_token:
+            logging.error('Cannot send message: no access token')
+            return False
+
+        # Clean up message content to avoid JSON issues
+        if not message or not message.strip():
+            logging.warning('Empty message content, skipping send')
+            return False
+
+        # Remove control characters and ensure valid UTF-8
+        cleaned_message = ''.join(char for char in message if ord(char) >= 32 or char in '\n\r\t')
+
+        # Use smart splitting instead of truncation
+        message_parts = nowplaying.utils.smart_split_message(cleaned_message, KICK_MESSAGE_LIMIT)
+
+        if len(message_parts) > 1:
+            logging.info('Message split into %d parts for Kick limits', len(message_parts))
+
+        # Send all message parts with rate limiting
+        success = True
+        for i, part in enumerate(message_parts):
+            if not await self._send_single_message(part):
+                success = False
+                logging.error('Failed to send message part %d/%d', i + 1, len(message_parts))
+
+            # Add delay between message parts to avoid rate limiting/spam detection
+            # Skip delay after the last message
+            if i < len(message_parts) - 1:
+                await asyncio.sleep(1.0)  # 1 second delay between parts
+
+        return success
+
+    async def _send_single_message(self, message: str) -> bool:
+        ''' send a single message to kick chat (internal method) '''
+        access_token, _ = self.oauth.get_stored_tokens()
+        if not access_token:
+            return False
+
+        try:
+            headers = {
+                'Authorization': f'Bearer {access_token}',
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+
+            # Use correct Kick API format from documentation
+            # For bots: broadcaster_user_id is not required, type should be 'bot'
+            data = {'content': message, 'type': 'bot'}
+
+            url = f"{self.api_base}/chat"  # POST /public/v1/chat
+            logging.debug('Sending message to: %s', url)
+            logging.debug('Message content: %r', message)
+            logging.debug('Message data: %s', data)
+            logging.debug('Headers: %s', headers)
+
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.post(url, headers=headers, json=data) as response:
+                    response_text = await response.text()
+                    logging.debug('Send message API response: status=%s, body=%s', response.status,
+                                  response_text)
+
+                    if response.status in [200, 201]:
+                        logging.info('Successfully sent message to Kick chat: "%s"', message)
+                        return True
+
+                    if response.status == 401:
+                        self.authenticated = False
+                        logging.warning('Kick token expired while sending message')
+                        return False
+
+                    if response.status == 403:
+                        logging.error(
+                            'Forbidden to send message - check bot permissions in channel')
+                        return False
+
+                    logging.error('Failed to send message: %s - %s', response.status,
+                                  response_text)
+                    return False
+
+        except Exception as error: # pylint: disable=broad-exception-caught
+            logging.exception('Error sending message to Kick: %s', error)
+            return False
+
+    async def run_chat(self, oauth_handler: nowplaying.kick.oauth2.KickOAuth2) -> None:
+        ''' main chat loop '''
+        self.oauth = oauth_handler
+
+        # Wait for chat to be enabled
+        while not self.config.cparser.value('kick/chat', type=bool) and not self.stopevent.is_set():
+            await asyncio.sleep(1)
+            self.config.get()
+
+        if self.stopevent.is_set():
+            return
+
+        connected = False
+        while not self.stopevent.is_set():
+
+            if connected and not self.authenticated:
+                logging.error('Lost Kick authentication')
+                connected = False
+
+            if connected:
+                await asyncio.sleep(60)
+                continue
+
+            try:
+                # Authenticate
+                if not await self._authenticate():
+                    await asyncio.sleep(60)
+                    continue
+
+                # Get channel name for display purposes
+                channel_name: str = self.config.cparser.value('kick/channel')
+                if not channel_name:
+                    logging.error('No Kick channel configured')
+                    await asyncio.sleep(60)
+                    continue
+
+                logging.info('Successfully authenticated with Kick. Channel: %s', channel_name)
+
+                # Send test message to verify connection
+                test_message = f'🤖 Kick bot connected! Now monitoring {channel_name} for commands.'
+                test_sent = await self._send_message(test_message)
+                if test_sent:
+                    logging.info('Test message sent successfully to Kick chat')
+                else:
+                    logging.warning('Failed to send test message to Kick chat')
+
+                connected = True
+
+                # Start announcement timer only (no chat polling)
+                loop = asyncio.get_running_loop()
+
+                # Announcement timer
+                task = loop.create_task(self._setup_timer())
+                self.tasks.add(task)
+                task.add_done_callback(self.tasks.discard)
+
+                logging.info('Kick chat announcements enabled for channel: %s', channel_name)
+
+            except Exception as error: # pylint: disable=broad-exception-caught
+                logging.exception('Kick chat error: %s', error)
+                await asyncio.sleep(60)
+                continue
+
+    @staticmethod
+    def _finalize(variable: Any) -> str:
+        ''' helper routine to avoid NoneType exceptions '''
+        if variable:
+            return variable
+        return ''
+
+    def setup_jinja2(self, directory: pathlib.Path) -> jinja2.Environment:
+        ''' set up the jinja2 environment '''
+        return jinja2.Environment(loader=jinja2.FileSystemLoader(directory),
+                                  finalize=self._finalize,
+                                  trim_blocks=True)
+
+    async def _setup_timer(self) -> None:
+        ''' setup announcement timer '''
+        async with self._watcher_lock:
+            # Prevent multiple watcher instances with proper synchronization
+            if self._watcher_running:
+                logging.debug('Kick chat watcher already running, skipping setup')
+                return
+
+            if self.watcher is not None:
+                logging.debug('Kick chat watcher already exists, stopping previous instance')
+                self.watcher.stop()
+                self.watcher = None
+
+            self.watcher = self.metadb.watcher()
+            self.watcher.start(customhandler=self._announce_track)
+            self._watcher_running = True
+
+        await self._process_announcement()
+        while not self.stopevent.is_set():
+            await asyncio.sleep(1)
+
+        logging.debug('Kick chat watcher stop event received')
+        async with self._watcher_lock:
+            if self.watcher:
+                self.watcher.stop()
+                self.watcher = None
+            self._watcher_running = False
+
+    def _announce_track(self, event: Any) -> None:  # pylint: disable=unused-argument
+        ''' handle track change announcements '''
+        logging.debug('Kick chat watcher event called')
+        try:
+            try:
+                loop = asyncio.get_running_loop()
+                task = loop.create_task(self._process_announcement())
+                self.tasks.add(task)
+                task.add_done_callback(self.tasks.discard)
+            except Exception:  # pylint: disable=broad-exception-caught
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(self._process_announcement())
+        except Exception as error: # pylint: disable=broad-exception-caught
+            logging.exception('Kick chat announcement error: %s', error)
+
+    async def _process_announcement(self) -> None:
+        ''' process track announcement logic '''
+        global LASTANNOUNCED # pylint: disable=global-statement, global-variable-not-assigned
+
+        self.config.get()
+
+        if not self.authenticated:
+            logging.debug('Kick chat not authenticated. Cannot announce.')
+            return
+
+        template_path = self._get_announcement_template()
+        if not template_path:
+            return
+
+        metadata = await self._prepare_metadata()
+        if not metadata:
+            return
+
+        if self._is_duplicate_announcement(metadata):
+            return
+
+        self._update_last_announced(metadata)
+        await self._send_announcement(template_path, metadata)
+
+    def _get_announcement_template(self) -> pathlib.Path | None:
+        ''' get and validate announcement template '''
+        anntemplstr = self.config.cparser.value('kick/announce')
+        if not anntemplstr:
+            logging.debug('Kick announcement template is not defined.')
+            return None
+
+        anntemplpath = pathlib.Path(anntemplstr)
+        if not anntemplpath.exists():
+            logging.error('Kick announcement template %s does not exist.', anntemplstr)
+            return None
+
+        if not self.anndir or self.anndir != anntemplpath.parent:
+            self.anndir = anntemplpath.parent
+            self.jinja2ann = self.setup_jinja2(self.anndir)
+
+        return anntemplpath
+
+    async def _prepare_metadata(self) -> dict | None:
+        ''' prepare metadata for announcement '''
+        metadata = await self.metadb.read_last_meta_async()
+        if not metadata:
+            logging.debug('No metadata available for Kick announcement')
+            return None
+
+        # Add startnewmessage support like Twitch
+        if 'coverimageraw' in metadata:
+            del metadata['coverimageraw']
+        metadata['startnewmessage'] = SPLITMESSAGETEXT
+        return metadata
+
+
+    @staticmethod
+    def _is_duplicate_announcement(metadata: dict) -> bool:
+        ''' check if this is a duplicate announcement '''
+        global LASTANNOUNCED # pylint: disable=global-statement, global-variable-not-assigned
+        return (LASTANNOUNCED['artist'] == metadata.get('artist')
+                and LASTANNOUNCED['title'] == metadata.get('title'))
+
+
+    @staticmethod
+    def _update_last_announced(metadata: dict) -> None:
+        ''' update last announced track '''
+        global LASTANNOUNCED # pylint: disable=global-statement, global-variable-not-assigned
+        LASTANNOUNCED['artist'] = metadata.get('artist')
+        LASTANNOUNCED['title'] = metadata.get('title')
+
+
+    async def _send_announcement(self, template_path: pathlib.Path, metadata: dict) -> None:
+        ''' generate and send announcement '''
+        try:
+            template = self.jinja2ann.get_template(template_path.name)
+            announcement = template.render(metadata)
+
+            if not announcement.strip():
+                return
+
+            await self._delay_write()
+            sent_parts = await self._send_announcement_parts(announcement)
+            logging.info('Sent Kick chat announcement (%d parts)', sent_parts)
+
+        except Exception as error: # pylint: disable=broad-exception-caught
+            logging.exception('Error generating Kick announcement: %s', error)
+
+    async def _send_announcement_parts(self, announcement: str) -> int:
+        ''' send announcement parts with rate limiting '''
+        messages = announcement.split(SPLITMESSAGETEXT)
+        sent_parts = 0
+
+        for i, message_part in enumerate(messages):
+            stripped_part = message_part.strip()
+            if not stripped_part:
+                continue
+
+            await self._send_message(stripped_part)
+            sent_parts += 1
+
+            # Add delay between announcement parts to avoid rate limiting
+            if i < len(messages) - 1:
+                await asyncio.sleep(1.5)  # Slightly longer delay for announcements
+
+        return sent_parts
+
+    async def _delay_write(self) -> None:
+        ''' handle the kick chat delay '''
+        try:
+            delay = self.config.cparser.value('kick/announcedelay', type=float, defaultValue=1.0)
+        except ValueError:
+            delay = 1.0
+        logging.debug('Kick chat delay: %s seconds', delay)
+        await asyncio.sleep(delay)
+
+    async def stop(self) -> None:
+        ''' stop kick chat '''
+        logging.debug('Stopping Kick chat')
+
+        # Cancel all tasks
+        for task in self.tasks:
+            task.cancel()
+
+        # Stop watcher and clear reference with proper synchronization
+        async with self._watcher_lock:
+            if self.watcher:
+                self.watcher.stop()
+                self.watcher = None
+            self._watcher_running = False
+
+        self.authenticated = False

--- a/nowplaying/kick/launch.py
+++ b/nowplaying/kick/launch.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+''' kick base launch code '''
+
+import asyncio
+import logging
+import signal
+import threading
+from typing import Any
+
+import nowplaying.bootstrap
+import nowplaying.config
+import nowplaying.frozen
+import nowplaying.kick.chat
+import nowplaying.kick.oauth2
+import nowplaying.kick.utils
+
+
+class KickLaunch:  # pylint: disable=too-many-instance-attributes
+    ''' handle kick integration '''
+
+    def __init__(self,
+                 config: nowplaying.config.ConfigFile | None = None,
+                 stopevent: asyncio.Event | None = None) -> None:
+        self.config = config
+        self.stopevent = stopevent or asyncio.Event()
+        self.widgets: Any = None
+        self.chat: nowplaying.kick.chat.KickChat | None = None
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.oauth: nowplaying.kick.oauth2.KickOAuth2 = nowplaying.kick.oauth2.KickOAuth2(
+            self.config)
+        self.tasks: set[asyncio.Task[Any]] = set()
+
+    async def bootstrap(self) -> None:
+        ''' Authenticate kick and launch related tasks '''
+
+        signal.signal(signal.SIGINT, self.forced_stop)
+
+        # Authenticate with Kick
+        if not await self.authenticate():
+            logging.error('Failed to authenticate with Kick')
+            return
+
+        # Now launch the actual tasks...
+        if not self.loop:
+            try:
+                self.loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self.loop = asyncio.new_event_loop()
+
+        await asyncio.sleep(5)
+
+        # Launch chat if enabled
+        if self.chat:
+            task = self.loop.create_task(self.chat.run_chat(self.oauth))
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+            await asyncio.sleep(5)
+
+    async def authenticate(self) -> bool:
+        ''' authenticate with Kick using stored tokens (no browser interaction) '''
+        try:
+            # Check if we have stored tokens
+            access_token, refresh_token = self.oauth.get_stored_tokens()
+
+            if not access_token:
+                logging.error(
+                    'No Kick access token stored - please authenticate via Settings first')
+                return False
+
+            logging.info('Validating stored Kick token...')
+
+            # Validate token using simple sync validation
+            if nowplaying.kick.utils.qtsafe_validate_kick_token(access_token):
+                logging.info('Kick token is valid - proceeding with chat')
+                return True
+
+            # Token invalid - try refresh if available
+            if refresh_token:
+                logging.info('Token invalid, attempting automatic refresh...')
+                try:
+                    _ = await self.oauth.refresh_access_token(refresh_token)
+
+                    # Re-validate the refreshed token
+                    new_access_token, _ = self.oauth.get_stored_tokens()
+                    if new_access_token and nowplaying.kick.utils.qtsafe_validate_kick_token(
+                            new_access_token):
+                        logging.info('Token refreshed successfully - proceeding with chat')
+                        return True
+
+                    logging.error('Refreshed token is still invalid')
+
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    logging.error('Failed to refresh Kick token: %s', error)
+                    logging.error('Please re-authenticate via Settings -> Kick -> Authenticate')
+            else:
+                logging.error('No refresh token available for automatic renewal')
+                logging.error('Please re-authenticate via Settings -> Kick -> Authenticate')
+
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging.error('Kick authentication error: %s', error)
+
+        return False
+
+    async def _watch_for_exit(self) -> None:
+        ''' watch for exit signal '''
+        while not self.stopevent.is_set():
+            await asyncio.sleep(1)
+        await self.stop()
+
+    def start(self) -> None:
+        ''' start kick support '''
+        try:
+            # Initialize chat
+            self.chat = nowplaying.kick.chat.KickChat(config=self.config, stopevent=self.stopevent)
+
+            if not self.loop:
+                try:
+                    self.loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    self.loop = asyncio.new_event_loop()
+
+            task = self.loop.create_task(self.bootstrap())
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+
+            task = self.loop.create_task(self._watch_for_exit())
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+
+            self.loop.run_forever()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception('Kick support crashed')
+
+    def forced_stop(self, signum: int, frame: Any) -> None:  # pylint: disable=unused-argument
+        ''' caught an int signal so tell the world to stop '''
+        self.stopevent.set()
+
+    async def stop(self) -> None:
+        ''' stop the kick support '''
+        # Stop chat
+        if self.chat:
+            await self.chat.stop()
+
+        await asyncio.sleep(1)
+
+        # Don't logout automatically - preserve tokens for next run
+        # await self.oauth.revoke_token()
+
+        if self.loop:
+            self.loop.stop()
+        logging.debug('kickbot stopped')
+
+
+def start(stopevent: asyncio.Event | None = None,
+          bundledir: str | None = None,
+          testmode: bool = False) -> None:
+    ''' multiprocessing start hook '''
+    threading.current_thread().name = 'KickBot'
+
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
+
+    if testmode:
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+    else:
+        nowplaying.bootstrap.set_qt_names()
+
+    logpath = nowplaying.bootstrap.setuplogging(logname='debug.log', rotate=False)
+    config = nowplaying.config.ConfigFile(bundledir=bundledir, logpath=logpath, testmode=testmode)
+
+    logging.info('Kick bot starting up')
+
+    try:
+        kicklaunch = KickLaunch(config=config, stopevent=stopevent)
+        kicklaunch.start()
+    except KeyboardInterrupt:
+        logging.info('Kick bot interrupted')
+    except Exception: # pylint: disable=broad-exception-caught
+        logging.exception('Kick bot crashed')
+
+
+async def launch_kickbot(config: nowplaying.config.ConfigFile | None = None,
+                         stopevent: asyncio.Event | None = None) -> None:
+    ''' launch kickbot for asyncio integration '''
+    try:
+        kicklaunch = KickLaunch(config=config, stopevent=stopevent)
+        await kicklaunch.bootstrap()
+    except Exception:  # pylint: disable=broad-exception-caught
+        logging.exception('Kick bot launch failed')
+
+    logging.info('Kick bot shutting down')
+
+
+if __name__ == "__main__":
+    start()

--- a/nowplaying/kick/launch.py
+++ b/nowplaying/kick/launch.py
@@ -30,10 +30,11 @@ class KickLaunch:  # pylint: disable=too-many-instance-attributes
             self.config)
         self.tasks: set[asyncio.Task[Any]] = set()
 
+        # Register signal handler in main thread during initialization
+        signal.signal(signal.SIGINT, self.forced_stop)
+
     async def bootstrap(self) -> None:
         ''' Authenticate kick and launch related tasks '''
-
-        signal.signal(signal.SIGINT, self.forced_stop)
 
         # Authenticate with Kick
         if not await self.authenticate():

--- a/nowplaying/kick/oauth2.py
+++ b/nowplaying/kick/oauth2.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+''' Kick OAuth2 authentication handler '''
+
+import asyncio
+import base64
+import hashlib
+import logging
+import secrets
+import urllib.parse
+import webbrowser
+from typing import Any
+
+import aiohttp
+
+import nowplaying.config
+
+
+class KickOAuth2:  # pylint: disable=too-many-instance-attributes
+    ''' Handle Kick.com OAuth 2.1 authentication flow with PKCE '''
+
+    OAUTH_HOST = 'https://id.kick.com'
+    SCOPES = ['user:read', 'chat:write', 'events:subscribe']
+
+    def __init__(self, config: nowplaying.config.ConfigFile | None = None) -> None:
+        self.config = config or nowplaying.config.ConfigFile()
+        self.client_id: str = self.config.cparser.value('kick/clientid')
+        self.client_secret: str = self.config.cparser.value('kick/secret')
+        self.redirect_uri: str = self.config.cparser.value('kick/redirecturi')
+
+        # PKCE parameters
+        self.code_verifier: str | None = None
+        self.code_challenge: str | None = None
+        self.state: str | None = None
+
+        # Tokens
+        self.access_token: str | None = None
+        self.refresh_token: str | None = None
+
+    def _generate_pkce_parameters(self) -> None:
+        ''' Generate PKCE code verifier and challenge '''
+        # Generate code verifier (43-128 characters, URL-safe)
+        self.code_verifier = base64.urlsafe_b64encode(
+            secrets.token_bytes(32)).decode('utf-8').rstrip('=')
+
+        # Generate code challenge (SHA256 hash of verifier, base64url encoded)
+        challenge_bytes = hashlib.sha256(self.code_verifier.encode('utf-8')).digest()
+        self.code_challenge = base64.urlsafe_b64encode(challenge_bytes).decode('utf-8').rstrip('=')
+
+        # Generate state parameter for CSRF protection
+        self.state = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode('utf-8').rstrip('=')
+
+        # Store PKCE parameters temporarily in config for callback handler
+        if self.config:
+            self.config.cparser.setValue('kick/temp_code_verifier', self.code_verifier)
+            self.config.cparser.setValue('kick/temp_state', self.state)
+            self.config.save()
+
+    def get_authorization_url(self, scopes: list[str] | None = None) -> str:
+        ''' Generate the authorization URL for user consent '''
+        if not self.client_id:
+            raise ValueError("Client ID is required")
+        if not self.redirect_uri:
+            raise ValueError("Redirect URI is required")
+
+        if scopes is None:
+            scopes = self.SCOPES
+
+        self._generate_pkce_parameters()
+
+        params = {
+            'client_id': self.client_id,
+            'response_type': 'code',
+            'redirect_uri': self.redirect_uri,
+            'state': self.state,
+            'scope': ' '.join(scopes),
+            'code_challenge': self.code_challenge,
+            'code_challenge_method': 'S256'
+        }
+
+        query_string = urllib.parse.urlencode(params)
+        auth_url = f"{self.OAUTH_HOST}/oauth/authorize?{query_string}"
+
+        logging.info('Generated Kick OAuth2 authorization URL')
+        return auth_url
+
+    def open_browser_for_auth(self, scopes: list[str] | None = None) -> bool:
+        ''' Open browser to initiate OAuth2 flow '''
+        auth_url = self.get_authorization_url(scopes)
+
+        try:
+            webbrowser.open(auth_url)
+            logging.info('Opened browser for Kick OAuth2 authentication')
+            return True
+        except OSError as error:
+            logging.error('Failed to open browser for Kick OAuth2: %s', error)
+            return False
+
+    async def exchange_code_for_token(self,
+                                      authorization_code: str,
+                                      received_state: str | None = None) -> dict[str, Any]:
+        ''' Exchange authorization code for access token '''
+        # Load PKCE parameters from config if not already set (for callback handler)
+        if not self.code_verifier and self.config:
+            self.code_verifier = self.config.cparser.value('kick/temp_code_verifier')
+            # State may have already been invalidated by callback handler for security
+            if not self.state:
+                self.state = self.config.cparser.value('kick/temp_state')
+
+        if not self.code_verifier:
+            self.cleanup_temp_pkce_params()
+            raise ValueError("Code verifier not generated. Call get_authorization_url first.")
+
+        # Skip state validation if state has already been validated and removed by callback handler
+        if received_state and self.state and received_state != self.state:
+            self.cleanup_temp_pkce_params()
+            raise ValueError("State parameter mismatch. Possible CSRF attack.")
+
+        token_data = {
+            'grant_type': 'authorization_code',
+            'client_id': self.client_id,
+            'code': authorization_code,
+            'redirect_uri': self.redirect_uri,
+            'code_verifier': self.code_verifier
+        }
+
+        # Add client_secret if available (some OAuth implementations require it)
+        if self.client_secret:
+            token_data['client_secret'] = self.client_secret
+
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.OAUTH_HOST}/oauth/token",
+                                        data=token_data,
+                                        headers=headers,
+                                        timeout=aiohttp.ClientTimeout(total=30)) as response:
+                    if response.status == 200:
+                        token_response: dict[str, Any] = await response.json()
+
+                        self.access_token = token_response.get('access_token')
+                        self.refresh_token = token_response.get('refresh_token')
+
+                        # Save tokens to config and clean up temporary PKCE parameters
+                        if self.config:
+                            self.config.cparser.setValue('kick/accesstoken', self.access_token)
+                            if self.refresh_token:
+                                self.config.cparser.setValue('kick/refreshtoken',
+                                                              self.refresh_token)
+
+                            # Clean up remaining temporary PKCE parameters
+                            # Note: temp_state may have already been removed by callback handler
+                            self.config.cparser.remove('kick/temp_code_verifier')
+                            self.config.cparser.remove('kick/temp_state')
+                            self.config.save()
+
+                        logging.info('Successfully obtained Kick OAuth2 tokens')
+                        return token_response
+                    error_text = await response.text()
+                    logging.error('Failed to exchange code for token: %s - %s', response.status,
+                                  error_text)
+                    # Clean up temporary PKCE parameters on failure
+                    self.cleanup_temp_pkce_params()
+                    raise ValueError(f"Token exchange failed: {response.status} - {error_text}")
+        except Exception as error:
+            # Clean up temporary PKCE parameters if OAuth flow is interrupted
+            if not isinstance(error, ValueError):
+                # Don't re-cleanup if it's a ValueError we raised above
+                self.cleanup_temp_pkce_params()
+            raise
+
+    async def refresh_access_token(self, refresh_token: str | None = None) -> dict[str, Any]:
+        ''' Refresh the access token using refresh token '''
+        if not refresh_token:
+            refresh_token = self.refresh_token or self.config.cparser.value('kick/refreshtoken')
+
+        if not refresh_token:
+            raise ValueError("Refresh token is required")
+
+        token_data = {
+            'grant_type': 'refresh_token',
+            'client_id': self.client_id,
+            'refresh_token': refresh_token
+        }
+
+        # Add client_secret if available
+        if self.client_secret:
+            token_data['client_secret'] = self.client_secret
+
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{self.OAUTH_HOST}/oauth/token",
+                                    data=token_data,
+                                    headers=headers,
+                                    timeout=aiohttp.ClientTimeout(total=30)) as response:
+                if response.status == 200:
+                    token_response: dict[str, Any] = await response.json()
+
+                    self.access_token = token_response.get('access_token')
+                    new_refresh_token = token_response.get('refresh_token')
+
+                    if new_refresh_token:
+                        self.refresh_token = new_refresh_token
+
+                    # Save updated tokens to config
+                    if self.config:
+                        self.config.cparser.setValue('kick/accesstoken', self.access_token)
+                        if self.refresh_token:
+                            self.config.cparser.setValue('kick/refreshtoken', self.refresh_token)
+                        self.config.save()
+
+                    logging.info('Successfully refreshed Kick OAuth2 tokens')
+                    return token_response
+                error_text = await response.text()
+                logging.error('Failed to refresh token: %s - %s', response.status, error_text)
+                raise ValueError(f"Token refresh failed: {response.status} - {error_text}")
+
+    async def revoke_token(self, token: str | None = None) -> None:
+        ''' Revoke an access or refresh token '''
+        if not token:
+            token = self.access_token or self.config.cparser.value('kick/accesstoken')
+
+        if not token:
+            logging.warning("No token to revoke")
+            return
+
+        revoke_data = {'token': token, 'client_id': self.client_id}
+
+        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{self.OAUTH_HOST}/oauth/revoke",
+                                    data=revoke_data,
+                                    headers=headers,
+                                    timeout=aiohttp.ClientTimeout(total=30)) as response:
+                if response.status == 200:
+                    logging.info('Successfully revoked Kick OAuth2 token')
+
+                    # Clear tokens from config
+                    if self.config:
+                        self.config.cparser.remove('kick/accesstoken')
+                        self.config.cparser.remove('kick/refreshtoken')
+                        self.config.save()
+
+                    self.access_token = None
+                    self.refresh_token = None
+                else:
+                    error_text = await response.text()
+                    logging.error('Failed to revoke token: %s - %s', response.status, error_text)
+
+    async def validate_token(self, token: str | None = None) -> dict[str, Any] | bool:
+        ''' Validate an access token '''
+        if not token:
+            token = self.access_token or self.config.cparser.value('kick/accesstoken')
+
+        if not token:
+            return False
+
+        headers = {'Authorization': f'Bearer {token}', 'Accept': 'application/json'}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{self.OAUTH_HOST}/oauth/validate",
+                                   headers=headers,
+                                   timeout=aiohttp.ClientTimeout(total=10)) as response:
+                if response.status == 200:
+                    validation_response = await response.json()
+                    logging.debug('Token validation successful')
+                    return validation_response
+
+                logging.debug('Token validation failed: %s', response.status)
+                return False
+
+    def get_stored_tokens(self) -> tuple[str | None, str | None]:
+        ''' Get tokens from config storage '''
+        if not self.config:
+            return None, None
+
+        access_token = self.config.cparser.value('kick/accesstoken')
+        refresh_token = self.config.cparser.value('kick/refreshtoken')
+
+        return access_token, refresh_token
+
+    def cleanup_temp_pkce_params(self) -> None:
+        '''Remove temporary PKCE parameters from config to prevent stale data.'''
+        if self.config:
+            self.config.cparser.remove('kick/temp_code_verifier')
+            self.config.cparser.remove('kick/temp_state')
+            self.config.save()
+            logging.debug('Cleaned up temporary PKCE parameters')
+
+    def clear_stored_tokens(self) -> None:
+        ''' Clear tokens from config storage '''
+        if self.config:
+            self.config.cparser.remove('kick/accesstoken')
+            self.config.cparser.remove('kick/refreshtoken')
+            self.config.save()
+
+        self.access_token = None
+        self.refresh_token = None
+        logging.info('Cleared stored Kick OAuth2 tokens')
+
+
+async def main() -> None:
+    ''' Example usage of KickOAuth2 '''
+    # Initialize with config (will read kick/clientid, kick/secret, kick/redirecturi from config)
+    oauth = KickOAuth2()
+
+    # Check if configuration is present
+    if not oauth.client_id:
+        print("Error: kick/clientid not configured")
+        return
+    if not oauth.redirect_uri:
+        print("Error: kick/redirecturi not configured")
+        return
+
+    # Step 1: Open browser for authorization
+    if oauth.open_browser_for_auth():
+        print("Please authorize the application and check the redirect URI "
+              "for the authorization code.")
+        print("The redirect URI should be:", oauth.redirect_uri)
+
+        # In a real application, you would capture the authorization code from the redirect
+        # For this example, we'll just print the auth URL
+        auth_url = oauth.get_authorization_url()
+        print(f"Authorization URL: {auth_url}")
+    else:
+        print("Failed to open browser for authorization")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/nowplaying/kick/settings.py
+++ b/nowplaying/kick/settings.py
@@ -3,11 +3,10 @@
 
 import logging
 import os
-import time
 from typing import Any
 
 from PySide6.QtWidgets import QCheckBox, QTableWidgetItem  # pylint: disable=no-name-in-module
-from PySide6.QtCore import Slot  # pylint: disable=no-name-in-module
+from PySide6.QtCore import Slot, QTimer  # pylint: disable=no-name-in-module
 
 from nowplaying.exceptions import PluginVerifyError
 import nowplaying.config
@@ -74,8 +73,8 @@ class KickSettings:
             config.cparser.remove('kick/refreshtoken')
             config.cparser.sync()
 
-            time.sleep(2)
-            subprocesses.start_kickbot()
+            # Use QTimer for non-blocking delay to keep UI responsive
+            QTimer.singleShot(2000, subprocesses.start_kickbot)
 
     @staticmethod
     def verify(widget: Any) -> None:
@@ -316,8 +315,8 @@ class KickChatSettings:
         # If chat settings changed, restart kick bot
         if (oldchat != newchat) or (oldannounce != newannounce):
             subprocesses.stop_kickbot()
-            time.sleep(2)
-            subprocesses.start_kickbot()
+            # Use QTimer for non-blocking delay to keep UI responsive
+            QTimer.singleShot(2000, subprocesses.start_kickbot)
 
     @staticmethod
     def _save_kickbot_commands(config: nowplaying.config.ConfigFile, widget: Any) -> None:

--- a/nowplaying/kick/settings.py
+++ b/nowplaying/kick/settings.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+''' kick settings '''
+
+import logging
+import os
+import time
+from typing import Any
+
+from PySide6.QtWidgets import QCheckBox, QTableWidgetItem  # pylint: disable=no-name-in-module
+from PySide6.QtCore import Slot  # pylint: disable=no-name-in-module
+
+from nowplaying.exceptions import PluginVerifyError
+import nowplaying.config
+import nowplaying.kick.oauth2
+import nowplaying.kick.utils
+
+
+class KickSettings:
+    ''' for settings UI '''
+
+    def __init__(self) -> None:
+        self.widget: Any = None
+        self.oauth: nowplaying.kick.oauth2.KickOAuth2 | None = None
+        self.refresh_token: str | None = None
+
+    def connect(self, uihelp: Any, widget: Any) -> None:  # pylint: disable=unused-argument
+        '''  connect kick '''
+        self.widget = widget
+        widget.authenticate_button.clicked.connect(self.authenticate_oauth)
+        widget.clientid_lineedit.editingFinished.connect(self.update_oauth_status)
+        widget.secret_lineedit.editingFinished.connect(self.update_oauth_status)
+        widget.redirecturi_lineedit.editingFinished.connect(self.update_oauth_status)
+
+    def load(self, config: nowplaying.config.ConfigFile, widget: Any) -> None:
+        ''' load the settings window '''
+        self.widget = widget
+        widget.enable_checkbox.setChecked(config.cparser.value('kick/enabled', type=bool))
+        widget.channel_lineedit.setText(config.cparser.value('kick/channel'))
+        widget.clientid_lineedit.setText(config.cparser.value('kick/clientid'))
+        widget.secret_lineedit.setText(config.cparser.value('kick/secret'))
+        widget.redirecturi_lineedit.setText(
+            config.cparser.value('kick/redirecturi') or 'http://localhost:8080/kickredirect')
+
+        # Initialize OAuth2 handler
+        self.oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+        self.update_oauth_status()
+
+    @staticmethod
+    def save(config: nowplaying.config.ConfigFile, widget: Any, subprocesses: Any) -> None:
+        ''' update the kick settings '''
+        oldchannel = config.cparser.value('kick/channel')
+        newchannel = widget.channel_lineedit.text()
+        oldclientid = config.cparser.value('kick/clientid')
+        newclientid = widget.clientid_lineedit.text()
+        oldsecret = config.cparser.value('kick/secret')
+        newsecret = widget.secret_lineedit.text()
+        oldredirecturi = config.cparser.value('kick/redirecturi')
+        newredirecturi = widget.redirecturi_lineedit.text()
+
+        config.cparser.setValue('kick/enabled', widget.enable_checkbox.isChecked())
+        config.cparser.setValue('kick/channel', newchannel)
+        config.cparser.setValue('kick/clientid', newclientid)
+        config.cparser.setValue('kick/secret', newsecret)
+        config.cparser.setValue('kick/redirecturi', newredirecturi)
+
+        # If critical settings changed, restart kick bot and clear tokens
+        if (oldchannel != newchannel) or (oldclientid != newclientid) or (
+                oldsecret != newsecret) or (oldredirecturi != newredirecturi):
+            # Stop kick bot if running
+            subprocesses.stop_kickbot()
+
+            # Clear stored OAuth tokens since config changed
+            config.cparser.remove('kick/accesstoken')
+            config.cparser.remove('kick/refreshtoken')
+            config.cparser.sync()
+
+            time.sleep(2)
+            subprocesses.start_kickbot()
+
+    @staticmethod
+    def verify(widget: Any) -> None:
+        ''' verify the settings are good '''
+        if not widget.enable_checkbox.isChecked():
+            return
+
+        # Check required fields
+        if not widget.clientid_lineedit.text().strip():
+            raise PluginVerifyError('Kick Client ID is required')
+
+        if not widget.secret_lineedit.text().strip():
+            raise PluginVerifyError('Kick Client Secret is required')
+
+        if not widget.redirecturi_lineedit.text().strip():
+            raise PluginVerifyError('Kick Redirect URI is required')
+
+        if not widget.channel_lineedit.text().strip():
+            raise PluginVerifyError('Kick Channel is required')
+
+        # Validate redirect URI format
+        redirect_uri = widget.redirecturi_lineedit.text().strip()
+        if not redirect_uri.startswith('http://') and not redirect_uri.startswith('https://'):
+            raise PluginVerifyError('Kick Redirect URI must start with http:// or https://')
+
+    def authenticate_oauth(self) -> None:
+        ''' initiate OAuth2 authentication flow '''
+        if not self.oauth:
+            logging.error('OAuth2 handler not initialized')
+            return
+
+        # Update config with current form values
+        if self.widget:
+            self.oauth.client_id = self.widget.clientid_lineedit.text().strip()
+            self.oauth.client_secret = self.widget.secret_lineedit.text().strip()
+            self.oauth.redirect_uri = self.widget.redirecturi_lineedit.text().strip()
+
+        # Validate required fields
+        if not self.oauth.client_id:
+            self.widget.oauth_status_label.setText('Error: Client ID required')
+            return
+        if not self.oauth.client_secret:
+            self.widget.oauth_status_label.setText('Error: Client Secret required')
+            return
+        if not self.oauth.redirect_uri:
+            self.widget.oauth_status_label.setText('Error: Redirect URI required')
+            return
+
+        try:
+            # Open browser for authentication
+            if self.oauth.open_browser_for_auth():
+                self.widget.oauth_status_label.setText('Browser opened - complete authentication')
+                self.widget.authenticate_button.setText('Authentication in progress...')
+                self.widget.authenticate_button.setEnabled(False)
+
+                # Start checking for authentication completion
+                # Note: In a real implementation, you'd want to monitor the webserver
+                # for the OAuth callback and automatically update the status
+                logging.info('Kick OAuth2 authentication initiated')
+            else:
+                self.widget.oauth_status_label.setText('Failed to open browser')
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging.error('Kick OAuth2 authentication error: %s', error)
+            self.widget.oauth_status_label.setText(f'Authentication error: {error}')
+
+    def update_oauth_status(self) -> None:
+        ''' update the OAuth status display '''
+        if not self.oauth or not self.widget:
+            return
+
+        # Reset button state
+        self.widget.authenticate_button.setText('Authenticate with Kick')
+        self.widget.authenticate_button.setEnabled(True)
+
+        # Check if we have valid configuration
+        client_id = self.widget.clientid_lineedit.text().strip()
+        client_secret = self.widget.secret_lineedit.text().strip()
+        redirect_uri = self.widget.redirecturi_lineedit.text().strip()
+
+        if not client_id or not client_secret or not redirect_uri:
+            self.widget.oauth_status_label.setText('Configuration incomplete')
+            return
+
+        # Check for stored tokens and validate them
+        access_token, _ = self.oauth.get_stored_tokens()
+
+        if access_token:
+            # Validate token synchronously like Twitch does
+            if nowplaying.kick.utils.qtsafe_validate_kick_token(access_token):
+                self.widget.oauth_status_label.setText('Authenticated (valid)')
+                self.widget.authenticate_button.setText('Re-authenticate')
+            else:
+                self.widget.oauth_status_label.setText(
+                    'Authentication expired - please re-authenticate')
+                self.widget.authenticate_button.setText('Authenticate')
+                # Don't auto-clear tokens here - let the user decide
+        else:
+            self.widget.oauth_status_label.setText('Not authenticated')
+
+    def clear_authentication(self) -> None:
+        ''' clear stored authentication tokens '''
+        if self.oauth:
+            self.oauth.clear_stored_tokens()
+            self.update_oauth_status()
+            logging.info('Cleared Kick OAuth2 authentication')
+
+
+class KickChatSettings:
+    ''' Kick chat settings for UI (exactly mirrors TwitchChatSettings pattern) '''
+
+    # Define Kick permission checkboxes (matches table columns)
+    KICKBOT_CHECKBOXES: list[str] = [
+        'anyone', 'broadcaster', 'moderator', 'subscriber', 'founder', 'vip'
+    ]
+
+    def __init__(self) -> None:
+        self.widget: Any = None
+        self.uihelp: Any = None
+
+    def connect(self, uihelp: Any, widget: Any) -> None:
+        ''' connect kick chat settings '''
+        self.widget = widget
+        self.uihelp = uihelp
+        # Connect buttons with hasattr checks for robustness
+        if hasattr(widget, 'announce_button'):
+            widget.announce_button.clicked.connect(self.on_announce_button)
+        if hasattr(widget, 'add_button'):
+            widget.add_button.clicked.connect(self.on_add_button)
+        if hasattr(widget, 'del_button'):
+            widget.del_button.clicked.connect(self.on_del_button)
+
+    @Slot()
+    def on_announce_button(self) -> None:
+        ''' kick announce button clicked action '''
+        self.uihelp.template_picker_lineedit(self.widget.announce_lineedit, limit='kickbot_*.txt')
+
+    @Slot()
+    def on_add_button(self) -> None:
+        ''' kick add button clicked action '''
+        filename = self.uihelp.template_picker(limit='kickbot_*.txt')
+        if not filename:
+            return
+
+        filename = os.path.basename(filename)
+        filename = filename.replace('kickbot_', '')
+        command = filename.replace('.txt', '')
+
+        self._add_kickbot_command_row(self.widget, f'!{command}')
+
+    @Slot()
+    def on_del_button(self) -> None:
+        ''' kick del button clicked action '''
+        if items := self.widget.command_perm_table.selectedIndexes():
+            self.widget.command_perm_table.removeRow(items[0].row())
+
+    def load(self, config: nowplaying.config.ConfigFile, widget: Any) -> None:
+        ''' load kick chat settings '''
+        self.widget = widget
+        widget.enable_checkbox.setChecked(config.cparser.value('kick/chat', type=bool))
+        widget.announce_lineedit.setText(config.cparser.value('kick/announce') or '')
+
+        # Handle delay field
+        if hasattr(widget, 'announce_delay_lineedit'):
+            delay_value = config.cparser.value('kick/announcedelay', type=float) or 1.0
+            widget.announce_delay_lineedit.setText(str(delay_value))
+        elif hasattr(widget, 'announcedelay_spin'):
+            widget.announcedelay_spin.setValue(
+                config.cparser.value('kick/announcedelay', type=float) or 1.0)
+
+        # Load permission table
+        if hasattr(widget, 'command_perm_table'):
+            self._kickbot_command_load(config, widget)
+
+    def _kickbot_command_load(self, config: nowplaying.config.ConfigFile, widget: Any) -> None:
+        ''' load kickbot commands into permission table (mirrors TwitchChatSettings) '''
+        widget.command_perm_table.setRowCount(0)
+
+        # Load commands from config groups starting with 'kickbot-command-'
+        for group in config.cparser.childGroups():
+            if group.startswith('kickbot-command-'):
+                command = group.replace('kickbot-command-', '!')
+
+                config.cparser.beginGroup(group)
+                # Read permission values from config
+                permissions = {}
+                for checkbox_type in self.KICKBOT_CHECKBOXES:
+                    permissions[checkbox_type] = config.cparser.value(checkbox_type, type=bool)
+                config.cparser.endGroup()
+
+                # Add row with permissions
+                self._add_kickbot_command_row(widget, command, **permissions)
+
+    def _add_kickbot_command_row(self, widget: Any, command: str, **kwargs: Any) -> None:
+        ''' add a command row to the permission table (mirrors TwitchChatSettings) '''
+        row = widget.command_perm_table.rowCount()
+        widget.command_perm_table.insertRow(row)
+
+        # Column 0: Command name
+        widget.command_perm_table.setItem(row, 0, QTableWidgetItem(command))
+
+        # Columns 1-6: Permission checkboxes
+        for col, checkbox_type in enumerate(self.KICKBOT_CHECKBOXES, 1):
+            checkbox = QCheckBox()
+            if checkbox_type in kwargs:
+                checkbox.setChecked(kwargs[checkbox_type])
+            else:
+                checkbox.setChecked(False)  # Default to disabled for new commands
+            widget.command_perm_table.setCellWidget(row, col, checkbox)
+
+    @staticmethod
+    def save(config: nowplaying.config.ConfigFile, widget: Any, subprocesses: Any) -> None:
+        ''' save kick chat settings '''
+        oldchat = config.cparser.value('kick/chat', type=bool)
+        oldannounce = config.cparser.value('kick/announce')
+
+        newchat = widget.enable_checkbox.isChecked()
+        newannounce = widget.announce_lineedit.text()
+
+        config.cparser.setValue('kick/chat', newchat)
+        config.cparser.setValue('kick/announce', newannounce)
+
+        # Handle delay field
+        delay_value = 1.0
+        if hasattr(widget, 'announce_delay_lineedit'):
+            try:
+                delay_value = float(widget.announce_delay_lineedit.text())
+            except (ValueError, AttributeError):
+                delay_value = 1.0
+        elif hasattr(widget, 'announcedelay_spin'):
+            delay_value = widget.announcedelay_spin.value()
+
+        config.cparser.setValue('kick/announcedelay', delay_value)
+
+        # Save permission table
+        if hasattr(widget, 'command_perm_table'):
+            KickChatSettings._save_kickbot_commands(config, widget)
+
+        # If chat settings changed, restart kick bot
+        if (oldchat != newchat) or (oldannounce != newannounce):
+            subprocesses.stop_kickbot()
+            time.sleep(2)
+            subprocesses.start_kickbot()
+
+    @staticmethod
+    def _save_kickbot_commands(config: nowplaying.config.ConfigFile, widget: Any) -> None:
+        ''' save kickbot command permissions (mirrors TwitchChatSettings) '''
+
+        def reset_commands():
+            # Clear existing commands
+            for group in config.cparser.childGroups():
+                if group.startswith('kickbot-command-'):
+                    config.cparser.remove(group)
+
+        reset_commands()
+
+        # Save current commands and their permissions
+        for row in range(widget.command_perm_table.rowCount()):
+            command_item = widget.command_perm_table.item(row, 0)
+
+            if command_item and (command := command_item.text().strip()):
+                # Remove ! prefix for group name
+                group_name = f'kickbot-command-{command.replace("!", "")}'
+                config.cparser.beginGroup(group_name)
+
+                # Save checkbox states for each permission
+                for col, checkbox_type in enumerate(KickChatSettings.KICKBOT_CHECKBOXES, 1):
+                    if checkbox := widget.command_perm_table.cellWidget(row, col):
+                        config.cparser.setValue(checkbox_type, checkbox.isChecked())
+
+                config.cparser.endGroup()
+
+    @staticmethod
+    def verify(widget: Any) -> None:
+        ''' verify kick chat settings '''
+        if widget.enable_checkbox.isChecked():
+            if not widget.announce_lineedit.text().strip():
+                raise PluginVerifyError(
+                    'Kick announcement template is required when chat is enabled')
+
+    def update_kickbot_commands(self, config: nowplaying.config.ConfigFile) -> None:
+        ''' auto-discover kickbot templates and create default commands '''
+        template_dir = config.templatedir
+
+        if not template_dir.exists():
+            logging.debug('Template directory does not exist: %s', template_dir)
+            return
+
+        # Find all kickbot template files
+        kickbot_templates = list(template_dir.glob('kickbot_*.txt'))
+
+        if not kickbot_templates:
+            logging.debug('No kickbot templates found in %s', template_dir)
+            return
+
+        # Create default command entries for templates that don't have config entries
+        for template_path in kickbot_templates:
+            template_name = template_path.stem  # Remove .txt extension
+            command_name = template_name.replace('kickbot_', '')  # Convert kickbot_track -> track
+            group_name = f'kickbot-command-{command_name}'
+
+            # Check if this command already exists
+            config.cparser.beginGroup(group_name)
+            existing_keys = config.cparser.childKeys()
+            config.cparser.endGroup()
+
+            if not existing_keys:
+                # Create default command entry with all permissions disabled
+                config.cparser.beginGroup(group_name)
+                for checkbox_type in self.KICKBOT_CHECKBOXES:
+                    config.cparser.setValue(checkbox_type, False)
+                config.cparser.endGroup()
+                logging.info('Auto-created Kick command: !%s -> %s', command_name,
+                             template_path.name)

--- a/nowplaying/kick/utils.py
+++ b/nowplaying/kick/utils.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+''' kick utils '''
+
+import logging
+
+import requests
+
+
+def qtsafe_validate_kick_token(access_token: str) -> bool:
+    ''' validate kick token synchronously (shared by settings and launch) '''
+    if not access_token:
+        return False
+
+    # Use Kick's token introspect endpoint to validate the token
+    url = 'https://api.kick.com/public/v1/token/introspect'
+    headers = {'Authorization': f'Bearer {access_token}'}
+
+    try:
+        req = requests.post(url, headers=headers, timeout=10)
+    except Exception as error:  # pylint: disable=broad-except
+        logging.error('Kick token validation check failed: %s', error)
+        return False
+
+    if req.status_code != 200:
+        if req.status_code == 401:
+            logging.debug('Kick token is invalid/expired')
+        else:
+            logging.warning('Kick token validation returned status %s', req.status_code)
+        return False
+
+    try:
+        response_data = req.json()
+        data = response_data.get('data', {})
+
+        # Check if token is active
+        if data.get('active'):
+            client_id = data.get('client_id', 'Unknown')
+            scopes = data.get('scope', 'Unknown')
+            token_type = data.get('token_type', 'Unknown')
+            logging.debug('Kick token valid - client: %s, type: %s, scopes: %s',
+                         client_id, token_type, scopes)
+            return True
+
+        logging.debug('Kick token is inactive')
+        return False
+    except Exception as error:  # pylint: disable=broad-except
+        logging.error('Kick token validation/bad json: %s', error)
+        return False

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -14,7 +14,6 @@ import sys
 import textwrap
 import typing as t
 
-import nltk
 import tinytag
 import url_normalize
 
@@ -388,7 +387,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                     await asyncio.gather(*remaining_tasks, return_exceptions=True)
                 except Exception as cleanup_error:  # pylint: disable=broad-except
                     logging.error('Exception during task cleanup in exception handler: %s',
-                                      cleanup_error)
+                                  cleanup_error)
 
     def _generate_short_bio(self):
         if not self.metadata:
@@ -399,7 +398,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         message = message.replace('\r', ' ')
         message = str(message).strip()
         text = textwrap.TextWrapper(width=450).wrap(message)[0]
-        tokens = nltk.sent_tokenize(text)
+        tokens = nowplaying.utils.tokenize_sentences(text)
 
         nonotes = [sent for sent in tokens if not NOTE_RE.match(sent)]
         tokens = nonotes

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -47,9 +47,7 @@ class MusicBrainzHelper():
 
         self.emailaddressset = False
         # Create our own MusicBrainz client instance
-        self.mb_client = client.MusicBrainzClient(
-            rate_limit_interval=0.5
-        )
+        self.mb_client = client.MusicBrainzClient(rate_limit_interval=0.5)
 
     def _setemail(self):
         ''' make sure the musicbrainz fetch has an email address set
@@ -159,11 +157,11 @@ class MusicBrainzHelper():
             for artist in artist_name_variations(addmeta['artist']):
                 try:
                     mydict = await self.mb_client.search_recordings(artist=artist,
-                                                                         recording=addmeta['title'],
-                                                                         release=addmeta['album'])
+                                                                    recording=addmeta['title'],
+                                                                    release=addmeta['album'])
                 except Exception:  # pylint: disable=broad-exception-caught
-                    logging.exception("mb_client.search_recordings- ar:%s, t:%s, al:%s",
-                                      artist, addmeta['title'], addmeta['album'])
+                    logging.exception("mb_client.search_recordings- ar:%s, t:%s, al:%s", artist,
+                                      addmeta['title'], addmeta['album'])
                     continue
 
                 if riddata := await self._pickarecording(addmeta,
@@ -193,7 +191,7 @@ class MusicBrainzHelper():
             logging.debug('Trying %s', artist)
             try:
                 mydict = await self.mb_client.search_recordings(artist=artist,
-                                                                     recording=addmeta['title'])
+                                                                recording=addmeta['title'])
             except Exception:  # pylint: disable=broad-exception-caught
                 logging.exception("mb_client.search_recordings- ar:%s, t:%s (strict)", artist,
                                   addmeta['title'])
@@ -305,13 +303,14 @@ class MusicBrainzHelper():
 
         for isrc in isrclist:
             with contextlib.suppress(Exception):
-                mbdata = await self.mb_client.get_recordings_by_isrc(
-                    isrc, includes=['releases'], release_status=['official'])
+                mbdata = await self.mb_client.get_recordings_by_isrc(isrc,
+                                                                     includes=['releases'],
+                                                                     release_status=['official'])
         if not mbdata:
             for isrc in isrclist:
                 try:
-                    mbdata = await self.mb_client.get_recordings_by_isrc(
-                        isrc, includes=['releases'])
+                    mbdata = await self.mb_client.get_recordings_by_isrc(isrc,
+                                                                         includes=['releases'])
                 except Exception as error:  # pylint: disable=broad-except
                     logging.info('musicbrainz cannot find ISRC %s: %s', isrc, error)
 
@@ -378,10 +377,12 @@ class MusicBrainzHelper():
 
             if 'release-count' not in mbdata or mbdata['release-count'] == 0:
                 try:
-                    mbdata = await self.mb_client.browse_releases(
-                        recording=recordingid,
-                        includes=['artist-credits', 'labels', 'release-groups',
-                                  'release-group-rels'])
+                    mbdata = await self.mb_client.browse_releases(recording=recordingid,
+                                                                  includes=[
+                                                                      'artist-credits', 'labels',
+                                                                      'release-groups',
+                                                                      'release-group-rels'
+                                                                  ])
                 except Exception as error:  # pylint: disable=broad-except
                     logging.error('MusicBrainz threw an error: %s', error)
                     return None

--- a/nowplaying/musicbrainz/parser.py
+++ b/nowplaying/musicbrainz/parser.py
@@ -300,7 +300,7 @@ def parse_label_info_list(element: ET.Element) -> list[dict[str, Any]]:  # pylin
                         label_tag = (label_child.tag.split('}')[-1]
                                      if '}' in label_child.tag else label_child.tag)
                         if (label_tag in ["name", "sort-name", "disambiguation"]
-                            and label_child.text):
+                                and label_child.text):
                             label[label_tag] = label_child.text
                     label_info["label"] = label
             labels.append(label_info)

--- a/nowplaying/processes/kickbot.py
+++ b/nowplaying/processes/kickbot.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+''' kickbot process '''
+
+import contextlib
+import logging
+import os
+import signal
+import sys
+import threading
+
+import nowplaying.bootstrap
+import nowplaying.config
+import nowplaying.frozen
+import nowplaying.kick.launch
+
+
+def stop(pid):
+    ''' stop kickbot '''
+    logging.info('sending INT to %s', pid)
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(pid, signal.SIGINT)
+
+
+def start(stopevent, bundledir, testmode=False):  # pragma: no cover
+    ''' multiprocessing start hook '''
+    threading.current_thread().name = 'KickBot'
+
+    bundledir = nowplaying.frozen.frozen_init(bundledir)
+
+    if testmode:
+        nowplaying.bootstrap.set_qt_names(appname='testsuite')
+    else:
+        nowplaying.bootstrap.set_qt_names()
+    logpath = nowplaying.bootstrap.setuplogging(logname='debug.log', rotate=False)
+    config = nowplaying.config.ConfigFile(bundledir=bundledir, logpath=logpath, testmode=testmode)
+
+    logging.info('boot up')
+    try:
+        kickbot = nowplaying.kick.launch.KickLaunch(stopevent=stopevent, config=config)
+        kickbot.start()
+    except Exception as error:  # pylint: disable=broad-except
+        logging.error('KickBot crashed: %s', error, exc_info=True)
+        sys.exit(1)
+    logging.info('shutting down kickbot v%s', config.version)

--- a/nowplaying/processes/twitchbot.py
+++ b/nowplaying/processes/twitchbot.py
@@ -5,7 +5,6 @@ Driver for the Twitch support code
 
 '''
 
-
 import contextlib
 import logging
 import os

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -4,6 +4,7 @@
 import asyncio
 import base64
 import contextlib
+import html
 import logging
 import logging.config
 import os
@@ -41,6 +42,7 @@ import nowplaying.db
 import nowplaying.frozen
 import nowplaying.hostmeta
 import nowplaying.imagecache
+import nowplaying.kick.oauth2
 import nowplaying.trackrequests
 import nowplaying.utils
 
@@ -164,7 +166,7 @@ class WebHandler():  # pylint: disable=too-many-public-methods
         return await self._metacheck_htm_handler(request, 'weboutput/requestertemplate')
 
     @staticmethod
-    async def _htm_handler(request, template, metadata=None):  # pylint: disable=unused-argument
+    async def _htm_handler(request, template, metadata=None):
         ''' handle static html files'''
         htmloutput = INDEXREFRESH
         try:
@@ -181,7 +183,7 @@ class WebHandler():  # pylint: disable=too-many-public-methods
                 logging.error(line)
         return htmloutput
 
-    async def _metacheck_htm_handler(self, request, cfgtemplate):  # pylint: disable=unused-argument
+    async def _metacheck_htm_handler(self, request, cfgtemplate):
         ''' handle static html files after checking metadata'''
         request.app[CONFIG_KEY].cparser.sync()
         template = request.app[CONFIG_KEY].cparser.value(cfgtemplate)
@@ -460,6 +462,104 @@ class WebHandler():  # pylint: disable=too-many-public-methods
         data = {"dbfile": str(request.app[METADB_KEY].databasefile)}
         return web.json_response(data)
 
+    async def kickredirect_handler(self, request):  # pylint: disable=no-self-use
+        ''' handle oauth2 redirect callbacks '''
+        # Extract query parameters from the redirect
+        params = dict(request.query)
+
+        # Log the redirect for debugging (don't log the auth code for security)
+        logging.info('Kick OAuth2 redirect received with parameters: %s', {
+            k: v
+            for k, v in params.items() if k != 'code'
+        })
+
+        # Get config for template loading and refresh it to pick up test changes
+        config = request.app[CONFIG_KEY]
+        config.get()
+        template_dir = config.getbundledir().joinpath('templates', 'oauth')
+
+        def load_oauth_template(template_name: str, **kwargs) -> str:
+            """Load and render an OAuth template with variables"""
+            template_path = template_dir.joinpath(template_name)
+            if not template_path.exists():
+                logging.error('OAuth template not found: %s', template_path)
+                return '<html><body><h1>Template Error</h1><p>Template not found</p></body></html>'
+            template_content = template_path.read_text(encoding='utf-8')
+            # Simple template variable replacement
+            for key, value in kwargs.items():
+                template_content = template_content.replace('{{ ' + key + ' }}', str(value))
+            return template_content
+
+        # Check for OAuth2 error
+        if 'error' in params:
+            error_code = html.escape(params.get('error', 'unknown_error'))
+            error_description = html.escape(
+                params.get('error_description', 'No description provided'))
+
+            response_html = load_oauth_template('kick_oauth_error.htm',
+                                                error_code=error_code,
+                                                error_description=error_description)
+            return web.Response(content_type='text/html', text=response_html)
+
+        # Check for authorization code
+        authorization_code = params.get('code')
+        received_state = params.get('state')
+
+        if not authorization_code:
+            # Clean up temporary PKCE parameters when OAuth flow fails
+            oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+            oauth.cleanup_temp_pkce_params()
+            response_html = load_oauth_template('kick_oauth_no_code.htm')
+            return web.Response(content_type='text/html', text=response_html)
+
+        # Validate state parameter to prevent CSRF attacks
+        expected_state = config.cparser.value('kick/temp_state')
+        if not expected_state:
+            # Clean up temporary PKCE parameters when session is invalid
+            oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+            oauth.cleanup_temp_pkce_params()
+            response_html = load_oauth_template('kick_oauth_invalid_session.htm')
+            logging.warning('Kick OAuth2 callback received without valid session state')
+            return web.Response(content_type='text/html', text=response_html)
+
+        if received_state != expected_state:
+            # Clean up temporary PKCE parameters when CSRF attack is detected
+            oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+            oauth.cleanup_temp_pkce_params()
+            response_html = load_oauth_template('kick_oauth_csrf_error.htm')
+            logging.error(
+                'Kick OAuth2 CSRF attack detected: state mismatch (expected: %s, received: %s)',
+                expected_state[:8] + '...',
+                received_state[:8] + '...' if received_state else 'None')
+            return web.Response(content_type='text/html', text=response_html)
+
+        # State validation successful - immediately invalidate to prevent replay attacks
+        config.cparser.remove('kick/temp_state')
+        config.save()
+        logging.debug('State parameter invalidated after successful validation')
+
+        # Attempt to exchange the code for tokens
+        try:
+            # Initialize OAuth2 handler (config already retrieved above)
+            oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+
+            # Exchange code for tokens with validated state
+            await oauth.exchange_code_for_token(authorization_code, received_state)
+
+            # Success response
+            response_html = load_oauth_template('kick_oauth_success.htm')
+            logging.info('Kick OAuth2 authentication completed successfully')
+            return web.Response(content_type='text/html', text=response_html)
+
+        except (ValueError, OSError, asyncio.TimeoutError) as error:
+            logging.error('Kick OAuth2 token exchange failed: %s', error)
+
+            # Error response - use generic message to avoid information exposure
+            response_html = load_oauth_template('kick_oauth_token_error.htm',
+                                                error_message='Authentication failed.'
+                                                ' Please check your configuration and try again.')
+            return web.Response(content_type='text/html', text=response_html)
+
     def create_runner(self):
         ''' setup http routing '''
         threading.current_thread().name = 'WebServer-runner'
@@ -484,6 +584,7 @@ class WebHandler():  # pylint: disable=too-many-public-methods
             web.get('/index.htm', self.index_htm_handler),
             web.get('/index.html', self.index_htm_handler),
             web.get('/index.txt', self.indextxt_handler),
+            web.get('/kickredirect', self.kickredirect_handler),
             web.get('/request.htm', self.requesterlaunch_htm_handler),
             web.get('/internals', self.internals),
             web.get('/ws', self.websocket_handler),

--- a/nowplaying/resources/kick_ui.ui
+++ b/nowplaying/resources/kick_ui.ui
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>kick</class>
+ <widget class="QWidget" name="kick">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="displayName" stdset="0">
+   <string>Kick</string>
+  </property>
+  <widget class="QWidget" name="formLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>40</y>
+     <width>624</width>
+     <height>191</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="settings_layout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="channel_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Channel</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="channel_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>496</width>
+        <height>0</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="clientid_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Client ID</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QLineEdit" name="clientid_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>496</width>
+        <height>0</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="secret_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Client Secret</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QLineEdit" name="secret_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>496</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="echoMode">
+       <enum>QLineEdit::Password</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="redirecturi_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Redirect URI</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLineEdit" name="redirecturi_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>496</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>http://localhost:8899/kickredirect</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="oauth_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>OAuth Status</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLabel" name="oauth_status_label">
+      <property name="text">
+       <string>Not authenticated</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::PlainText</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QPushButton" name="authenticate_button">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Authenticate with Kick</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QCheckBox" name="enable_checkbox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>141</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Enable Kick</string>
+   </property>
+  </widget>
+  <widget class="QTextBrowser" name="help_text">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>240</y>
+     <width>621</width>
+     <height>241</height>
+    </rect>
+   </property>
+   <property name="html">
+    <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Kick.com Integration Setup:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;1. Create a Kick application at &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;https://id.kick.com/developers&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;2. Copy the &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Client ID&lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt; and &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Client Secret&lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt; from your application&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;3. Set the redirect URI in your Kick application to match the one shown above&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;4. Enter your channel name (username where you want to monitor/send messages)&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;5. Click &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Authenticate with Kick&lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt; to complete OAuth2 setup&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;The webserver must be enabled for OAuth2 authentication to work.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>channel_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>37</x>
+     <y>66</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>channel_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>66</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>clientid_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>38</x>
+     <y>97</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>clientid_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>97</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>secret_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>29</x>
+     <y>128</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>secret_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>128</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>redirecturi_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>47</x>
+     <y>159</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>redirecturi_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>159</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>oauth_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>43</x>
+     <y>190</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>authenticate_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>221</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/nowplaying/resources/kickchat_ui.ui
+++ b/nowplaying/resources/kickchat_ui.ui
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>kickchat_form</class>
+ <widget class="QWidget" name="kickchat_form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>625</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Kick Chat</string>
+  </property>
+  <property name="displayName" stdset="0">
+   <string>Kick Chat</string>
+  </property>
+  <widget class="QWidget" name="formLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>30</y>
+     <width>624</width>
+     <height>71</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="settings_layout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="commandchar_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Command Identifier</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="commandchar_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>496</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>!</string>
+      </property>
+      <property name="maxLength">
+       <number>1</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="announce_delay_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Announce Delay</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QLineEdit" name="announce_delay_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>496</width>
+        <height>0</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QCheckBox" name="enable_checkbox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>0</y>
+     <width>171</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Enable Kick Chat</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="announce_label">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>100</y>
+     <width>103</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Track Announce</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="announce_lineedit">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>240</x>
+     <y>100</y>
+     <width>381</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>381</width>
+     <height>0</height>
+    </size>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="announce_button">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>100</y>
+     <width>83</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Template</string>
+   </property>
+  </widget>
+  <widget class="QTableWidget" name="command_perm_table">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>170</y>
+     <width>611</width>
+     <height>261</height>
+    </rect>
+   </property>
+   <property name="alternatingRowColors">
+    <bool>true</bool>
+   </property>
+   <property name="selectionBehavior">
+    <enum>QAbstractItemView::SelectRows</enum>
+   </property>
+   <column>
+    <property name="text">
+     <string>Command</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Anyone</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Broadcaster</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Moderator</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Subscriber</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Founder</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>VIP</string>
+    </property>
+   </column>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>440</y>
+     <width>621</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="commandbuttons_layout">
+    <item>
+     <widget class="QPushButton" name="add_button">
+      <property name="text">
+       <string>Add Entry</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="del_button">
+      <property name="text">
+       <string>Delete Entry</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QCheckBox" name="replies_checkbox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>140</y>
+     <width>321</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Use Kick 'Replies' when answering commands</string>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>commandchar_label</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>commandchar_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_delay_label</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_delay_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_label</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_button</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>replies_checkbox</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>command_perm_table</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>add_button</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>del_button</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+ </connections>
+</ui>

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
     pass
 import nowplaying.twitch.settings
 import nowplaying.twitch.chat
+import nowplaying.kick.settings
 import nowplaying.trackrequests
 import nowplaying.uihelp
 import nowplaying.utils
@@ -50,6 +51,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self.settingsclasses = {
             'twitch': nowplaying.twitch.settings.TwitchSettings(),
             'twitchchat': nowplaying.twitch.chat.TwitchChatSettings(),
+            'kick': nowplaying.kick.settings.KickSettings(),
+            'kickchat': nowplaying.kick.settings.KickChatSettings(),
             'requests': nowplaying.trackrequests.RequestSettings(),
         }
 
@@ -67,6 +70,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         # twitch chat files are irrelevant
         if self.config.initialized:
             self.settingsclasses['twitchchat'].update_twitchbot_commands(self.config)
+            self.settingsclasses['kickchat'].update_kickbot_commands(self.config)
 
     def _setup_widgets(self, uiname, displayname=None):
         self.widgets[uiname] = load_widget_ui(self.config, f'{uiname}')
@@ -96,7 +100,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         else:
             baseuis = [
                 'general', 'source', 'filter', 'trackskip', 'textoutput', 'webserver', 'twitch',
-                'twitchchat', 'requests', 'artistextras', 'obsws', 'discordbot', 'quirks'
+                'twitchchat', 'kick', 'kickchat', 'requests', 'artistextras', 'obsws', 'discordbot',
+                'quirks'
             ]
 
         for uiname in baseuis:
@@ -125,6 +130,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             for key in [
                     'twitch',
                     'twitchchat',
+                    'kick',
+                    'kickchat',
                     'requests',
             ]:
                 self.settingsclasses[key].load(self.config, self.widgets[key])
@@ -236,6 +243,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             for key in [
                     'twitch',
                     'twitchchat',
+                    'kick',
                     'requests',
             ]:
                 self.settingsclasses[key].load(self.config, self.widgets[key])
@@ -407,14 +415,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         logging.getLogger().setLevel(loglevel)
 
         if not self.config.cparser.value('control/beam', type=bool):
-            for key in [
-                    'twitch',
-                    'twitchchat',
-                    'requests',
-            ]:
-                self.settingsclasses[key].save(self.config, self.widgets[key],
-                                               self.tray.subprocesses)
-
+            self._upd_conf_external_services()
             self._upd_conf_textoutput()
             self._upd_conf_artistextras()
             self._upd_conf_filters()
@@ -423,11 +424,23 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             self._upd_conf_obsws()
             self._upd_conf_quirks()
             self._upd_conf_discordbot()
+            self._upd_conf_kickbot()
 
         self._upd_conf_recognition()
         self._upd_conf_input()
         self._upd_conf_plugins()
         self.config.cparser.sync()
+
+    def _upd_conf_external_services(self):
+        """Update external service configurations (Twitch, Kick, etc.)"""
+        for key in [
+                'twitch',
+                'twitchchat',
+                'kick',
+                'kickchat',
+                'requests',
+        ]:
+            self.settingsclasses[key].save(self.config, self.widgets[key], self.tray.subprocesses)
 
     def _upd_conf_textoutput(self):
         self.config.cparser.setValue('setlist/enabled',
@@ -541,6 +554,22 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self.config.cparser.setValue('discord/template',
                                      self.widgets['discordbot'].template_lineedit.text())
         self.config.cparser.setValue('discord/enabled', enabled)
+
+    def _upd_conf_kickbot(self):
+        ''' update the kickbot settings '''
+
+        old_enabled = self.config.cparser.value('kick/enabled', type=bool)
+        old_chat = self.config.cparser.value('kick/chat', type=bool)
+
+        new_enabled = self.widgets['kick'].enable_checkbox.isChecked()
+        new_chat = self.widgets['kickchat'].enable_checkbox.isChecked()
+
+        # The individual settings save methods handle their own config values
+        # We just need to check if the overall enable/disable state changed
+        # and restart the kickbot if needed
+
+        if (old_enabled != new_enabled) or (old_chat != new_chat):
+            self.tray.subprocesses.restart_kickbot()
 
     def verify_regex_filters(self):
         ''' verify the regex filters are real '''
@@ -776,6 +805,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             for key in [
                     'twitch',
                     'twitchchat',
+                    'kick',
+                    'kickchat',
                     'requests',
             ]:
                 try:

--- a/nowplaying/subprocesses.py
+++ b/nowplaying/subprocesses.py
@@ -18,7 +18,7 @@ class SubprocessManager:
         if self.config.cparser.value('control/beam', type=bool):
             processlist = ['trackpoll', 'beamsender']
         else:
-            processlist = ['trackpoll', 'obsws', 'twitchbot', 'discordbot', 'webserver']
+            processlist = ['trackpoll', 'obsws', 'twitchbot', 'discordbot', 'webserver', 'kickbot']
 
         for name in processlist:
             self.processes[name] = {
@@ -32,8 +32,7 @@ class SubprocessManager:
 
         for key, module in self.processes.items():
             module['stopevent'].clear()
-            func = getattr(self, f'start_{key}')
-            func()
+            self.start_process(key)
 
     def stop_all_processes(self):
         ''' stop all the subprocesses '''
@@ -44,13 +43,12 @@ class SubprocessManager:
                 module['stopevent'].set()
 
         for key in self.processes:
-            func = getattr(self, f'stop_{key}')
-            func()
+            self.stop_process(key)
 
         if not self.config.cparser.value('control/beam', type=bool):
-            self.stop_obsws()
+            self.stop_process('obsws')
 
-    def _process_start(self, processname):
+    def _start_process(self, processname):
         ''' Start trackpoll '''
         if not self.processes[processname]['process']:
             logging.info('Starting %s', processname)
@@ -65,7 +63,7 @@ class SubprocessManager:
                 ))
             self.processes[processname]['process'].start()
 
-    def _process_stop(self, processname):
+    def _stop_process(self, processname):
         if self.processes[processname]['process']:
             logging.debug('Notifying %s', processname)
             self.processes[processname]['stopevent'].set()
@@ -84,77 +82,54 @@ class SubprocessManager:
             self.processes[processname]['process'] = None
         logging.debug('%s should be stopped', processname)
 
-    def start_discordbot(self):
-        ''' Start discordbot '''
-        self._process_start('discordbot')
+    def start_process(self, processname):
+        ''' Start a specific process '''
+        if processname == 'twitchbot' and not self.config.cparser.value('twitchbot/enabled',
+                                                                         type=bool):
+            return
+        if processname == 'webserver' and not self.config.cparser.value('weboutput/httpenabled',
+                                                                         type=bool):
+            return
+        if (processname == 'kickbot' and
+                not (self.config.cparser.value('kick/enabled', type=bool) and
+                     self.config.cparser.value('kick/chat', type=bool))):
+            return
+        self._start_process(processname)
 
-    def stop_discordbot(self):
-        ''' stop discordbot '''
-        self._process_stop('discordbot')
+    def stop_process(self, processname):
+        ''' Stop a specific process '''
+        self._stop_process(processname)
 
-    def start_beamsender(self):
-        ''' Start beamsender '''
-        self._process_start('beamsender')
+    def restart_process(self, processname):
+        ''' Restart a specific process '''
+        self.stop_process(processname)
+        self.start_process(processname)
 
-    def stop_beamsender(self):
-        ''' stop beamsender '''
-        self._process_stop('beamsender')
-
-    def start_obsws(self):
-        ''' Start obsws '''
-        self._process_start('obsws')
-
-    def stop_obsws(self):
-        ''' stop obsws '''
-        self._process_stop('obsws')
-
-    def start_trackpoll(self):
-        ''' Start trackpoll '''
-        self._process_start('trackpoll')
-
-    def stop_trackpoll(self):
-        ''' stop trackpoll '''
-        self._process_stop('trackpoll')
-
-    def start_twitchbot(self):
-        ''' Start the twitchbot '''
-        if self.config.cparser.value('twitchbot/enabled', type=bool):
-            self._process_start('twitchbot')
-
-    def stop_twitchbot(self):
-        ''' stop the twitchbot process '''
-        self._process_stop('twitchbot')
-
+    # Legacy methods for backward compatibility
     def start_webserver(self):
         ''' Start the webserver '''
-        if self.config.cparser.value('weboutput/httpenabled', type=bool):
-            self._process_start('webserver')
+        self.start_process('webserver')
 
     def stop_webserver(self):
-        ''' stop the web process '''
-        self._process_stop('webserver')
+        ''' Stop the webserver '''
+        self.stop_process('webserver')
 
-    def restart_discordbot(self):
-        ''' handle starting or restarting the discordbot process '''
-        self.stop_discordbot()
-        self.start_discordbot()
+    def stop_twitchbot(self):
+        ''' Stop the twitchbot '''
+        self.stop_process('twitchbot')
 
-    def restart_obsws(self):
-        ''' handle starting or restarting the obsws process '''
-        self.stop_obsws()
-        self.start_obsws()
-
-    def restart_trackpoll(self):
-        ''' handle starting or restarting the trackpoll process '''
-        self.stop_trackpoll()
-        self.start_trackpoll()
+    def stop_kickbot(self):
+        ''' Stop the kickbot '''
+        self.stop_process('kickbot')
 
     def restart_webserver(self):
-        ''' handle starting or restarting the webserver process '''
-        self.stop_webserver()
-        self.start_webserver()
+        ''' Restart the webserver process '''
+        self.restart_process('webserver')
 
-    def restart_twitchbot(self):
-        ''' handle starting or restarting the twitchbot process '''
-        self.stop_twitchbot()
-        self.start_twitchbot()
+    def restart_obsws(self):
+        ''' Restart the obsws process '''
+        self.restart_process('obsws')
+
+    def restart_kickbot(self):
+        ''' Restart the kickbot process '''
+        self.restart_process('kickbot')

--- a/nowplaying/subprocesses.py
+++ b/nowplaying/subprocesses.py
@@ -94,6 +94,12 @@ class SubprocessManager:
                 not (self.config.cparser.value('kick/enabled', type=bool) and
                      self.config.cparser.value('kick/chat', type=bool))):
             return
+        if processname == 'obsws' and not self.config.cparser.value('obsws/enabled', type=bool):
+            return
+        if processname == 'discordbot' and not self.config.cparser.value('discord/enabled',
+                                                                          type=bool):
+            return
+        # trackpoll always starts - it's the core monitoring process
         self._start_process(processname)
 
     def stop_process(self, processname):

--- a/nowplaying/templates/kickbot_artistshortbio.txt
+++ b/nowplaying/templates/kickbot_artistshortbio.txt
@@ -1,0 +1,1 @@
+{% if artistshortbio %}{{ artistshortbio }} {%else%} Sorry, no information. {% endif %}

--- a/nowplaying/templates/kickbot_previoustrack.txt
+++ b/nowplaying/templates/kickbot_previoustrack.txt
@@ -1,0 +1,13 @@
+{% if previoustrack and previoustrack[1] %}
+{% if cmdtarget[0] %}
+{% if previoustrack[cmdtarget[0]|int + 1] %}
+{{ previoustrack[cmdtarget[0]|int + 1].artist }} - "{{ previoustrack[cmdtarget[0]|int + 1].title }}"
+{% else %}
+No track past {{cmdtarget[0]}}.
+{% endif %}
+{% else %}
+{{ previoustrack[1].artist }} - "{{ previoustrack[1].title }}"
+{% endif %}
+{% else %}
+This is the first track!
+{% endif %}

--- a/nowplaying/templates/kickbot_request.txt
+++ b/nowplaying/templates/kickbot_request.txt
@@ -1,0 +1,5 @@
+{% if requester %} Thanks @{{ requester }}! {% endif %}
+Your {% if requestdisplayname %} {{ requestdisplayname }} {% endif %} request
+{% if requesttitle %} of "{{requesttitle}}"{% endif %}
+{% if requestartist %} by {{ requestartist }}{% endif %}
+ has been noted!

--- a/nowplaying/templates/kickbot_track.txt
+++ b/nowplaying/templates/kickbot_track.txt
@@ -1,0 +1,2 @@
+{% if requester %} This {{requestdisplayname}} track was requested by @{{ requester }}. {% endif %}
+{% if artist %}{{ artist }} - {% endif %}"{{ title }}"

--- a/nowplaying/templates/kickbot_track_and_bio.txt
+++ b/nowplaying/templates/kickbot_track_and_bio.txt
@@ -1,0 +1,14 @@
+{% if requester %} This {{requestdisplayname}} track was requested by @{{ requester }}. {% endif %}
+{% if artist %}{{ artist }} - {% endif %}"{{ title }}"
+{% if artistwebsites %}
+{% for website in artistwebsites %}
+{% if 'bandcamp' in website %} | Bandcamp: {{ website }}
+{% elif 'discogs' in website %} | Discogs: {{ website }}
+{% elif 'musicbrainz' in website %} | MusicBrainz: {{ website }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if artistshortbio %}
+{{ startnewmessage }}
+{{ artistshortbio }}
+{% endif %}

--- a/nowplaying/templates/kickbot_trackdetail.txt
+++ b/nowplaying/templates/kickbot_trackdetail.txt
@@ -1,0 +1,17 @@
+{% if cmdtarget[0] %}Hey @{{ cmdtarget[0] }} this song has these details... {% endif %}
+"{{ title }}"
+{% if artist %} by {{ artist }}.{% endif %}
+{% if track %} It is track #{{ track }}
+{% if track_total %} out of {{ track_total }} {% endif %}.{% endif %}
+{% if album %} This song was on the album _{{ album }}_ {% endif %}
+{% if disc %} on disc #{{ disc }}
+{% if disc_total %} out of {{ disc_total }}{% endif %}. {% endif %}
+{% if albumartist %} The album artist is listed as {{ albumartist }}. {% endif %}
+{% if lang %} The language is {{ lang }}.{% endif %}
+{% if genre %} It is classified as {{ genre }} by some people. {% endif %}
+{% if bpm %} The BPM is approximately {{ bpm }}.{% endif %}
+{% if key %} Performed in the key of {{ key }}.{% endif %}
+{% if composer %} {{ composer }} is the composer listing. {% endif %}
+{% if label %} It was published by {{ label }}.{% endif %}
+{% if date %} The date is listed as {{ date }}, but that might be the date of the media. {% endif %}
+{% if requester %} It was requested by @{{ requester }}. {% endif %}

--- a/nowplaying/templates/oauth/kick_oauth_csrf_error.htm
+++ b/nowplaying/templates/oauth/kick_oauth_csrf_error.htm
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kick OAuth2 - Security Error</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .error { color: #d32f2f; }
+        .security-warning { background: #fff3cd; border: 1px solid #ffeaa7; color: #856404; padding: 10px; border-radius: 4px; margin: 10px 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="error">OAuth2 State Mismatch</h2>
+        <div class="security-warning">
+            <strong>Security Warning:</strong> The OAuth2 state parameter does not match the expected value.
+            This may indicate a Cross-Site Request Forgery (CSRF) attack.
+        </div>
+        <p>For your security, the authentication process has been blocked.</p>
+        <p>Please return to the settings and start the authentication process again.</p>
+        <button onclick="window.close()">Close Window</button>
+    </div>
+</body>
+</html>

--- a/nowplaying/templates/oauth/kick_oauth_error.htm
+++ b/nowplaying/templates/oauth/kick_oauth_error.htm
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kick OAuth2 - Error</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .error { color: #d32f2f; }
+        .close-btn { background: #1976d2; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="error">Kick OAuth2 Authentication Failed</h2>
+        <p><strong>Error:</strong> {{ error_code }}</p>
+        <p><strong>Description:</strong> {{ error_description }}</p>
+        <p>Please return to the settings and try again.</p>
+        <button class="close-btn" onclick="window.close()">Close Window</button>
+    </div>
+</body>
+</html>

--- a/nowplaying/templates/oauth/kick_oauth_invalid_session.htm
+++ b/nowplaying/templates/oauth/kick_oauth_invalid_session.htm
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kick OAuth2 - Error</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .error { color: #d32f2f; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="error">Invalid OAuth2 Session</h2>
+        <p>No OAuth2 session found. Please start the authentication process again.</p>
+        <p>This may happen if the authentication session has expired.</p>
+        <button onclick="window.close()">Close Window</button>
+    </div>
+</body>
+</html>

--- a/nowplaying/templates/oauth/kick_oauth_no_code.htm
+++ b/nowplaying/templates/oauth/kick_oauth_no_code.htm
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kick OAuth2 - Error</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .error { color: #d32f2f; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="error">No Authorization Code Received</h2>
+        <p>The OAuth2 callback did not include an authorization code.</p>
+        <p>Please return to the settings and try again.</p>
+        <button onclick="window.close()">Close Window</button>
+    </div>
+</body>
+</html>

--- a/nowplaying/templates/oauth/kick_oauth_success.htm
+++ b/nowplaying/templates/oauth/kick_oauth_success.htm
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kick OAuth2 - Success</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .success { color: #388e3c; }
+        .info { background: #e3f2fd; padding: 15px; border-radius: 4px; margin: 20px 0; }
+        .close-btn { background: #388e3c; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="success">Kick OAuth2 Authentication Successful!</h2>
+        <p>Your Kick account has been successfully authenticated with What's Now Playing.</p>
+        <div class="info">
+            <p><strong>What's Next:</strong></p>
+            <ul>
+                <li>Your authentication tokens have been saved securely</li>
+                <li>You can now close this window</li>
+                <li>Return to the settings panel to complete your configuration</li>
+                <li>Save your settings to activate Kick integration</li>
+            </ul>
+        </div>
+        <button class="close-btn" onclick="window.close()">Close Window</button>
+    </div>
+    <script>
+        // Auto-close after 10 seconds
+        setTimeout(function() {
+            window.close();
+        }, 10000);
+    </script>
+</body>
+</html>

--- a/nowplaying/templates/oauth/kick_oauth_token_error.htm
+++ b/nowplaying/templates/oauth/kick_oauth_token_error.htm
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kick OAuth2 - Error</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .error { color: #d32f2f; }
+        .close-btn { background: #d32f2f; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="error">Kick OAuth2 Token Exchange Failed</h2>
+        <p>There was an error completing the authentication process:</p>
+        <p><code>{{ error_message }}</code></p>
+        <p>Please check your Kick application configuration and try again.</p>
+        <button class="close-btn" onclick="window.close()">Close Window</button>
+    </div>
+</body>
+</html>

--- a/nowplaying/tinytag_fixes.py
+++ b/nowplaying/tinytag_fixes.py
@@ -25,11 +25,11 @@ def _check_tinytag_compatibility():
             return False
         if not hasattr(tinytag.tinytag._MP4, '_parse_custom_field'):  # pylint: disable=protected-access
             logging.error("tinytag._MP4._parse_custom_field method not found. "
-                         "Incompatible tinytag version.")
+                          "Incompatible tinytag version.")
             return False
         if not hasattr(tinytag.tinytag.TinyTag, '_set_field'):
             logging.error("tinytag.TinyTag._set_field method not found. "
-                         "Incompatible tinytag version.")
+                          "Incompatible tinytag version.")
             return False
         return True
     except AttributeError as exc:

--- a/nowplaying/twitch/launch.py
+++ b/nowplaying/twitch/launch.py
@@ -16,12 +16,9 @@ import nowplaying.utils
 class TwitchLaunch:  # pylint: disable=too-many-instance-attributes
     ''' handle twitch  '''
 
-    def __init__(self, config=None, stopevent=None):
+    def __init__(self, config=None, stopevent: asyncio.Event = None):
         self.config = config
-        if stopevent:
-            self.stopevent = stopevent
-        else:
-            self.stopevent = asyncio.Event()
+        self.stopevent = stopevent or asyncio.Event()
         self.widgets = None
         self.chat = None
         #self.redemptions = None

--- a/nowplaying/twitch/utils.py
+++ b/nowplaying/twitch/utils.py
@@ -21,10 +21,8 @@ import nowplaying.utils
 #     AuthScope.CHAT_EDIT
 # ]
 
-USER_SCOPE = [
-    AuthScope.CHAT_READ,
-    AuthScope.CHAT_EDIT
-]
+USER_SCOPE = [AuthScope.CHAT_READ, AuthScope.CHAT_EDIT]
+
 
 async def get_user_image(twitch, loginname):
     ''' ask twitch for the user profile image '''

--- a/nowplaying/uihelp.py
+++ b/nowplaying/uihelp.py
@@ -22,7 +22,7 @@ class UIHelp:
         if startfile:
             startdir = os.path.dirname(startfile)
         elif not startdir:
-            startdir = os.path.join(self.config.templatedir, "templates")
+            startdir = str(self.config.templatedir)
         if filename := QFileDialog.getOpenFileName(self.qtui, 'Open file', startdir, limit):
             return filename[0]
         return None

--- a/nowplaying/upgradeutils.py
+++ b/nowplaying/upgradeutils.py
@@ -108,6 +108,14 @@ class Version:
         ''' version not equal '''
         return not self == other
 
+    def __hash__(self):
+        ''' version hash '''
+        return hash((self.chunk.get('major'),
+                     self.chunk.get('minor'),
+                     self.chunk.get('micro'),
+                     self.chunk.get('rc'),
+                     self.chunk.get('commitnum')))
+
     def __gt__(self, other):
         ''' version greater than '''
         return not (self < other or self == other)

--- a/nowplaying/upgradeutils.py
+++ b/nowplaying/upgradeutils.py
@@ -90,6 +90,32 @@ class Version:
 
         return False
 
+    def __le__(self, other):
+        ''' version less than or equal '''
+        return self == other or self < other
+
+    def __eq__(self, other):
+        ''' version equality '''
+        if not isinstance(other, Version):
+            return False
+        return (self.chunk.get('major') == other.chunk.get('major') and
+                self.chunk.get('minor') == other.chunk.get('minor') and
+                self.chunk.get('micro') == other.chunk.get('micro') and
+                self.chunk.get('rc') == other.chunk.get('rc') and
+                self.chunk.get('commitnum') == other.chunk.get('commitnum'))
+
+    def __ne__(self, other):
+        ''' version not equal '''
+        return not self == other
+
+    def __gt__(self, other):
+        ''' version greater than '''
+        return not (self < other or self == other)
+
+    def __ge__(self, other):
+        ''' version greater than or equal '''
+        return self == other or self > other
+
 
 class UpgradeBinary:
     ''' routines to determine if the binary is out of date '''

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -11,6 +11,7 @@ with just the functionality needed by the nowplaying application.
 import logging
 import ssl
 from typing import Any
+from urllib.parse import quote
 import aiohttp
 
 import nowplaying.utils
@@ -201,8 +202,8 @@ class AsyncWikiClient:
         if not filenames or not self.session:
             return []
 
-        # Create pipe-separated list of file titles for batch query
-        titles = '|'.join(f'File:{filename}' for filename in filenames)
+        # Create pipe-separated list of file titles for batch query, URL-encoding each filename
+        titles = '|'.join(f'File:{quote(filename, safe="")}' for filename in filenames)
 
         commons_url = "https://commons.wikimedia.org/w/api.php"
         params = {

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -102,10 +102,11 @@ class AsyncWikiClient:
 
             return result
 
-    async def _get_wikipedia_extract(self,  # pylint: disable=too-many-return-statements
-                                     entity: str,
-                                     lang: str,
-                                     sitelinks: dict | None = None) -> str | None:
+    async def _get_wikipedia_extract(
+            self,
+            entity: str,
+            lang: str,
+            sitelinks: dict | None = None) -> str | None:
         """Get Wikipedia page extract using sitelinks (fetched separately if not provided)."""
         if sitelinks is None:
             # Fallback: fetch sitelinks separately if not provided
@@ -156,13 +157,11 @@ class AsyncWikiClient:
                 return None
 
             pages = data['query']['pages']
-            return next(
-                (page_data['extract'] for page_data in pages.values() if 'extract' in page_data),
-                None
-            )
+            return next((page_data['extract']
+                         for page_data in pages.values() if 'extract' in page_data), None)
 
     async def _get_wikidata_images(self, entity: str) -> list[dict[str, str]]:
-        """Get images directly from Wikidata entity."""
+        """Get images directly from Wikidata entity with batch processing."""
         images = []
 
         # Get Wikidata entity with claims
@@ -182,51 +181,77 @@ class AsyncWikiClient:
 
             # Get P18 (image) claims
             if 'P18' in claims:
+                filenames = []
                 for claim in claims['P18']:
                     if 'mainsnak' in claim and 'datavalue' in claim['mainsnak']:
                         filename = claim['mainsnak']['datavalue']['value']
-                        # Convert to Commons URL
-                        img_url = await self._get_commons_image_url(filename)
+                        filenames.append(filename)
+
+                # Batch process all filenames at once for better performance
+                if filenames:
+                    image_urls = await self._get_commons_image_urls_batch(filenames)
+                    for img_url in image_urls:
                         if img_url:
                             images.append({'kind': 'wikidata-image', 'url': img_url})
 
         return images
 
-    async def _get_commons_image_url(self, filename: str) -> str | None:
-        """Get Commons image URL from filename."""
-        # Query Commons for the image URL
+    async def _get_commons_image_urls_batch(self, filenames: list[str]) -> list[str | None]:
+        """Get Commons image URLs for multiple filenames in a single batch API call."""
+        if not filenames or not self.session:
+            return []
+
+        # Create pipe-separated list of file titles for batch query
+        titles = '|'.join(f'File:{filename}' for filename in filenames)
+
         commons_url = "https://commons.wikimedia.org/w/api.php"
         params = {
             'action': 'query',
             'format': 'json',
-            'titles': f'File:{filename}',
+            'titles': titles,
             'prop': 'imageinfo',
             'iiprop': 'url'
         }
 
         try:
-            if not self.session:
-                return None
             async with self.session.get(commons_url, params=params) as response:
                 data = await response.json()
 
                 if 'query' not in data or 'pages' not in data['query']:
-                    return None
+                    return []
 
                 pages = data['query']['pages']
-                return next(
-                    (page_data['imageinfo'][0].get('url')
-                     for page_data in pages.values()
-                     if 'imageinfo' in page_data and page_data['imageinfo']),
-                    None
-                )
-        except Exception:  # pylint: disable=broad-exception-caught
-            return None
+                results = []
 
-    async def _get_wikipedia_images(self,  # pylint: disable=too-many-locals
-                                    entity: str,
-                                    lang: str,
-                                    sitelinks: dict | None = None) -> list[dict[str, str]]:
+                # Maintain order by matching against original filenames
+                for filename in filenames:
+                    file_title = f'File:{filename}'
+                    url = None
+
+                    for page_data in pages.values():
+                        if (page_data.get('title') == file_title and
+                            'imageinfo' in page_data and page_data['imageinfo']):
+                            url = page_data['imageinfo'][0].get('url')
+                            break
+
+                    results.append(url)
+
+                return results
+
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.debug("Batch Commons image URL fetch failed, skipping images")
+            return []
+
+    async def _get_commons_image_url(self, filename: str) -> str | None:
+        """Get Commons image URL from filename (single file convenience method)."""
+        results = await self._get_commons_image_urls_batch([filename])
+        return results[0] if results else None
+
+    async def _get_wikipedia_images(  # pylint: disable=too-many-locals
+            self,
+            entity: str,
+            lang: str,
+            sitelinks: dict | None = None) -> list[dict[str, str]]:
         """Get images from Wikipedia page using sitelinks (fetched separately if not provided)."""
         if sitelinks is None:
             # Fallback: fetch sitelinks separately if not provided
@@ -295,42 +320,14 @@ class AsyncWikiClient:
 
         return images
 
-    async def _get_image_url(self, filename: str, lang: str) -> str | None:
-        """Get the actual URL for an image file."""
-        wiki_url = f"https://{lang}.wikipedia.org/w/api.php"
-        params = {
-            'action': 'query',
-            'format': 'json',
-            'titles': filename,
-            'prop': 'imageinfo',
-            'iiprop': 'url'
-        }
 
-        try:
-            if not self.session:
-                return None
-            async with self.session.get(wiki_url, params=params) as response:
-                data = await response.json()
-
-                if 'query' not in data or 'pages' not in data['query']:
-                    return None
-
-                pages = data['query']['pages']
-                return next(
-                    (page_data['imageinfo'][0].get('url')
-                     for page_data in pages.values()
-                     if 'imageinfo' in page_data and page_data['imageinfo']),
-                    None
-                )
-        except Exception:  # pylint: disable=broad-exception-caught
-            return None
-
-    async def get_page(self,  # pylint: disable=too-many-arguments
-                       entity: str,
-                       lang: str = 'en',
-                       fetch_bio: bool = True,
-                       fetch_images: bool = True,
-                       max_images: int = 10) -> WikiPage:
+    async def get_page(  # pylint: disable=too-many-arguments
+            self,
+            entity: str,
+            lang: str = 'en',
+            fetch_bio: bool = True,
+            fetch_images: bool = True,
+            max_images: int = 10) -> WikiPage:
         """Get a Wikipedia page by Wikidata entity ID with selective fetching."""
         wiki_page = WikiPage(entity, lang)
 
@@ -363,12 +360,13 @@ class AsyncWikiClient:
         return wiki_page
 
 
-async def get_page_async(entity: str,  # pylint: disable=too-many-arguments
-                         lang: str = 'en',
-                         timeout: int = 5,
-                         need_bio: bool = True,
-                         need_images: bool = True,
-                         max_images: int = 5) -> WikiPage:
+async def get_page_async(  # pylint: disable=too-many-arguments
+        entity: str,
+        lang: str = 'en',
+        timeout: int = 5,
+        need_bio: bool = True,
+        need_images: bool = True,
+        max_images: int = 5) -> WikiPage:
     """
     Async function for nowplaying wikimedia plugin.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ qt_qapp_name = "testsuite"
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
 load-plugins = ["pylint.extensions.no_self_use"]
+init-hook = 'import sys; sys.path.append(".")'
 ignore-paths = [
   "nowplaying/beam",
   "nowplaying/qtrc.py",
@@ -148,3 +149,71 @@ ignore_patterns = [
   "nowplaying/vendor/**",
   "nowplaying/qtrc.py",
 ]
+
+[tool.ruff]
+line-length = 100
+extend-exclude = [
+  "nowplaying/version.py",
+  "nowplaying/vendor/**",
+  "nowplaying/qtrc.py",
+  "nowplaying/beam/**",
+]
+
+[tool.ruff.lint]
+# Enable pylint-like rule sets
+select = [
+  "E",    # pycodestyle errors
+  "W",    # pycodestyle warnings
+  "F",    # pyflakes
+  "I",    # isort
+  "N",    # pep8-naming
+  "UP",   # pyupgrade
+  "YTT",  # flake8-2020
+  "S",    # flake8-bandit
+  "BLE",  # flake8-blind-except
+  "B",    # flake8-bugbear
+  "A",    # flake8-builtins
+  "C4",   # flake8-comprehensions
+  "PIE",  # flake8-pie
+  "T20",  # flake8-print
+  "SIM",  # flake8-simplify
+  "ARG",  # flake8-unused-arguments
+  "PTH",  # flake8-use-pathlib
+  "PL",   # pylint rules
+]
+
+# Ignore specific rules that don't match pylint defaults or project needs
+ignore = [
+  "S101",   # assert statements (common in tests)
+  "T201",   # print statements (may be needed for CLI)
+  "PLR0913", # too many arguments (pylint equivalent: R0913)
+  "PLR0915", # too many statements (pylint equivalent: R0915)
+  "PLR2004", # magic value comparison
+  "S603",   # subprocess without shell=True check
+  "S607",   # subprocess with partial executable path
+]
+
+# Per-file ignores (similar to pylint ignore-paths)
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+  "S101",     # assert statements in tests
+  "PLR0913",  # many arguments in test functions
+  "ARG001",   # unused function arguments (fixtures)
+  "S105",     # hardcoded passwords in tests
+]
+
+[tool.ruff.lint.pylint]
+# Configure pylint-specific rules
+max-args = 7
+max-locals = 20
+max-statements = 60
+
+[tool.ruff.format]
+# Use double quotes for strings
+quote-style = "double"
+# Use spaces around equals signs in keyword arguments
+skip-magic-trailing-comma = false
+# Indent with spaces
+indent-style = "space"
+# Keep line breaks in function signatures like yapf
+docstring-code-format = true

--- a/tests-qt/test_settingsui.py
+++ b/tests-qt/test_settingsui.py
@@ -22,6 +22,12 @@ class MockSubprocesses:
     def start_twitchbot(self):
         ''' mock '''
 
+    def stop_kickbot(self):
+        ''' mock '''
+
+    def start_kickbot(self):
+        ''' mock '''
+
 
 class MockTray:
     ''' mock '''

--- a/tests/audio_metadata/test_tinytag_functionality.py
+++ b/tests/audio_metadata/test_tinytag_functionality.py
@@ -340,8 +340,7 @@ def test_m4a_freeform_tags(test_files):  # pylint: disable=redefined-outer-name
 
         # Check for MusicBrainz IDs in freeform tags (tinytag 2.1.1+ API)
         if hasattr(tag, 'other') and tag.other:
-            musicbrainz_fields = [key for key in tag.other.keys()
-                                if 'musicbrainz' in key.lower()]
+            musicbrainz_fields = [key for key in tag.other.keys() if 'musicbrainz' in key.lower()]
 
             if musicbrainz_fields:
                 print(f"TinyTag MusicBrainz freeform tags in {m4a_file.name}: "

--- a/tests/audio_metadata/test_upgrade_detection.py.disabled
+++ b/tests/audio_metadata/test_upgrade_detection.py.disabled
@@ -144,8 +144,8 @@ class LibraryVersionTracker:
         return capability_changes
 
     @staticmethod
-    def _find_capability_differences(prev: dict[str, Any],
-                                     current: dict[str, Any]) -> dict[str, Any]:
+    def _find_capability_differences(prev: dict[str, Any], current: dict[str,
+                                                                         Any]) -> dict[str, Any]:
         """Find differences in capabilities."""
         changes = {}
 

--- a/tests/kick/test_kick_chat.py
+++ b/tests/kick/test_kick_chat.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Unit tests for Kick chat functionality."""
+# pylint: disable=protected-access,import-error,no-member,no-else-return
+
+import asyncio
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aioresponses import aioresponses
+
+import nowplaying.kick.chat  #pylint: disable=no-name-in-module
+import nowplaying.kick.settings  #pylint: disable=no-name-in-module
+from nowplaying.exceptions import PluginVerifyError  #pylint: disable=no-name-in-module
+
+
+def test_kickchat_init_with_config(bootstrap):
+    """Test KickChat initialization with config."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    assert chat.config == config
+    assert chat.stopevent == stopevent
+    assert chat.watcher is None
+    assert chat.oauth is None
+    assert not chat.authenticated
+    assert chat.api_base == "https://api.kick.com/public/v1"
+    assert isinstance(chat.jinja2, nowplaying.kick.chat.jinja2.Environment)  #pylint: disable=no-member
+
+
+def test_kickchat_init_without_config():
+    """Test KickChat initialization without config."""
+    chat = nowplaying.kick.chat.KickChat()  #pylint: disable=no-member
+
+    assert chat.config is None
+    assert isinstance(chat.stopevent, asyncio.Event)
+
+
+@pytest.mark.asyncio
+async def test_kickchat_authenticate_success(bootstrap):
+    """Test successful authentication."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('access_token', 'refresh_token')
+    mock_oauth.validate_token = AsyncMock(return_value=True)
+    chat.oauth = mock_oauth
+
+    result = await chat._authenticate()
+
+    assert result
+    assert chat.authenticated
+
+
+@pytest.mark.asyncio
+async def test_kickchat_authenticate_no_tokens(bootstrap):
+    """Test authentication failure with no tokens."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    # Mock OAuth2 handler with no tokens
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = (None, None)
+    chat.oauth = mock_oauth
+
+    result = await chat._authenticate()
+
+    assert not result
+    assert chat.authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_kickchat_authenticate_token_refresh(bootstrap):
+    """Test authentication with token refresh."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    # Mock OAuth2 handler with invalid token that needs refresh
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('invalid_token', 'refresh_token')
+    mock_oauth.validate_token = AsyncMock(return_value=False)
+    mock_oauth.refresh_access_token = AsyncMock()
+    chat.oauth = mock_oauth
+
+    result = await chat._authenticate()
+
+    assert result is True
+    assert chat.authenticated is True
+    mock_oauth.refresh_access_token.assert_called_once_with('refresh_token')
+
+
+@pytest.mark.asyncio
+async def test_kickchat_send_message_success(bootstrap):
+    """Test successful message sending."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('access_token', 'refresh_token')
+    chat.oauth = mock_oauth
+
+    # Mock successful API response
+    with aioresponses() as mock_resp:
+        mock_resp.post('https://api.kick.com/public/v1/chat',
+                       status=200,
+                       payload={
+                           "data": {
+                               "is_sent": True
+                           },
+                           "message": "OK"
+                       })
+
+        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_kickchat_send_message_not_authenticated(bootstrap):
+    """Test message sending when not authenticated."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = False
+
+    result = await chat._send_message("Test message")  # pylint: disable=protected-access
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_kickchat_send_message_api_error(bootstrap):
+    """Test message sending with API error."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('access_token', 'refresh_token')
+    chat.oauth = mock_oauth
+
+    # Mock failed API response
+    with aioresponses() as mock_resp:
+        mock_resp.post('https://api.kick.com/public/v1/chat',
+                       status=400,
+                       payload={"message": "Invalid request"})
+
+        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_kickchat_send_message_token_expired(bootstrap):
+    """Test message sending with expired token."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('access_token', 'refresh_token')
+    chat.oauth = mock_oauth
+
+    # Mock 401 response (token expired)
+    with aioresponses() as mock_resp:
+        mock_resp.post('https://api.kick.com/public/v1/chat',
+                       status=401,
+                       payload={"message": "Unauthorized"})
+
+        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+
+        assert result is False
+        assert chat.authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_kickchat_send_message_smart_splitting(bootstrap):
+    """Test message splitting for messages longer than KICK_MESSAGE_LIMIT."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('access_token', 'refresh_token')
+    chat.oauth = mock_oauth
+
+    # Create a long message that exceeds KICK_MESSAGE_LIMIT (500 chars)
+    long_message = "This is a very long message. " * 20  # ~600 characters
+    assert len(long_message) > nowplaying.kick.chat.KICK_MESSAGE_LIMIT  #pylint: disable=no-member
+
+    # Mock _send_single_message to track calls
+    with patch.object(chat, '_send_single_message', new_callable=AsyncMock) as mock_send_single:
+        mock_send_single.return_value = True
+
+        result = await chat._send_message(long_message)  # pylint: disable=protected-access
+
+        # Verify the message was split and sent in multiple parts
+        assert result is True
+        assert mock_send_single.call_count > 1  # Should be called multiple times
+
+        # Verify each part is within the limit
+        for call in mock_send_single.call_args_list:
+            message_part = call[0][0]  # First argument of each call
+            assert len(message_part) <= nowplaying.kick.chat.KICK_MESSAGE_LIMIT
+            assert message_part.strip()  # Should not be empty
+
+        # Verify content preservation - reconstruct message from parts
+        sent_parts = [call[0][0] for call in mock_send_single.call_args_list]
+        reconstructed = ' '.join(sent_parts)
+
+        # Should preserve essential content (allowing for some spacing differences)
+        assert "This is a very long message" in reconstructed
+
+
+@pytest.mark.asyncio
+async def test_kickchat_send_message_empty_content(bootstrap):
+    """Test message sending with empty or whitespace-only content."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('access_token', 'refresh_token')
+    chat.oauth = mock_oauth
+
+    # Test empty message
+    result = await chat._send_message("")  # pylint: disable=protected-access
+    assert result is False
+
+    # Test whitespace-only message
+    result = await chat._send_message("   \n\t   ")  # pylint: disable=protected-access
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_kickchat_process_announcement_no_metadata(bootstrap):
+    """Test track announcement with no metadata."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock metadb to return None
+    chat.metadb.read_last_meta_async = AsyncMock(return_value=None)
+
+    await chat._process_announcement()  # pylint: disable=protected-access
+
+    # Should not crash, just return early
+
+
+@pytest.mark.asyncio
+async def test_kickchat_async_announce_track_no_template(bootstrap):
+    """Test track announcement with no template configured."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # No announcement template configured
+    config.cparser.setValue('kick/announce', '')
+
+    # Mock metadb to return metadata
+    mock_metadata = {'artist': 'Test Artist', 'title': 'Test Title'}
+    chat.metadb.read_last_meta_async = AsyncMock(return_value=mock_metadata)
+
+    await chat._process_announcement()  # pylint: disable=protected-access
+
+    # Should not crash, just return early
+
+
+@pytest.mark.asyncio
+async def test_kickchat_async_announce_track_success(bootstrap):
+    """Test successful track announcement."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Configure announcement template in test directory
+    test_template_dir = config.testdir / 'testsuite' / 'templates'
+    test_template_dir.mkdir(parents=True, exist_ok=True)
+    template_path = test_template_dir / 'test_announce.txt'
+    template_path.write_text('Now playing: {{artist}} - {{title}}')
+    config.cparser.setValue('kick/announce', str(template_path))
+
+    # Mock metadb to return metadata
+    mock_metadata = {'artist': 'Test Artist', 'title': 'Test Title'}
+    chat.metadb.read_last_meta_async = AsyncMock(return_value=mock_metadata)
+
+    # Mock send_message
+    chat._send_message = AsyncMock(return_value=True)  # pylint: disable=protected-access
+
+    await chat._process_announcement()  # pylint: disable=protected-access
+
+    # Verify message was sent
+    chat._send_message.assert_called_once_with('Now playing: Test Artist - Test Title')
+
+
+@pytest.mark.asyncio
+async def test_kickchat_async_announce_track_same_track(bootstrap):
+    """Test track announcement skipped for same track."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Set last announced track
+    nowplaying.kick.chat.LASTANNOUNCED['artist'] = 'Test Artist'  # pylint: disable=no-member
+    nowplaying.kick.chat.LASTANNOUNCED['title'] = 'Test Title'  # pylint: disable=no-member
+
+    # Mock metadb to return same metadata
+    mock_metadata = {'artist': 'Test Artist', 'title': 'Test Title'}
+    chat.metadb.read_last_meta_async = AsyncMock(return_value=mock_metadata)
+
+    # Mock send_message
+    chat._send_message = AsyncMock(return_value=True)
+
+    await chat._process_announcement()  # pylint: disable=protected-access
+
+    # Verify message was NOT sent (same track)
+    chat._send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kickchat_delay_write(bootstrap):
+    """Test announcement delay."""
+    config = bootstrap
+    config.cparser.setValue('kick/announcedelay', 2.0)
+
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    # This should not raise an exception and should delay appropriately
+    await chat._delay_write()
+
+
+@pytest.mark.asyncio
+async def test_kickchat_delay_write_invalid_value(bootstrap):
+    """Test announcement delay with invalid value."""
+    config = bootstrap
+    config.cparser.setValue('kick/announcedelay', 'invalid')
+
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    # Should fall back to default 1.0 seconds
+    await chat._delay_write()
+
+
+def test_kickchat_setup_jinja2(bootstrap):
+    """Test Jinja2 environment setup."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    template_dir = pathlib.Path(bootstrap.templatedir)
+
+    jinja_env = chat.setup_jinja2(template_dir)
+
+    assert isinstance(jinja_env, nowplaying.kick.chat.jinja2.Environment)
+    assert jinja_env.trim_blocks
+
+
+def test_kickchat_finalize_method():
+    """Test _finalize static method."""
+    assert nowplaying.kick.chat.KickChat._finalize('test') == 'test'  #pylint: disable=no-member
+    assert nowplaying.kick.chat.KickChat._finalize(None) == ''  #pylint: disable=no-member
+    assert nowplaying.kick.chat.KickChat._finalize('') == ''  #pylint: disable=no-member
+
+
+@pytest.mark.asyncio
+async def test_kickchat_stop(bootstrap):
+    """Test chat stop functionality."""
+    config = bootstrap
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock watcher
+    mock_watcher = MagicMock()
+    chat.watcher = mock_watcher
+
+    # Add mock task
+    mock_task = MagicMock()
+    chat.tasks.add(mock_task)
+
+    await chat.stop()
+
+    # Verify cleanup
+    mock_task.cancel.assert_called_once()
+    mock_watcher.stop.assert_called_once()
+    assert chat.authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_kickchat_run_chat_disabled(bootstrap):
+    """Test run_chat when chat is disabled."""
+    config = bootstrap
+    config.cparser.setValue('kick/chat', False)
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+
+    # Set stop event immediately to exit loop
+    stopevent.set()
+
+    await chat.run_chat(mock_oauth)
+
+    # Should exit early without doing anything
+
+
+@pytest.mark.asyncio
+async def test_kickchat_run_chat_no_channel(bootstrap):
+    """Test run_chat with no channel configured."""
+    config = bootstrap
+    config.cparser.setValue('kick/chat', True)
+    config.cparser.setValue('kick/channel', '')
+    stopevent = asyncio.Event()
+
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  #pylint: disable=no-member
+    chat._authenticate = AsyncMock(return_value=True)
+
+    # Mock OAuth2 handler
+    mock_oauth = MagicMock()
+
+    # Create a task that will exit after short delay
+    async def stop_after_delay():
+        await asyncio.sleep(0.1)
+        stopevent.set()
+
+    # Run both tasks concurrently
+    await asyncio.gather(chat.run_chat(mock_oauth), stop_after_delay(), return_exceptions=True)
+
+
+# Settings tests
+def test_kickchat_settings_init():
+    """Test KickChatSettings initialization."""
+    settings = nowplaying.kick.settings.KickChatSettings()  #pylint: disable=no-member
+
+    assert settings.widget is None
+
+
+def test_kickchat_settings_connect():
+    """Test settings connection."""
+    settings = nowplaying.kick.settings.KickChatSettings()  #pylint: disable=no-member
+    mock_uihelp = MagicMock()
+    mock_widget = MagicMock()
+
+    settings.connect(mock_uihelp, mock_widget)
+
+    assert settings.widget == mock_widget
+
+
+def test_kickchat_settings_load(bootstrap):
+    """Test settings loading."""
+    config = bootstrap
+    config.cparser.setValue('kick/chat', True)
+    config.cparser.setValue('kick/announce', 'test_template.txt')
+    config.cparser.setValue('kick/announcedelay', 2.5)
+
+    settings = nowplaying.kick.settings.KickChatSettings()  #pylint: disable=no-member
+    mock_widget = MagicMock()
+
+    settings.load(config, mock_widget)
+
+    assert settings.widget == mock_widget
+    mock_widget.enable_checkbox.setChecked.assert_called_with(True)
+    mock_widget.announce_lineedit.setText.assert_called_with('test_template.txt')
+
+
+def test_kickchat_settings_save(bootstrap):
+    """Test settings saving."""
+    config = bootstrap
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = True
+    mock_widget.announce_lineedit.text.return_value = 'new_template.txt'
+    # Setup announce_delay_lineedit for delay handling
+    mock_widget.announce_delay_lineedit.text.return_value = '3.0'
+    mock_subprocesses = MagicMock()
+
+    # Patch hasattr to return False only for command_perm_table, True for announce_delay_lineedit
+    def mock_hasattr(obj, attr):  # pylint: disable=unused-argument
+        if attr == 'command_perm_table':
+            return False
+        elif attr == 'announce_delay_lineedit':
+            return True
+        return False
+
+    with patch('nowplaying.kick.settings.hasattr', side_effect=mock_hasattr):
+        nowplaying.kick.settings.KickChatSettings.save(config, mock_widget, mock_subprocesses)
+
+    assert config.cparser.value('kick/chat', type=bool)
+    assert config.cparser.value('kick/announce') == 'new_template.txt'
+    assert config.cparser.value('kick/announcedelay', type=float) == 3.0
+
+
+def test_kickchat_settings_verify_enabled_no_template():
+    """Test settings verification fails when enabled but no template."""
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = True
+    mock_widget.announce_lineedit.text.return_value = ''
+
+    with pytest.raises(PluginVerifyError, match='Kick announcement template is required'):
+        nowplaying.kick.settings.KickChatSettings.verify(mock_widget)  #pylint: disable=no-member
+
+
+def test_kickchat_settings_verify_disabled():
+    """Test settings verification passes when disabled."""
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = False
+
+    # Should not raise an exception
+    nowplaying.kick.settings.KickChatSettings.verify(mock_widget)  #pylint: disable=no-member
+
+
+def test_kickchat_settings_verify_enabled_with_template():
+    """Test settings verification passes when enabled with template."""
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = True
+    mock_widget.announce_lineedit.text.return_value = 'template.txt'
+
+    # Should not raise an exception
+    nowplaying.kick.settings.KickChatSettings.verify(mock_widget)  #pylint: disable=no-member

--- a/tests/kick/test_kick_chat.py
+++ b/tests/kick/test_kick_chat.py
@@ -336,8 +336,8 @@ async def test_kickchat_async_announce_track_same_track(bootstrap):
     chat.authenticated = True
 
     # Set last announced track
-    nowplaying.kick.chat.LASTANNOUNCED['artist'] = 'Test Artist'  # pylint: disable=no-member
-    nowplaying.kick.chat.LASTANNOUNCED['title'] = 'Test Title'  # pylint: disable=no-member
+    chat.last_announced['artist'] = 'Test Artist'
+    chat.last_announced['title'] = 'Test Title'
 
     # Mock metadb to return same metadata
     mock_metadata = {'artist': 'Test Artist', 'title': 'Test Title'}

--- a/tests/kick/test_kick_integration.py
+++ b/tests/kick/test_kick_integration.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""Integration tests for the Kick module - REFACTORED VERSION."""
+
+import asyncio
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aioresponses import aioresponses
+
+import nowplaying.kick.oauth2  # pylint: disable=import-error,no-name-in-module
+import nowplaying.kick.chat  # pylint: disable=import-error,no-name-in-module
+import nowplaying.kick.launch  # pylint: disable=import-error,no-name-in-module
+import nowplaying.kick.settings  # pylint: disable=import-error,no-name-in-module
+
+
+# Fixtures
+@pytest.fixture
+def kick_integration_config(bootstrap):
+    """Create a fully configured integration test config."""
+    config = bootstrap
+    config.cparser.setValue('kick/clientid', 'test_client_id')
+    config.cparser.setValue('kick/secret', 'test_secret')
+    config.cparser.setValue('kick/redirecturi', 'http://localhost:8080/callback')
+    config.cparser.setValue('kick/channel', 'testchannel')
+    config.cparser.setValue('kick/chat', True)
+    config.cparser.setValue('kick/accesstoken', 'valid_token')
+    config.cparser.setValue('kick/refreshtoken', 'refresh_token')
+    config.cparser.setValue('kick/announcedelay', 0.1)  # Fast for testing
+    return config
+
+
+@pytest.fixture
+def mock_oauth_success():
+    """Create a mock OAuth handler that succeeds."""
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = ('valid_token', 'refresh_token')
+
+    # Create AsyncMock with explicit spec to avoid attribute access issues
+    validate_mock = AsyncMock(return_value=True)
+    validate_mock.__name__ = 'validate_token'  # Prevent string conversion issues
+    mock_oauth.validate_token = validate_mock
+    return mock_oauth
+
+
+@pytest.fixture
+def mock_oauth_failure():
+    """Create a mock OAuth handler that fails."""
+    mock_oauth = MagicMock()
+    mock_oauth.get_stored_tokens.return_value = (None, None)
+    mock_oauth.validate_token = AsyncMock(return_value=False)
+    return mock_oauth
+
+
+@pytest.fixture
+def kick_templates(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Create test template files for integration tests."""
+    config = kick_integration_config
+    # Bootstrap fixture already sets up templatedir, just use it
+    config.templatedir.mkdir(parents=True, exist_ok=True)
+
+    templates = {
+        'announce': config.templatedir / 'kick_announce.txt',
+        'track': config.templatedir / 'kickbot_track.txt',
+        'artist': config.templatedir / 'kickbot_artist.txt',
+        'request': config.templatedir / 'kickbot_request.txt',
+    }
+
+    templates['announce'].write_text('Now playing: {{artist}} - {{title}}')
+    templates['track'].write_text('Now playing: {{artist}} - {{title}}')
+    templates['artist'].write_text('Artist: {{artist}}')
+    templates['request'].write_text('Request: {{request}}')
+
+    return templates
+
+
+@pytest.fixture
+def mock_chat_with_oauth(kick_integration_config, mock_oauth_success):  # pylint: disable=redefined-outer-name
+    """Create a chat instance with mocked OAuth."""
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=kick_integration_config, stopevent=stopevent)  # pylint: disable=no-member
+    chat.oauth = mock_oauth_success
+    return chat, stopevent
+
+
+@pytest.fixture
+def mock_aiohttp_success():
+    """Fixture that mocks successful aiohttp responses using aioresponses."""
+    with aioresponses() as mock:
+        # Setup default success responses for common endpoints (repeat=True for multiple calls)
+        mock.post("https://api.kick.com/public/v1/chat",
+                  status=200,
+                  payload={'success': True},
+                  repeat=True)
+        yield mock
+
+
+@pytest.fixture
+def mock_responses():
+    """Fixture that provides aioresponses for mocking HTTP calls."""
+    with aioresponses() as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_full_authentication_flow(kick_integration_config, mock_responses):  # pylint: disable=redefined-outer-name
+    """Test complete OAuth2 authentication flow."""
+    config = kick_integration_config
+
+    # Create OAuth2 handler
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+    # Test authorization URL generation
+    auth_url = oauth.get_authorization_url()
+    assert 'client_id=test_client_id' in auth_url
+    assert oauth.code_verifier is not None
+    assert oauth.state is not None
+
+    # Mock successful token exchange
+    mock_token_response = {
+        'access_token': 'test_access_token',
+        'refresh_token': 'test_refresh_token'
+    }
+
+    mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token", status=200, payload=mock_token_response)
+
+    result = await oauth.exchange_code_for_token('test_auth_code', oauth.state)
+
+    assert result == mock_token_response
+    assert oauth.access_token == 'test_access_token'
+    assert oauth.refresh_token == 'test_refresh_token'
+
+    # Verify tokens were stored in config
+    assert config.cparser.value('kick/accesstoken') == 'test_access_token'
+    assert config.cparser.value('kick/refreshtoken') == 'test_refresh_token'
+
+
+@pytest.mark.asyncio
+async def test_chat_with_oauth_integration(mock_chat_with_oauth, mock_responses):  # pylint: disable=redefined-outer-name
+    """Test chat integration with OAuth2."""
+    chat, _ = mock_chat_with_oauth
+
+    # Test authentication
+    result = await chat._authenticate()  # pylint: disable=protected-access
+    assert result
+    assert chat.authenticated
+
+    # Mock message sending endpoint
+    mock_responses.post("https://api.kick.com/public/v1/chat",
+                        status=200,
+                        payload={
+                            'data': {
+                                'is_sent': True
+                            },
+                            'message': 'OK'
+                        })
+
+    # Test message sending
+    result = await chat._send_message("Test message")  # pylint: disable=protected-access
+    assert result is True
+
+
+# Parameterized settings integration tests
+@pytest.mark.parametrize("settings_type", ['main', 'chat'])
+def test_settings_integration_scenarios(kick_integration_config, settings_type):  # pylint: disable=redefined-outer-name
+    """Test settings integration for different types."""
+    config = kick_integration_config
+
+    if settings_type == 'main':
+        settings = nowplaying.kick.settings.KickSettings()  # pylint: disable=no-member
+
+        # Create a very explicit mock to avoid AsyncMock contamination
+        mock_widget = MagicMock(spec=[
+            'enable_checkbox', 'channel_lineedit', 'clientid_lineedit', 'secret_lineedit',
+            'redirecturi_lineedit', 'authenticate_button', 'oauth_status_label'
+        ])
+
+        # Ensure all text methods return proper strings
+        mock_widget.clientid_lineedit.text.return_value = 'test_client'
+        mock_widget.secret_lineedit.text.return_value = 'test_secret'
+        mock_widget.redirecturi_lineedit.text.return_value = 'http://localhost:8080'
+        mock_widget.channel_lineedit.text.return_value = 'testchannel'
+
+        settings.load(config, mock_widget)
+        assert isinstance(settings.oauth, nowplaying.kick.oauth2.KickOAuth2)  # pylint: disable=no-member
+    else:
+        chat_settings = nowplaying.kick.settings.KickChatSettings()  # pylint: disable=no-member
+        mock_chat_widget = MagicMock()
+
+        chat_settings.load(config, mock_chat_widget)
+        assert chat_settings.widget == mock_chat_widget
+
+
+@pytest.mark.asyncio
+async def test_token_refresh_integration(kick_integration_config, mock_responses):  # pylint: disable=redefined-outer-name
+    """Test token refresh across components."""
+    config = kick_integration_config
+    config.cparser.setValue('kick/accesstoken', 'expired_token')
+
+    # Create OAuth2 handler
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+    # Mock refresh token response
+    mock_refresh_response = {
+        'access_token': 'new_access_token',
+        'refresh_token': 'new_refresh_token'
+    }
+
+    mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token",
+                        status=200,
+                        payload=mock_refresh_response)
+
+    result = await oauth.refresh_access_token('valid_refresh_token')
+
+    assert result == mock_refresh_response
+    assert oauth.access_token == 'new_access_token'
+
+    # Verify new tokens were stored
+    assert config.cparser.value('kick/accesstoken') == 'new_access_token'
+    assert config.cparser.value('kick/refreshtoken') == 'new_refresh_token'
+
+
+@pytest.mark.asyncio
+async def test_announcement_flow_integration(kick_integration_config, kick_templates):  # pylint: disable=redefined-outer-name
+    """Test track announcement flow integration."""
+    config = kick_integration_config
+    config.cparser.setValue('kick/announce', str(kick_templates['announce']))
+
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock metadata
+    mock_metadata = {'artist': 'Test Artist', 'title': 'Test Song'}
+    chat.metadb.read_last_meta_async = AsyncMock(return_value=mock_metadata)
+
+    # Mock message sending
+    chat._send_message = AsyncMock(return_value=True)  # pylint: disable=protected-access
+
+    # Test announcement
+    await chat._process_announcement()  # pylint: disable=protected-access
+
+    # Verify message was sent with rendered template
+    chat._send_message.assert_called_once_with('Now playing: Test Artist - Test Song')  # pylint: disable=protected-access
+
+    # Verify last announced was updated
+    assert nowplaying.kick.chat.LASTANNOUNCED['artist'] == 'Test Artist'  # pylint: disable=no-member
+    assert nowplaying.kick.chat.LASTANNOUNCED['title'] == 'Test Song'  # pylint: disable=no-member
+
+
+def test_command_discovery_integration(kick_integration_config, kick_templates):  # pylint: disable=redefined-outer-name,unused-argument
+    """Test command template discovery integration."""
+    config = kick_integration_config
+
+    # Create settings and update commands
+    chat_settings = nowplaying.kick.settings.KickChatSettings()  # pylint: disable=no-member
+    chat_settings.update_kickbot_commands(config)
+
+    # Verify commands were created
+    groups = config.cparser.childGroups()
+    assert 'kickbot-command-track' in groups
+    assert 'kickbot-command-artist' in groups
+    assert 'kickbot-command-request' in groups
+
+    # Verify default permissions (all disabled)
+    config.cparser.beginGroup('kickbot-command-track')
+    for permission in chat_settings.KICKBOT_CHECKBOXES:
+        assert not config.cparser.value(permission, type=bool)
+    config.cparser.endGroup()
+
+
+# Parameterized error handling tests
+@pytest.mark.parametrize("component,error_scenario,expected_behavior", [
+    ('oauth', 'network_error', 'raises_exception'),
+    ('chat', 'no_tokens', 'returns_false'),
+    ('chat', 'not_authenticated', 'returns_false'),
+])
+@pytest.mark.asyncio
+async def test_error_handling_scenarios( # pylint: disable=redefined-outer-name
+        kick_integration_config,
+        component,
+        error_scenario,
+        expected_behavior):
+    """Test error handling across different components and scenarios."""
+    config = kick_integration_config
+
+    if component == 'oauth':
+        oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+        oauth.code_verifier = 'test_verifier'
+
+        # Use aioresponses to mock network error
+        with aioresponses() as mock:
+            mock.post(f"{oauth.OAUTH_HOST}/oauth/token", exception=Exception("Network error"))
+
+            if expected_behavior == 'raises_exception':
+                with pytest.raises(Exception):
+                    await oauth.exchange_code_for_token('test_code')
+            else:
+                # If we expect different behavior, implement it here
+                result = await oauth.exchange_code_for_token('test_code')
+                assert result is False  # or other expected behavior
+
+    elif component == 'chat':
+        stopevent = asyncio.Event()
+        chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+
+        if error_scenario == 'no_tokens':
+            # Mock OAuth to fail
+            mock_oauth = MagicMock()
+            mock_oauth.get_stored_tokens.return_value = (None, None)
+            chat.oauth = mock_oauth
+
+            result = await chat._authenticate()  # pylint: disable=protected-access
+
+            if expected_behavior == 'returns_false':
+                assert not result
+                assert not chat.authenticated
+
+        elif error_scenario == 'not_authenticated':
+            chat.authenticated = False
+
+            result = await chat._send_message("Test message")  # pylint: disable=protected-access
+
+            if expected_behavior == 'returns_false':
+                assert result is False
+
+
+@pytest.mark.asyncio
+async def test_config_changes_integration(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test configuration changes affecting components."""
+    config = kick_integration_config
+
+    # Initial configuration
+    config.cparser.setValue('kick/clientid', 'old_client_id')
+    config.cparser.setValue('kick/channel', 'oldchannel')
+    config.cparser.setValue('kick/accesstoken', 'old_token')
+
+    # Test settings save with changes
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = True
+    mock_widget.channel_lineedit.text.return_value = 'newchannel'
+    mock_widget.clientid_lineedit.text.return_value = 'new_client_id'
+    mock_widget.secret_lineedit.text.return_value = 'secret'
+    mock_widget.redirecturi_lineedit.text.return_value = 'http://localhost:8080'
+
+    mock_subprocesses = MagicMock()
+
+    with patch('time.sleep'):  # Speed up test
+        nowplaying.kick.settings.KickSettings.save(config, mock_widget, mock_subprocesses)  # pylint: disable=no-member
+
+    # Verify kickbot was restarted due to changes
+    mock_subprocesses.stop_kickbot.assert_called_once()
+    mock_subprocesses.start_kickbot.assert_called_once()
+
+    # Verify tokens were cleared due to config changes
+    assert config.cparser.value('kick/accesstoken') is None
+
+
+# Parameterized UI widget integration tests
+@pytest.mark.parametrize("widget_type", ['main', 'chat'])
+def test_ui_widget_integration_scenarios(widget_type):
+    """Test UI widget integration for different widget types."""
+    if widget_type == 'main':
+        main_settings = nowplaying.kick.settings.KickSettings()  # pylint: disable=no-member
+        mock_uihelp = MagicMock()
+        mock_widget = MagicMock()
+
+        main_settings.connect(mock_uihelp, mock_widget)
+
+        # Verify button connections
+        mock_widget.authenticate_button.clicked.connect.assert_called_once()
+        mock_widget.clientid_lineedit.editingFinished.connect.assert_called_once()
+
+    else:
+        chat_settings = nowplaying.kick.settings.KickChatSettings()  # pylint: disable=no-member
+        mock_chat_widget = MagicMock()
+        mock_chat_widget.announce_button = MagicMock()
+        mock_chat_widget.add_button = MagicMock()
+        mock_chat_widget.del_button = MagicMock()
+
+        chat_settings.connect(MagicMock(), mock_chat_widget)
+
+        # Verify chat widget connections
+        mock_chat_widget.announce_button.clicked.connect.assert_called_once()
+        mock_chat_widget.add_button.clicked.connect.assert_called_once()
+        mock_chat_widget.del_button.clicked.connect.assert_called_once()
+
+
+# Test edge cases and error conditions
+
+
+@pytest.mark.asyncio
+async def test_malformed_api_responses(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test handling of malformed API responses."""
+    config = kick_integration_config
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+    oauth.code_verifier = 'test_verifier'
+
+    # Test malformed JSON response using aioresponses
+    with aioresponses() as mock:
+        mock.post(f"{oauth.OAUTH_HOST}/oauth/token", status=200, body='invalid json content')
+
+        with pytest.raises(Exception):
+            await oauth.exchange_code_for_token('test_code')
+
+
+@pytest.mark.asyncio
+async def test_network_timeouts(kick_integration_config, mock_oauth_success):  # pylint: disable=redefined-outer-name
+    """Test network timeout handling."""
+    config = kick_integration_config
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+    chat.authenticated = True
+    chat.oauth = mock_oauth_success
+
+    # Test timeout during message sending using aioresponses
+    with aioresponses() as mock:
+        mock.post("https://api.kick.com/public/v1/chat",
+                  exception=asyncio.TimeoutError("Request timed out"))
+
+        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+        assert result is False
+
+
+def test_invalid_template_files(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test handling of invalid template files."""
+    config = kick_integration_config
+
+    # Create invalid template path
+    config.cparser.setValue('kick/announce', '/nonexistent/template.txt')
+
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+    chat.authenticated = True
+
+    # Mock metadata
+    mock_metadata = {'artist': 'Test', 'title': 'Test'}
+    chat.metadb.read_last_meta_async = AsyncMock(return_value=mock_metadata)
+
+    # Test announcement with invalid template - should not crash
+    async def test_announcement():
+        await chat._process_announcement()  # pylint: disable=protected-access
+
+    # Should not raise exception
+    asyncio.run(test_announcement())
+
+
+def test_concurrent_access(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test concurrent access to components."""
+    config = kick_integration_config
+
+    # Test multiple OAuth instances
+    oauth1 = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+    oauth2 = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+    # Both should work independently
+    oauth1._generate_pkce_parameters()  # pylint: disable=protected-access
+    oauth2._generate_pkce_parameters()  # pylint: disable=protected-access
+
+    assert oauth1.code_verifier != oauth2.code_verifier
+    assert oauth1.state != oauth2.state
+
+
+def test_memory_cleanup(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test memory cleanup on component destruction."""
+    config = kick_integration_config
+    stopevent = asyncio.Event()
+
+    # Create components
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+    launch = nowplaying.kick.launch.KickLaunch(config=config, stopevent=stopevent)  # pylint: disable=no-member
+
+    # Add tasks
+    mock_task = MagicMock()
+    chat.tasks.add(mock_task)
+    launch.tasks.add(mock_task)
+
+    # Test cleanup
+    async def test_cleanup():
+        await chat.stop()
+        await launch.stop()
+
+    asyncio.run(test_cleanup())
+
+    # Verify tasks were cancelled
+    mock_task.cancel.assert_called()
+
+
+def test_unicode_and_special_characters(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test handling of unicode and special characters."""
+    config = kick_integration_config
+
+    # Bootstrap already sets up templatedir, just use it
+    config.templatedir.mkdir(parents=True, exist_ok=True)
+
+    # Test template with unicode
+    template_content = 'Now playing: {{artist}} - {{title}} 🎵'
+    template_path = config.templatedir / 'unicode_template.txt'
+    template_path.write_text(template_content, encoding='utf-8')
+
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+
+    # Test Jinja2 environment can handle unicode
+    env = chat.setup_jinja2(pathlib.Path(config.templatedir))
+    template = env.get_template('unicode_template.txt')
+
+    result = template.render(artist='Björk', title='Jóga')
+    assert 'Björk' in result
+    assert 'Jóga' in result
+    assert '🎵' in result
+
+
+# Test performance-related integration scenarios
+
+
+@pytest.mark.asyncio
+async def test_rapid_message_sending(mock_chat_with_oauth, mock_aiohttp_success):  # pylint: disable=redefined-outer-name,unused-argument
+    """Test rapid successive message sending."""
+    chat, _ = mock_chat_with_oauth
+    chat.authenticated = True
+
+    # Send multiple messages quickly
+    results = await asyncio.gather(*[chat._send_message(f"Message {i}") for i in range(5)])  # pylint: disable=protected-access
+
+    # All should succeed
+    assert all(results)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_authentication_attempts(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test concurrent authentication attempts."""
+    config = kick_integration_config
+
+    # Create multiple launch instances
+    launches = [
+        nowplaying.kick.launch.KickLaunch(config=config, stopevent=asyncio.Event())  # pylint: disable=no-member
+        for _ in range(3)
+    ]
+
+    # Mock token validation for all using the shared utils function
+    with patch('nowplaying.kick.utils.qtsafe_validate_kick_token', return_value=True):
+        # Mock stored tokens for all launches
+        for launch in launches:
+            launch.oauth.get_stored_tokens = MagicMock(return_value=('valid_token',
+                                                                     'refresh_token'))
+        # Authenticate concurrently
+        results = await asyncio.gather(*[launch.authenticate() for launch in launches])
+
+    # All should succeed
+    assert all(results)
+
+
+def test_large_template_processing(kick_integration_config):  # pylint: disable=redefined-outer-name
+    """Test processing of large template files."""
+    config = kick_integration_config
+
+    # Bootstrap already sets up templatedir, just use it
+    config.templatedir.mkdir(parents=True, exist_ok=True)
+
+    large_template = 'Now playing: {{artist}} - {{title}}\n' * 1000
+    template_path = config.templatedir / 'large_template.txt'
+    template_path.write_text(large_template)
+
+    stopevent = asyncio.Event()
+    chat = nowplaying.kick.chat.KickChat(config=config, stopevent=stopevent)  # pylint: disable=no-member
+
+    # Should handle large templates without issues
+    env = chat.setup_jinja2(pathlib.Path(config.templatedir))
+    template = env.get_template('large_template.txt')
+
+    result = template.render(artist='Test Artist', title='Test Song')
+    assert len(result) > 10000  # Should be large
+    assert 'Test Artist' in result

--- a/tests/kick/test_kick_integration.py
+++ b/tests/kick/test_kick_integration.py
@@ -244,8 +244,8 @@ async def test_announcement_flow_integration(kick_integration_config, kick_templ
     chat._send_message.assert_called_once_with('Now playing: Test Artist - Test Song')  # pylint: disable=protected-access
 
     # Verify last announced was updated
-    assert nowplaying.kick.chat.LASTANNOUNCED['artist'] == 'Test Artist'  # pylint: disable=no-member
-    assert nowplaying.kick.chat.LASTANNOUNCED['title'] == 'Test Song'  # pylint: disable=no-member
+    assert chat.last_announced['artist'] == 'Test Artist'
+    assert chat.last_announced['title'] == 'Test Song'
 
 
 def test_command_discovery_integration(kick_integration_config, kick_templates):  # pylint: disable=redefined-outer-name,unused-argument
@@ -345,7 +345,9 @@ async def test_config_changes_integration(kick_integration_config):  # pylint: d
 
     mock_subprocesses = MagicMock()
 
-    with patch('time.sleep'):  # Speed up test
+    with patch('nowplaying.kick.settings.QTimer.singleShot') as mock_timer:
+        # Configure the mock to immediately call the callback
+        mock_timer.side_effect = lambda delay, callback: callback()
         nowplaying.kick.settings.KickSettings.save(config, mock_widget, mock_subprocesses)  # pylint: disable=no-member
 
     # Verify kickbot was restarted due to changes

--- a/tests/kick/test_kick_launch.py
+++ b/tests/kick/test_kick_launch.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Unit tests for Kick launch functionality - REFACTORED VERSION."""
+
+import asyncio
+import signal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import requests
+
+import nowplaying.kick.oauth2  # pylint: disable=import-error,no-name-in-module,no-member
+import nowplaying.kick.launch  # pylint: disable=import-error,no-name-in-module,no-member
+import nowplaying.kick.utils  # pylint: disable=import-error,no-name-in-module,no-member
+
+
+# Fixtures
+@pytest.fixture
+def kick_launch(bootstrap):
+    """Create a KickLaunch instance with bootstrap config."""
+    return nowplaying.kick.launch.KickLaunch(config=bootstrap)  # pylint: disable=no-member
+
+
+@pytest.fixture
+def kick_launch_with_stopevent(bootstrap):
+    """Create a KickLaunch instance with bootstrap config and stopevent."""
+    stopevent = asyncio.Event()
+    launch = nowplaying.kick.launch.KickLaunch(config=bootstrap, stopevent=stopevent)  # pylint: disable=no-member
+    return launch, stopevent
+
+
+def test_init_with_config(bootstrap):
+    """Test KickLaunch initialization with config."""
+    stopevent = asyncio.Event()
+
+    launch = nowplaying.kick.launch.KickLaunch(config=bootstrap, stopevent=stopevent)  # pylint: disable=no-member
+
+    assert launch.config == bootstrap
+    assert launch.stopevent == stopevent
+    assert launch.widgets is None
+    assert launch.chat is None
+    assert launch.loop is None
+    assert isinstance(launch.oauth, nowplaying.kick.oauth2.KickOAuth2)  # pylint: disable=no-member
+    assert len(launch.tasks) == 0
+
+
+def test_init_without_stopevent(kick_launch):  # pylint: disable=redefined-outer-name
+    """Test KickLaunch initialization without stopevent."""
+    launch = kick_launch
+
+    assert isinstance(launch.stopevent, asyncio.Event)
+
+
+def test_init_without_config():
+    """Test KickLaunch initialization without config."""
+    launch = nowplaying.kick.launch.KickLaunch()  # pylint: disable=no-member
+
+    assert launch.config is None
+    assert isinstance(launch.stopevent, asyncio.Event)
+
+
+# Parameterized token validation tests
+@pytest.mark.parametrize(
+    "status_code,response_data,expected_result",
+    [
+        # Success case
+        (200, {
+            'data': {
+                'active': True,
+                'client_id': 'test_client',
+                'scope': 'user:read chat:write'
+            }
+        }, True),
+        # Inactive token
+        (200, {
+            'data': {
+                'active': False
+            }
+        }, False),
+        # HTTP error codes
+        (401, {}, False),
+        (403, {}, False),
+        (500, {}, False),
+    ])
+def test_validate_kick_token_sync_responses(  # pylint: disable=redefined-outer-name,unused-argument
+        kick_launch,
+        status_code,
+        response_data,
+        expected_result):
+    """Test token validation with various HTTP responses."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = response_data
+
+    with patch('requests.post', return_value=mock_response):
+        result = nowplaying.kick.utils.qtsafe_validate_kick_token('test_token')  # pylint: disable=no-member
+
+        assert result == expected_result
+
+
+@pytest.mark.parametrize("token,expected_result", [
+    ('', False),
+    (None, False),
+])
+def test_validate_kick_token_sync_invalid_input(kick_launch, token, expected_result):  # pylint: disable=redefined-outer-name,unused-argument
+    """Test token validation with invalid inputs."""
+    result = nowplaying.kick.utils.qtsafe_validate_kick_token(token)  # pylint: disable=no-member
+    assert result == expected_result
+
+
+@pytest.mark.parametrize("exception_type,exception_msg", [
+    (requests.RequestException, "Network error"),
+    (ValueError, "Invalid JSON"),
+])
+def test_validate_kick_token_sync_exceptions(kick_launch, exception_type, exception_msg):  # pylint: disable=redefined-outer-name,unused-argument
+    """Test token validation with various exceptions."""
+    if exception_type == ValueError:
+        # JSON parsing error
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = exception_type(exception_msg)
+
+        with patch('requests.post', return_value=mock_response):
+            result = nowplaying.kick.utils.qtsafe_validate_kick_token('test_token')  # pylint: disable=no-member
+    else:
+        # Network error
+        with patch('requests.post', side_effect=exception_type(exception_msg)):
+            result = nowplaying.kick.utils.qtsafe_validate_kick_token('test_token')  # pylint: disable=no-member
+
+    assert not result
+
+
+# Parameterized authentication tests
+@pytest.mark.parametrize(
+    "stored_tokens,token_validation,refresh_succeeds,expected_result",
+    [
+        # No tokens
+        ((None, None), None, None, False),
+        # Valid token
+        (('valid_token', 'refresh_token'), True, None, True),
+        # Invalid token, no refresh token
+        (('invalid_token', None), False, None, False),
+        # Invalid token, refresh succeeds
+        (('invalid_token', 'refresh_token'), False, True, True),
+        # Invalid token, refresh fails
+        (('invalid_token', 'refresh_token'), False, False, False),
+    ])
+@pytest.mark.asyncio
+async def test_authenticate_scenarios(  # pylint: disable=redefined-outer-name,unused-argument
+        kick_launch,
+        stored_tokens,
+        token_validation,
+        refresh_succeeds,
+        expected_result):
+    """Test authentication with various scenarios."""
+    # Setup mocks
+    kick_launch.oauth.get_stored_tokens = MagicMock()
+
+    if refresh_succeeds is not None:
+        # Test refresh scenarios
+        kick_launch.oauth.get_stored_tokens.side_effect = [
+            stored_tokens,  # First call
+            ('new_valid_token',
+             stored_tokens[1]) if refresh_succeeds else stored_tokens  # After refresh
+        ]
+        with patch('nowplaying.kick.utils.qtsafe_validate_kick_token') as mock_validate:
+            mock_validate.side_effect = [False, refresh_succeeds]
+
+            if refresh_succeeds:
+                kick_launch.oauth.refresh_access_token = AsyncMock()
+            else:
+                kick_launch.oauth.refresh_access_token = AsyncMock(
+                    side_effect=Exception("Refresh failed"))
+
+            result = await kick_launch.authenticate()
+            assert result == expected_result
+    else:
+        # Simple scenarios
+        kick_launch.oauth.get_stored_tokens.return_value = stored_tokens
+        with patch('nowplaying.kick.utils.qtsafe_validate_kick_token') as mock_validate:
+            if token_validation is not None:
+                mock_validate.return_value = token_validation
+
+            result = await kick_launch.authenticate()
+            assert result == expected_result
+
+
+@pytest.mark.asyncio
+async def test_authenticate_exception(kick_launch):  # pylint: disable=redefined-outer-name
+    """Test authentication with unexpected exception."""
+    kick_launch.oauth.get_stored_tokens = MagicMock(side_effect=Exception("Unexpected error"))
+
+    result = await kick_launch.authenticate()
+    assert not result
+
+
+def test_forced_stop(kick_launch_with_stopevent):  # pylint: disable=redefined-outer-name
+    """Test forced stop signal handler."""
+    launch, stopevent = kick_launch_with_stopevent
+
+    assert not stopevent.is_set()
+    launch.forced_stop(signal.SIGINT, None)
+    assert stopevent.is_set()
+
+
+@pytest.mark.parametrize(
+    "has_chat,has_loop",
+    [
+        (True, True),  # Both chat and loop present
+        (False, True),  # No chat, but has loop
+        (True, False),  # Has chat, no loop
+        (False, False),  # Neither present
+    ])
+@pytest.mark.asyncio
+async def test_stop_scenarios(kick_launch_with_stopevent, has_chat, has_loop):  # pylint: disable=redefined-outer-name
+    """Test stop functionality with different configurations."""
+    launch, _ = kick_launch_with_stopevent  # stopevent not used in this test
+
+    # Setup mocks based on parameters
+    if has_chat:
+        mock_chat = AsyncMock()
+        launch.chat = mock_chat
+
+    if has_loop:
+        mock_loop = MagicMock()
+        launch.loop = mock_loop
+
+    await launch.stop()
+
+    # Verify appropriate methods were called
+    if has_chat:
+        mock_chat.stop.assert_called_once()
+    if has_loop:
+        mock_loop.stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_watch_for_exit(kick_launch_with_stopevent):  # pylint: disable=redefined-outer-name
+    """Test watch for exit functionality."""
+    launch, stopevent = kick_launch_with_stopevent
+
+    # Mock stop method
+    launch.stop = AsyncMock()
+
+    # Set stop event after short delay
+    async def set_stop_event():
+        await asyncio.sleep(0.01)
+        stopevent.set()
+
+    # Run both tasks
+    await asyncio.gather(launch._watch_for_exit(), set_stop_event())  # pylint: disable=protected-access
+
+    # Verify stop was called
+    launch.stop.assert_called_once()
+
+
+# Module-level function tests
+@pytest.mark.parametrize("testmode,expected_appname", [
+    (True, 'testsuite'),
+    (False, None),
+])
+@patch('nowplaying.kick.launch.KickLaunch')
+@patch('nowplaying.frozen.frozen_init')
+@patch('nowplaying.bootstrap.set_qt_names')
+@patch('nowplaying.bootstrap.setuplogging')
+@patch('nowplaying.config.ConfigFile')
+def test_start_function(   # pylint: disable=too-many-arguments
+        mock_config,
+        mock_logging,
+        mock_set_names,
+        mock_frozen,
+        mock_kick_launch,
+        testmode,
+        expected_appname):
+    """Test module start function with different testmode values."""
+    mock_stopevent = MagicMock()
+    mock_bundledir = "/test/bundle"
+
+    # Mock objects
+    mock_frozen.return_value = mock_bundledir
+    mock_logging.return_value = "/test/logs"
+    mock_config_instance = MagicMock()
+    mock_config.return_value = mock_config_instance
+    mock_launch_instance = MagicMock()
+    mock_kick_launch.return_value = mock_launch_instance
+
+    # Call function
+    if testmode:
+        nowplaying.kick.launch.start(   # pylint: disable=no-member
+            stopevent=mock_stopevent,
+            bundledir=mock_bundledir,
+            testmode=testmode)
+    else:
+        nowplaying.kick.launch.start(stopevent=mock_stopevent)  # pylint: disable=no-member
+
+    # Verify calls
+    if expected_appname:
+        mock_set_names.assert_called_once_with(appname=expected_appname)
+    else:
+        mock_set_names.assert_called_once_with()
+
+    mock_launch_instance.start.assert_called_once()
+
+
+@pytest.mark.parametrize("exception_raised", [True, False])
+@pytest.mark.asyncio
+async def test_launch_kickbot_function(bootstrap, exception_raised):  # pylint: disable=redefined-outer-name
+    """Test launch_kickbot async function with and without exceptions."""
+    stopevent = asyncio.Event()
+
+    with patch('nowplaying.kick.launch.KickLaunch') as mock_kick_launch:
+        mock_launch_instance = MagicMock()
+
+        if exception_raised:
+            mock_launch_instance.bootstrap = AsyncMock(side_effect=Exception("Test error"))
+        else:
+            mock_launch_instance.bootstrap = AsyncMock()
+
+        mock_kick_launch.return_value = mock_launch_instance
+
+        # Should not raise exception in either case
+        await nowplaying.kick.launch.launch_kickbot(config=bootstrap, stopevent=stopevent)  # pylint: disable=no-member
+
+        mock_kick_launch.assert_called_once_with(config=bootstrap, stopevent=stopevent)
+        mock_launch_instance.bootstrap.assert_called_once()

--- a/tests/kick/test_kick_oauth2.py
+++ b/tests/kick/test_kick_oauth2.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Unit tests for Kick OAuth2 functionality - REFACTORED VERSION."""
+
+import asyncio
+import base64
+import hashlib
+from unittest.mock import patch
+
+import pytest
+from aioresponses import aioresponses
+
+import nowplaying.kick.oauth2  # pylint: disable=import-error,no-name-in-module
+
+
+  # pylint: disable=redefined-outer-name, too-many-arguments, unused-argument
+
+# Fixtures
+@pytest.fixture
+def configured_oauth(bootstrap):  # pylint: disable=redefined-outer-name
+    """Create OAuth2 instance with test configuration."""
+    config = bootstrap
+    config.cparser.setValue('kick/clientid', 'test_client_id')
+    config.cparser.setValue('kick/secret', 'test_secret')
+    config.cparser.setValue('kick/redirecturi', 'http://localhost:8080/callback')
+    return nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+
+@pytest.fixture
+def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
+    """Create OAuth2 instance with PKCE parameters generated."""
+    oauth = configured_oauth
+    oauth._generate_pkce_parameters()  # pylint: disable=protected-access
+    return oauth
+
+
+@pytest.fixture
+def mock_responses():
+    """Fixture that provides aioresponses for mocking HTTP calls."""
+    with aioresponses() as mock:
+        yield mock
+
+
+# Basic OAuth2 functionality tests
+def test_init_with_config(configured_oauth):  # pylint: disable=redefined-outer-name
+    """Test OAuth2 initialization with config."""
+    oauth = configured_oauth
+
+    assert oauth.client_id == 'test_client_id'
+    assert oauth.client_secret == 'test_secret'  # pragma: allowlist secret
+    assert oauth.redirect_uri == 'http://localhost:8080/callback'
+    assert oauth.code_verifier is None
+    assert oauth.code_challenge is None
+    assert oauth.state is None
+
+
+def test_init_without_config():
+    """Test OAuth2 initialization without config."""
+    oauth = nowplaying.kick.oauth2.KickOAuth2()  # pylint: disable=no-member
+
+    assert oauth.config is not None
+    assert hasattr(oauth.config, 'cparser')  # Check it's a config-like object
+
+
+def test_generate_pkce_parameters(configured_oauth):  # pylint: disable=redefined-outer-name
+    """Test PKCE parameter generation."""
+    oauth = configured_oauth
+
+    oauth._generate_pkce_parameters()  # pylint: disable=protected-access
+
+    # Verify code verifier is generated
+    assert oauth.code_verifier is not None
+    assert len(oauth.code_verifier) >= 43
+    assert len(oauth.code_verifier) <= 128
+
+    # Verify code challenge is generated correctly
+    assert oauth.code_challenge is not None
+    expected_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(oauth.code_verifier.encode('utf-8')).digest()).decode('utf-8').rstrip('=')
+    assert oauth.code_challenge == expected_challenge
+
+    # Verify state is generated
+    assert oauth.state is not None
+    assert len(oauth.state) >= 43
+
+
+# Parameterized authorization URL tests
+@pytest.mark.parametrize(
+    "client_id,redirect_uri,expected_error",
+    [
+        (None, 'http://localhost:8080', 'Client ID is required'),
+        ('test_client', None, 'Redirect URI is required'),
+        ('test_client', 'http://localhost:8080', None),  # Success
+    ])
+def test_get_authorization_url_scenarios(  # pylint: disable=redefined-outer-name
+        bootstrap,
+        client_id,
+        redirect_uri,
+        expected_error):
+    """Test authorization URL generation with various configurations."""
+    config = bootstrap
+    if client_id:
+        config.cparser.setValue('kick/clientid', client_id)
+    if redirect_uri:
+        config.cparser.setValue('kick/redirecturi', redirect_uri)
+
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+    if expected_error:
+        with pytest.raises(ValueError, match=expected_error):
+            oauth.get_authorization_url()
+    else:
+        auth_url = oauth.get_authorization_url()
+
+        assert auth_url.startswith('https://id.kick.com/oauth/authorize?')
+        assert f'client_id={client_id}' in auth_url
+        assert 'response_type=code' in auth_url
+        encoded_uri = redirect_uri.replace(":", "%3A").replace("/", "%2F")
+        assert f'redirect_uri={encoded_uri}' in auth_url
+        assert 'scope=user%3Aread+chat%3Awrite+events%3Asubscribe' in auth_url
+        assert 'code_challenge_method=S256' in auth_url
+        assert oauth.code_verifier is not None
+        assert oauth.state is not None
+
+
+# Parameterized browser opening tests
+@pytest.mark.parametrize("browser_succeeds", [True, False])
+@patch('webbrowser.open')
+def test_open_browser_for_auth_scenarios(mock_open, configured_oauth, browser_succeeds):  # pylint: disable=redefined-outer-name
+    """Test browser opening with success and failure scenarios."""
+    oauth = configured_oauth
+
+    if not browser_succeeds:
+        mock_open.side_effect = OSError("Browser error")
+
+    result = oauth.open_browser_for_auth()
+
+    assert result == browser_succeeds
+    mock_open.assert_called_once()
+
+
+# Parameterized token exchange tests
+@pytest.mark.parametrize(
+    "has_verifier,state_matches,response_status,response_data,should_succeed",
+    [
+        (False, True, 200, {
+            'access_token': 'token'
+        }, False),  # No verifier
+        (True, False, 200, {
+            'access_token': 'token'
+        }, False),  # State mismatch
+        (True, True, 400, {}, False),  # HTTP error
+        (True, True, 200, {
+            'access_token': 'token',
+            'refresh_token': 'refresh'
+        }, True),  # Success
+    ])
+@pytest.mark.asyncio
+async def test_exchange_code_for_token_scenarios(   # pylint: disable=redefined-outer-name
+        configured_oauth,
+        mock_responses,
+        has_verifier,
+        state_matches,
+        response_status,
+        response_data,
+        should_succeed):
+    """Test token exchange with various scenarios."""
+    oauth = configured_oauth
+
+    if has_verifier:
+        oauth.code_verifier = 'test_verifier'
+        oauth.state = 'expected_state'
+
+    test_state = 'expected_state' if state_matches else 'wrong_state'
+
+    if should_succeed:
+        # Success case - setup mock and verify result
+        mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token",
+                            status=response_status,
+                            payload=response_data)
+
+        result = await oauth.exchange_code_for_token('test_code', test_state)
+        assert result == response_data
+        assert oauth.access_token == 'token'
+        assert oauth.refresh_token == 'refresh'
+
+    elif response_status != 200:
+        # HTTP error case
+        mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token", status=response_status, body='Error')
+
+        with pytest.raises(Exception):
+            await oauth.exchange_code_for_token('test_code', test_state)
+
+    else:
+        # ValueError cases (no verifier, state mismatch) - no HTTP mock needed
+        with pytest.raises(ValueError):
+            await oauth.exchange_code_for_token('test_code', test_state)
+
+
+# Parameterized refresh token tests
+@pytest.mark.parametrize(
+    "has_refresh_token,response_status,response_data,should_succeed",
+    [
+        (False, 200, {
+            'access_token': 'new_token'
+        }, False),  # No refresh token
+        (True, 400, {}, False),  # HTTP error
+        (True, 200, {
+            'access_token': 'new_token',
+            'refresh_token': 'new_refresh'
+        }, True),  # Success
+    ])
+@pytest.mark.asyncio
+async def test_refresh_access_token_scenarios(
+        bootstrap, configured_oauth, mock_responses, has_refresh_token, response_status,
+        response_data, should_succeed):
+    """Test token refresh with various scenarios."""
+    oauth = configured_oauth
+
+    if has_refresh_token:
+        oauth.config.cparser.setValue('kick/refreshtoken', 'test_refresh_token')
+        refresh_token = 'test_refresh_token'
+    else:
+        refresh_token = None
+
+    if should_succeed:
+        mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token",
+                            status=response_status,
+                            payload=response_data)
+
+        result = await oauth.refresh_access_token(refresh_token)
+        assert result == response_data
+        assert oauth.access_token == 'new_token'
+        assert oauth.refresh_token == 'new_refresh'
+    else:
+        if has_refresh_token:
+            # HTTP error case
+            mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token",
+                                status=response_status,
+                                body='Error')
+
+        with pytest.raises((ValueError, Exception)):
+            await oauth.refresh_access_token(refresh_token)
+
+
+# Parameterized token validation tests
+@pytest.mark.parametrize(
+    "response_status,response_data,expected_result",
+    [
+        (200, {
+            'valid': True,
+            'client_id': 'test_client'
+        }, {
+            'valid': True,
+            'client_id': 'test_client'
+        }),
+        (401, {}, False),  # Unauthorized
+        (500, {}, False),  # Server error
+    ])
+@pytest.mark.asyncio
+async def test_validate_token_scenarios(
+        configured_oauth,
+        mock_responses,
+        response_status,  # pylint: disable=redefined-outer-name
+        response_data,
+        expected_result):
+    """Test token validation with various responses."""
+    oauth = configured_oauth
+
+    if response_status == 200:
+        mock_responses.get(f"{oauth.OAUTH_HOST}/oauth/validate",
+                           status=response_status,
+                           payload=response_data)
+    else:
+        mock_responses.get(f"{oauth.OAUTH_HOST}/oauth/validate",
+                           status=response_status,
+                           body='Error')
+
+    result = await oauth.validate_token('test_token')
+    assert result == expected_result
+
+
+# Parameterized stored tokens tests
+@pytest.mark.parametrize(
+    "access_token,refresh_token",
+    [
+        ('stored_access', 'stored_refresh'),  # Both tokens present
+        (None, None),  # No tokens stored
+        ('access_only', None),  # Only access token
+        (None, 'refresh_only'),  # Only refresh token
+    ])
+def test_get_stored_tokens_scenarios(bootstrap, access_token, refresh_token):  # pylint: disable=redefined-outer-name
+    """Test getting stored tokens with various configurations."""
+    config = bootstrap
+    if access_token:
+        config.cparser.setValue('kick/accesstoken', access_token)
+    if refresh_token:
+        config.cparser.setValue('kick/refreshtoken', refresh_token)
+
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+    result_access, result_refresh = oauth.get_stored_tokens()
+
+    assert result_access == access_token
+    assert result_refresh == refresh_token
+
+
+def test_clear_stored_tokens(configured_oauth):  # pylint: disable=redefined-outer-name
+    """Test clearing stored tokens."""
+    oauth = configured_oauth
+    oauth.config.cparser.setValue('kick/accesstoken', 'stored_access')
+    oauth.config.cparser.setValue('kick/refreshtoken', 'stored_refresh')
+    oauth.access_token = 'current_access'
+    oauth.refresh_token = 'current_refresh'
+
+    oauth.clear_stored_tokens()
+
+    assert oauth.access_token is None
+    assert oauth.refresh_token is None
+    assert oauth.config.cparser.value('kick/accesstoken') is None
+    assert oauth.config.cparser.value('kick/refreshtoken') is None
+
+
+# Parameterized token revocation tests
+@pytest.mark.parametrize(
+    "has_client_id,has_token,response_status,should_clear_tokens",
+    [
+        (False, False, 200, False),  # No client ID or token - should not crash
+        (True, True, 200, True),  # Success - should clear tokens
+        (True, True, 400, False),  # HTTP error - should NOT clear tokens
+    ])
+@pytest.mark.asyncio
+async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, too-many-arguments
+        bootstrap, mock_responses, has_client_id, has_token, response_status, should_clear_tokens):
+    """Test token revocation with various scenarios."""
+    config = bootstrap
+    if has_client_id:
+        config.cparser.setValue('kick/clientid', 'test_client_id')
+    if has_token:
+        config.cparser.setValue('kick/accesstoken', 'test_token')
+
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+    token_to_revoke = 'test_token' if has_token else None
+
+    if has_client_id and has_token:
+        # Setup mock response for cases where we have credentials
+        mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/revoke", status=response_status)
+
+    # Should not raise exception in any case
+    await oauth.revoke_token(token_to_revoke)
+
+    if should_clear_tokens:
+        assert oauth.access_token is None
+        assert oauth.refresh_token is None
+        assert oauth.config.cparser.value('kick/accesstoken') is None
+        assert oauth.config.cparser.value('kick/refreshtoken') is None
+    else:
+        # For error cases, tokens should remain if they were set
+        if has_token:
+            assert oauth.config.cparser.value('kick/accesstoken') == 'test_token'
+
+
+# Edge cases and error conditions tests
+
+
+@pytest.mark.asyncio
+async def test_json_parsing_error(oauth_with_pkce, mock_responses):  # pylint: disable=redefined-outer-name
+    """Test handling of JSON parsing errors."""
+    oauth = oauth_with_pkce
+
+    # Mock response with invalid JSON
+    mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token", status=200, body='invalid json content')
+
+    with pytest.raises(Exception):
+        await oauth.exchange_code_for_token('test_code')
+
+
+@pytest.mark.asyncio
+async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disable=redefined-outer-name
+    """Test network timeout handling."""
+    oauth = oauth_with_pkce
+
+    # Mock a timeout by using an exception
+    mock_responses.post(f"{oauth.OAUTH_HOST}/oauth/token",
+                        exception=asyncio.TimeoutError("Request timed out"))
+
+    with pytest.raises(asyncio.TimeoutError):
+        await oauth.exchange_code_for_token('test_code')
+
+
+def test_pkce_parameter_uniqueness(configured_oauth):  # pylint: disable=redefined-outer-name
+    """Test that PKCE parameters are unique across instances."""
+    oauth1 = configured_oauth
+    oauth2 = nowplaying.kick.oauth2.KickOAuth2(oauth1.config)  # pylint: disable=no-member
+
+    oauth1._generate_pkce_parameters()  # pylint: disable=protected-access
+    oauth2._generate_pkce_parameters()  # pylint: disable=protected-access
+
+    assert oauth1.code_verifier != oauth2.code_verifier
+    assert oauth1.code_challenge != oauth2.code_challenge
+    assert oauth1.state != oauth2.state
+
+
+def test_pkce_challenge_calculation(configured_oauth):  # pylint: disable=redefined-outer-name
+    """Test PKCE code challenge calculation correctness."""
+    oauth = configured_oauth
+
+    # Set known verifier for predictable challenge
+    oauth.code_verifier = 'test_verifier_123456789'
+    oauth._generate_pkce_parameters()  # pylint: disable=protected-access
+
+    # Manually calculate expected challenge
+    expected_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(oauth.code_verifier.encode('utf-8')).digest()).decode('utf-8').rstrip('=')
+
+    assert oauth.code_challenge == expected_challenge
+
+
+@pytest.mark.parametrize("invalid_config_key", [
+    'kick/clientid',
+    'kick/secret',
+    'kick/redirecturi',
+])
+def test_missing_config_handling(bootstrap, invalid_config_key):  # pylint: disable=redefined-outer-name
+    """Test handling of missing configuration values."""
+    config = bootstrap
+    # Set all required config except one
+    config.cparser.setValue('kick/clientid', 'test_client')
+    config.cparser.setValue('kick/secret', 'test_secret')
+    config.cparser.setValue('kick/redirecturi', 'http://localhost')
+
+    # Remove the specified config key
+    config.cparser.remove(invalid_config_key)
+
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
+
+    # Should handle missing config gracefully
+    if invalid_config_key in ['kick/clientid', 'kick/redirecturi']:
+        with pytest.raises(ValueError):
+            oauth.get_authorization_url()
+    else:
+        # Missing secret shouldn't prevent URL generation
+        auth_url = oauth.get_authorization_url()
+        assert 'client_id=test_client' in auth_url

--- a/tests/kick/test_kick_oauth2.py
+++ b/tests/kick/test_kick_oauth2.py
@@ -253,8 +253,8 @@ async def test_refresh_access_token_scenarios(
             'valid': True,
             'client_id': 'test_client'
         }),
-        (401, {}, False),  # Unauthorized
-        (500, {}, False),  # Server error
+        (401, {}, None),  # Unauthorized
+        (500, {}, None),  # Server error
     ])
 @pytest.mark.asyncio
 async def test_validate_token_scenarios(
@@ -384,7 +384,7 @@ async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disa
                         exception=asyncio.TimeoutError("Request timed out"))
 
     with pytest.raises(asyncio.TimeoutError):
-        await oauth.exchange_code_for_token('test_code')
+        await oauth.exchange_code_for_token('test_code', oauth.state)
 
 
 def test_pkce_parameter_uniqueness(configured_oauth):  # pylint: disable=redefined-outer-name

--- a/tests/kick/test_kick_settings.py
+++ b/tests/kick/test_kick_settings.py
@@ -142,7 +142,9 @@ def test_kick_settings_save_scenarios(bootstrap, mock_kick_widget, has_changes, 
 
     mock_subprocesses = MagicMock()
 
-    with patch('time.sleep'):  # Speed up test
+    with patch('nowplaying.kick.settings.QTimer.singleShot') as mock_timer:
+        # Configure the mock to immediately call the callback
+        mock_timer.side_effect = lambda delay, callback: callback()
         nowplaying.kick.settings.KickSettings.save(config, mock_kick_widget, mock_subprocesses)
 
     if should_restart:

--- a/tests/kick/test_kick_settings.py
+++ b/tests/kick/test_kick_settings.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Unit tests for Kick settings functionality - REFACTORED VERSION."""
+# pylint: disable=no-member,redefined-outer-name,too-many-arguments,unused-argument,protected-access,import-error,no-name-in-module
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import nowplaying.kick.settings
+import nowplaying.kick.oauth2
+import nowplaying.kick.utils
+from nowplaying.exceptions import PluginVerifyError
+
+
+# Fixtures
+@pytest.fixture
+def mock_kick_widget():
+    """Create a mock widget with all Kick UI elements."""
+    widget = MagicMock()
+    widget.enable_checkbox = MagicMock()
+    widget.channel_lineedit = MagicMock()
+    widget.clientid_lineedit = MagicMock()
+    widget.secret_lineedit = MagicMock()
+    widget.redirecturi_lineedit = MagicMock()
+    widget.authenticate_button = MagicMock()
+    widget.oauth_status_label = MagicMock()
+    # Set default text values for the update_oauth_status method
+    widget.clientid_lineedit.text.return_value = 'test_client'
+    widget.secret_lineedit.text.return_value = 'test_secret'
+    widget.redirecturi_lineedit.text.return_value = 'http://localhost:8080'
+    return widget
+
+
+@pytest.fixture
+def mock_chat_widget():
+    """Create a mock chat widget with command table and controls."""
+    widget = MagicMock()
+    widget.enable_checkbox = MagicMock()
+    widget.announce_lineedit = MagicMock()
+    widget.announcedelay_spin = MagicMock()
+    widget.command_perm_table = MagicMock()
+    widget.command_perm_table.rowCount.return_value = 0
+    widget.announce_button = MagicMock()
+    widget.add_button = MagicMock()
+    widget.del_button = MagicMock()
+    return widget
+
+
+@pytest.fixture
+def configured_kick_config(bootstrap):
+    """Create a bootstrap config with Kick settings pre-configured."""
+    config = bootstrap
+    config.cparser.setValue('kick/enabled', True)
+    config.cparser.setValue('kick/channel', 'testchannel')
+    config.cparser.setValue('kick/clientid', 'test_client_id')
+    config.cparser.setValue('kick/secret', 'test_secret')
+    config.cparser.setValue('kick/redirecturi', 'http://localhost:8080/callback')
+    return config
+
+
+def test_kick_settings_init():
+    """Test KickSettings initialization."""
+    settings = nowplaying.kick.settings.KickSettings()
+
+    assert settings.widget is None
+    assert settings.oauth is None
+
+
+def test_kick_settings_connect(mock_kick_widget):
+    """Test settings connection."""
+    settings = nowplaying.kick.settings.KickSettings()
+    mock_uihelp = MagicMock()
+
+    settings.connect(mock_uihelp, mock_kick_widget)
+
+    assert settings.widget == mock_kick_widget
+    mock_kick_widget.authenticate_button.clicked.connect.assert_called_once()
+    mock_kick_widget.clientid_lineedit.editingFinished.connect.assert_called_once()
+    mock_kick_widget.secret_lineedit.editingFinished.connect.assert_called_once()
+    mock_kick_widget.redirecturi_lineedit.editingFinished.connect.assert_called_once()
+
+
+def test_kick_settings_load(configured_kick_config, mock_kick_widget):
+    """Test settings loading."""
+    settings = nowplaying.kick.settings.KickSettings()
+
+    settings.load(configured_kick_config, mock_kick_widget)
+
+    assert settings.widget == mock_kick_widget
+    mock_kick_widget.enable_checkbox.setChecked.assert_called_with(True)
+    mock_kick_widget.channel_lineedit.setText.assert_called_with('testchannel')
+    mock_kick_widget.clientid_lineedit.setText.assert_called_with('test_client_id')
+    mock_kick_widget.secret_lineedit.setText.assert_called_with('test_secret')
+    mock_kick_widget.redirecturi_lineedit.setText.assert_called_with(
+        'http://localhost:8080/callback')
+    assert isinstance(settings.oauth, nowplaying.kick.oauth2.KickOAuth2)
+
+
+def test_kick_settings_load_default_redirect_uri(bootstrap, mock_kick_widget):
+    """Test settings loading with default redirect URI."""
+    settings = nowplaying.kick.settings.KickSettings()
+
+    settings.load(bootstrap, mock_kick_widget)
+
+    # Should set default redirect URI
+    mock_kick_widget.redirecturi_lineedit.setText.assert_called_with(
+        'http://localhost:8080/kickredirect')
+
+
+@pytest.mark.parametrize(
+    "has_changes,should_restart",
+    [
+        (False, False),  # No changes - no restart
+        (True, True),  # Changes - restart kickbot
+    ])
+def test_kick_settings_save_scenarios(bootstrap, mock_kick_widget, has_changes, should_restart):
+    """Test settings saving with and without changes."""
+    config = bootstrap
+    if not has_changes:
+        # Set initial values that match widget values
+        config.cparser.setValue('kick/channel', 'testchannel')
+        config.cparser.setValue('kick/clientid', 'testclient')
+        config.cparser.setValue('kick/secret', 'testsecret')
+        config.cparser.setValue('kick/redirecturi', 'testuri')
+    else:
+        # Set different initial values
+        config.cparser.setValue('kick/channel', 'oldchannel')
+        config.cparser.setValue('kick/clientid', 'oldclient')
+        config.cparser.setValue('kick/secret', 'oldsecret')
+        config.cparser.setValue('kick/redirecturi', 'olduri')
+        config.cparser.setValue('kick/accesstoken', 'old_token')
+        config.cparser.setValue('kick/refreshtoken', 'old_refresh')
+
+    # Setup widget return values
+    mock_kick_widget.enable_checkbox.isChecked.return_value = True
+    mock_kick_widget.channel_lineedit.text.return_value = 'testchannel'
+    mock_kick_widget.clientid_lineedit.text.return_value = 'testclient'
+    mock_kick_widget.secret_lineedit.text.return_value = 'testsecret'
+    mock_kick_widget.redirecturi_lineedit.text.return_value = 'testuri'
+
+    mock_subprocesses = MagicMock()
+
+    with patch('time.sleep'):  # Speed up test
+        nowplaying.kick.settings.KickSettings.save(config, mock_kick_widget, mock_subprocesses)
+
+    if should_restart:
+        mock_subprocesses.stop_kickbot.assert_called_once()
+        mock_subprocesses.start_kickbot.assert_called_once()
+        # Tokens should be cleared
+        assert config.cparser.value('kick/accesstoken') is None
+        assert config.cparser.value('kick/refreshtoken') is None
+    else:
+        mock_subprocesses.stop_kickbot.assert_not_called()
+        mock_subprocesses.start_kickbot.assert_not_called()
+
+
+# Parameterized verification tests
+@pytest.mark.parametrize(
+    "enabled,client_id,secret,redirect_uri,channel,expected_error",
+    [
+        (False, '', '', '', '', None),  # Disabled - no validation
+        (True, '', 'secret', 'http://localhost', 'channel', 'Kick Client ID is required'),
+        (True, 'client', '', 'http://localhost', 'channel', 'Kick Client Secret is required'),
+        (True, 'client', 'secret', '', 'channel', 'Kick Redirect URI is required'),
+        (True, 'client', 'secret', 'http://localhost', '', 'Kick Channel is required'),
+        (True, 'client', 'secret', 'invalid_uri', 'channel',
+         'Kick Redirect URI must start with http'),
+        (True, 'client', 'secret', 'http://localhost', 'channel', None),  # Valid
+    ])
+def test_kick_settings_verify_scenarios(enabled, client_id, secret, redirect_uri, channel,
+                                        expected_error):
+    """Test verification with various input combinations."""
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = enabled
+    mock_widget.clientid_lineedit.text.return_value = client_id
+    mock_widget.secret_lineedit.text.return_value = secret
+    mock_widget.redirecturi_lineedit.text.return_value = redirect_uri
+    mock_widget.channel_lineedit.text.return_value = channel
+
+    if expected_error:
+        with pytest.raises(PluginVerifyError, match=expected_error):
+            nowplaying.kick.settings.KickSettings.verify(mock_widget)
+    else:
+        nowplaying.kick.settings.KickSettings.verify(mock_widget)
+
+
+def test_kick_settings_authenticate_oauth(bootstrap, mock_kick_widget):
+    """Test OAuth authentication."""
+    settings = nowplaying.kick.settings.KickSettings()
+    settings.widget = mock_kick_widget
+
+    # Mock OAuth
+    mock_oauth = MagicMock()
+    mock_oauth.open_browser_for_auth.return_value = True
+    settings.oauth = mock_oauth
+
+    settings.authenticate_oauth()
+
+    mock_oauth.open_browser_for_auth.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "has_oauth,has_tokens,token_valid,expected_status",
+    [
+        (False, False, False, None),  # No OAuth - should not crash
+        (True, False, False, 'Not authenticated'),  # No tokens
+        (True, True, True, 'called'),  # Valid token - status will be set
+        (True, True, False, 'called'),  # Invalid token - status will be set
+    ])
+def test_kick_settings_update_oauth_status_scenarios(bootstrap, mock_kick_widget, has_oauth,
+                                                     has_tokens, token_valid, expected_status):
+    """Test OAuth status update with various scenarios."""
+    settings = nowplaying.kick.settings.KickSettings()
+    settings.widget = mock_kick_widget
+
+    if has_oauth:
+        mock_oauth = MagicMock()
+        if has_tokens:
+            mock_oauth.get_stored_tokens.return_value = ('valid_token', 'refresh_token')
+        else:
+            mock_oauth.get_stored_tokens.return_value = (None, None)
+        settings.oauth = mock_oauth
+        with patch('nowplaying.kick.utils.qtsafe_validate_kick_token', return_value=token_valid):
+            settings.update_oauth_status()
+    else:
+        settings.oauth = None
+        settings.update_oauth_status()
+
+    if expected_status == 'Not authenticated':
+        mock_kick_widget.oauth_status_label.setText.assert_called_with('Not authenticated')
+    elif expected_status == 'called':
+        assert mock_kick_widget.oauth_status_label.setText.called
+
+
+# Parameterized token validation tests
+@pytest.mark.parametrize(
+    "status_code,response_data,exception_type,expected_result",
+    [
+        (200, {
+            'data': {
+                'active': True,
+                'client_id': 'test_client'
+            }
+        }, None, True),
+        (200, {
+            'data': {
+                'active': False
+            }
+        }, None, False),
+        (401, {}, None, False),
+        (500, {}, None, False),
+        (200, {}, requests.RequestException, False),  # Network error
+        (200, {}, ValueError, False),  # JSON parsing error
+    ])
+def test_qtsafe_validate_kick_token_scenarios(status_code, response_data, exception_type,
+                                              expected_result):
+    """Test Qt-safe token validation with various responses."""
+    if exception_type:
+        with patch('requests.post', side_effect=exception_type("Test error")):
+            result = nowplaying.kick.utils.qtsafe_validate_kick_token('test_token')
+    else:
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.json.return_value = response_data
+
+        with patch('requests.post', return_value=mock_response):
+            result = nowplaying.kick.utils.qtsafe_validate_kick_token('test_token')
+
+    assert result == expected_result
+
+
+def test_kick_settings_clear_authentication(bootstrap):
+    """Test clearing authentication."""
+    settings = nowplaying.kick.settings.KickSettings()
+
+    # Mock OAuth
+    mock_oauth = MagicMock()
+    settings.oauth = mock_oauth
+    settings.update_oauth_status = MagicMock()
+
+    settings.clear_authentication()
+
+    mock_oauth.clear_stored_tokens.assert_called_once()
+    settings.update_oauth_status.assert_called_once()
+
+
+def test_kick_chat_settings_init():
+    """Test KickChatSettings initialization."""
+    settings = nowplaying.kick.settings.KickChatSettings()
+
+    assert settings.widget is None
+    assert settings.KICKBOT_CHECKBOXES == [
+        'anyone', 'broadcaster', 'moderator', 'subscriber', 'founder', 'vip'
+    ]
+
+
+@pytest.mark.parametrize("has_buttons", [True, False])
+def test_kick_chat_settings_connect_scenarios(mock_chat_widget, has_buttons):
+    """Test settings connection with and without buttons."""
+    settings = nowplaying.kick.settings.KickChatSettings()
+    mock_uihelp = MagicMock()
+
+    if not has_buttons:
+        # Remove button attributes
+        del mock_chat_widget.announce_button
+        del mock_chat_widget.add_button
+        del mock_chat_widget.del_button
+
+    # Should not crash regardless
+    settings.connect(mock_uihelp, mock_chat_widget)
+
+    assert settings.widget == mock_chat_widget
+
+    if has_buttons:
+        mock_chat_widget.announce_button.clicked.connect.assert_called_once()
+        mock_chat_widget.add_button.clicked.connect.assert_called_once()
+        mock_chat_widget.del_button.clicked.connect.assert_called_once()
+
+
+@pytest.mark.parametrize("delay_field_type", ['spin', 'lineedit'])
+def test_kick_chat_settings_load_delay_field_types(bootstrap, mock_chat_widget, delay_field_type):
+    """Test loading with different delay field types."""
+    config = bootstrap
+    config.cparser.setValue('kick/chat', True)
+    config.cparser.setValue('kick/announce', 'test_template.txt')
+    config.cparser.setValue('kick/announcedelay', 2.5)
+
+    settings = nowplaying.kick.settings.KickChatSettings()
+
+    # Setup delay field based on type
+    if delay_field_type == 'spin':
+        mock_chat_widget.announcedelay_spin = MagicMock()
+        delattr(mock_chat_widget, 'announce_delay_lineedit')
+    else:
+        mock_chat_widget.announce_delay_lineedit = MagicMock()
+        delattr(mock_chat_widget, 'announcedelay_spin')
+
+    settings.load(config, mock_chat_widget)
+
+    assert settings.widget == mock_chat_widget
+    mock_chat_widget.enable_checkbox.setChecked.assert_called_with(True)
+    mock_chat_widget.announce_lineedit.setText.assert_called_with('test_template.txt')
+
+    if delay_field_type == 'spin':
+        mock_chat_widget.announcedelay_spin.setValue.assert_called_with(2.5)
+    else:
+        mock_chat_widget.announce_delay_lineedit.setText.assert_called_with('2.5')
+
+
+@patch('nowplaying.kick.settings.QCheckBox')
+@patch('nowplaying.kick.settings.QTableWidgetItem')
+def test_kick_chat_settings_load_with_command_table(mock_table_widget_item, mock_qcheckbox,
+                                                    bootstrap, mock_chat_widget):
+    """Test loading with command permission table."""
+    config = bootstrap
+
+    # Create test command configuration
+    config.cparser.beginGroup('kickbot-command-track')
+    config.cparser.setValue('anyone', True)
+    config.cparser.setValue('broadcaster', True)
+    config.cparser.setValue('moderator', False)
+    config.cparser.endGroup()
+
+    settings = nowplaying.kick.settings.KickChatSettings()
+
+    # Mock command table
+    mock_chat_widget.command_perm_table.setRowCount = MagicMock()
+    mock_chat_widget.command_perm_table.rowCount.return_value = 1
+
+    settings.load(config, mock_chat_widget)
+
+    # Verify table was reset
+    mock_chat_widget.command_perm_table.setRowCount.assert_called_with(0)
+
+
+@pytest.mark.parametrize(
+    "delay_field_type,delay_value,expected_delay",
+    [
+        ('spin', 2.5, 2.5),
+        ('lineedit', '1.5', 1.5),
+        ('lineedit', 'invalid', 1.0),  # Invalid value defaults to 1.0
+    ])
+def test_kick_chat_settings_save_delay_scenarios(bootstrap, mock_chat_widget, delay_field_type,
+                                                 delay_value, expected_delay):
+    """Test saving with different delay field types and values."""
+    config = bootstrap
+    mock_chat_widget.enable_checkbox.isChecked.return_value = False
+    mock_chat_widget.announce_lineedit.text.return_value = ''
+
+    # Setup delay field based on type
+    if delay_field_type == 'spin':
+        mock_chat_widget.announcedelay_spin.value.return_value = delay_value
+        delattr(mock_chat_widget, 'announce_delay_lineedit')
+    else:
+        mock_chat_widget.announce_delay_lineedit.text.return_value = delay_value
+        delattr(mock_chat_widget, 'announcedelay_spin')
+
+    mock_subprocesses = MagicMock()
+
+    nowplaying.kick.settings.KickChatSettings.save(config, mock_chat_widget, mock_subprocesses)
+
+    assert config.cparser.value('kick/announcedelay', type=float) == expected_delay
+
+
+def test_kick_chat_settings_save_kickbot_commands(bootstrap, mock_chat_widget):
+    """Test saving kickbot command permissions."""
+    config = bootstrap
+
+    # Create existing command to be removed
+    config.cparser.beginGroup('kickbot-command-oldcommand')
+    config.cparser.setValue('anyone', True)
+    config.cparser.endGroup()
+
+    mock_chat_widget.command_perm_table.rowCount.return_value = 1
+
+    # Mock table item
+    mock_item = MagicMock()
+    mock_item.text.return_value = '!newcommand'
+    mock_chat_widget.command_perm_table.item.return_value = mock_item
+
+    # Mock checkboxes
+    mock_checkbox = MagicMock()
+    mock_checkbox.isChecked.return_value = True
+    mock_chat_widget.command_perm_table.cellWidget.return_value = mock_checkbox
+
+    nowplaying.kick.settings.KickChatSettings._save_kickbot_commands(config, mock_chat_widget)
+
+    # Old command should be removed
+    assert 'kickbot-command-oldcommand' not in config.cparser.childGroups()
+
+    # New command should be saved
+    config.cparser.beginGroup('kickbot-command-newcommand')
+    assert config.cparser.value('anyone', type=bool)
+    config.cparser.endGroup()
+
+
+# Parameterized verification tests
+@pytest.mark.parametrize(
+    "enabled,template_path,expected_error",
+    [
+        (False, '', None),  # Disabled - no validation
+        (True, '', 'Kick announcement template is required'),
+        (True, 'template.txt', None),  # Valid
+    ])
+def test_kick_chat_settings_verify_scenarios(enabled, template_path, expected_error):
+    """Test verification with various input combinations."""
+    mock_widget = MagicMock()
+    mock_widget.enable_checkbox.isChecked.return_value = enabled
+    mock_widget.announce_lineedit.text.return_value = template_path
+
+    if expected_error:
+        with pytest.raises(PluginVerifyError, match=expected_error):
+            nowplaying.kick.settings.KickChatSettings.verify(mock_widget)
+    else:
+        nowplaying.kick.settings.KickChatSettings.verify(mock_widget)
+
+
+@pytest.mark.parametrize(
+    "template_dir_exists,has_templates",
+    [
+        (False, False),  # No template directory
+        (True, False),  # Template directory but no kickbot templates
+        (True, True),  # Template directory with kickbot templates
+    ])
+def test_kick_chat_settings_update_kickbot_commands_scenarios(bootstrap, template_dir_exists,
+                                                              has_templates):
+    """Test command update with various template directory scenarios."""
+    config = bootstrap
+
+    if not template_dir_exists:
+        # Set non-existent template directory
+        config.templatedir = pathlib.Path('/non/existent/path')
+    elif has_templates:
+        # Create test template files in test directory
+        test_template_dir = config.testdir / 'templates'
+        config.templatedir = test_template_dir
+        test_template_dir.mkdir(parents=True, exist_ok=True)
+        (test_template_dir / 'kickbot_track.txt').write_text('Template content')
+        (test_template_dir / 'kickbot_artist.txt').write_text('Template content')
+
+    settings = nowplaying.kick.settings.KickChatSettings()
+
+    # Should not crash in any scenario
+    settings.update_kickbot_commands(config)
+
+    if template_dir_exists and has_templates:
+        # Should create command entries
+        assert 'kickbot-command-track' in config.cparser.childGroups()
+        assert 'kickbot-command-artist' in config.cparser.childGroups()
+
+        # Verify default permissions (all disabled)
+        config.cparser.beginGroup('kickbot-command-track')
+        for checkbox_type in settings.KICKBOT_CHECKBOXES:
+            assert not config.cparser.value(checkbox_type, type=bool)
+        config.cparser.endGroup()
+
+
+def test_kick_chat_settings_update_kickbot_commands_existing_command(bootstrap):
+    """Test command update doesn't overwrite existing commands."""
+    config = bootstrap
+
+    # Create existing command
+    config.cparser.beginGroup('kickbot-command-track')
+    config.cparser.setValue('anyone', True)
+    config.cparser.endGroup()
+
+    # Create template file in test directory
+    test_template_dir = config.testdir / 'templates'
+    config.templatedir = test_template_dir
+    test_template_dir.mkdir(parents=True, exist_ok=True)
+    (test_template_dir / 'kickbot_track.txt').write_text('Template content')
+
+    settings = nowplaying.kick.settings.KickChatSettings()
+
+    settings.update_kickbot_commands(config)
+
+    # Existing command should not be overwritten
+    config.cparser.beginGroup('kickbot-command-track')
+    assert config.cparser.value('anyone', type=bool) is True
+    config.cparser.endGroup()
+
+
+@patch('nowplaying.kick.settings.QCheckBox')
+@patch('nowplaying.kick.settings.QTableWidgetItem')
+def test_kick_chat_settings_add_kickbot_command_row(mock_table_widget_item, mock_qcheckbox):
+    """Test adding a command row to the table."""
+    mock_widget = MagicMock()
+    mock_widget.command_perm_table.rowCount.return_value = 0
+
+    settings = nowplaying.kick.settings.KickChatSettings()
+    settings._add_kickbot_command_row(mock_widget, '!test')
+
+    mock_widget.command_perm_table.insertRow.assert_called_with(0)
+    mock_widget.command_perm_table.setItem.assert_called_once()
+    # Should call setCellWidget for each checkbox column (6 times)
+    assert mock_widget.command_perm_table.setCellWidget.call_count == 6

--- a/tests/test_acoustidmb_joinphrases.py
+++ b/tests/test_acoustidmb_joinphrases.py
@@ -40,42 +40,65 @@ async def test_join_phrases_multiartist(getacoustidmbplugin):  # pylint: disable
     # feat. Robbie Williams & Maxi Jazz
     mock_acoustid_response = {
         'results': [{
-            'id': '4ba8faaf-cc17-4a38-8e35-9b21889e4001',
-            'score': 0.99775845,
+            'id':
+            '4ba8faaf-cc17-4a38-8e35-9b21889e4001',
+            'score':
+            0.99775845,
             'recordings': [{
-                'id': 'b366689f-4b81-4f1f-974b-3dff361d45a1',
+                'id':
+                'b366689f-4b81-4f1f-974b-3dff361d45a1',
                 'releases': [{
-                    'artists': [
-                        {'id': '3eff5a3a-b011-4da3-81fe-bc8d4a11b28c',
-                         'name': '1 Giant Leap'}
-                    ],
-                    'country': 'XE',
-                    'date': {'year': 2001},
-                    'id': 'b79afe7c-7f2c-4516-a8bf-e34efa290c54',
-                    'medium_count': 1,
+                    'artists': [{
+                        'id': '3eff5a3a-b011-4da3-81fe-bc8d4a11b28c',
+                        'name': '1 Giant Leap'
+                    }],
+                    'country':
+                    'XE',
+                    'date': {
+                        'year': 2001
+                    },
+                    'id':
+                    'b79afe7c-7f2c-4516-a8bf-e34efa290c54',
+                    'medium_count':
+                    1,
                     'mediums': [{
-                        'format': 'CD',
-                        'position': 1,
-                        'track_count': 12,
+                        'format':
+                        'CD',
+                        'position':
+                        1,
+                        'track_count':
+                        12,
                         'tracks': [{
-                            'artists': [
-                                {'id': '3eff5a3a-b011-4da3-81fe-bc8d4a11b28c',
-                                 'joinphrase': ' feat. ',
-                                 'name': '1 Giant Leap'},
-                                {'id': 'db4624cf-0e44-481e-a9dc-2142b833ec2f',
-                                 'joinphrase': ' & ',
-                                 'name': 'Robbie Williams'},
-                                {'id': 'debd408d-72b3-4c14-a0eb-dd4fe526e240',
-                                 'name': 'Maxi Jazz'}
-                            ],
-                            'id': 'c713d252-3ba9-445e-a70e-1dda9609029f',
-                            'position': 2,
-                            'title': 'My Culture'
+                            'artists': [{
+                                'id': '3eff5a3a-b011-4da3-81fe-bc8d4a11b28c',
+                                'joinphrase': ' feat. ',
+                                'name': '1 Giant Leap'
+                            }, {
+                                'id': 'db4624cf-0e44-481e-a9dc-2142b833ec2f',
+                                'joinphrase': ' & ',
+                                'name': 'Robbie Williams'
+                            }, {
+                                'id': 'debd408d-72b3-4c14-a0eb-dd4fe526e240',
+                                'name': 'Maxi Jazz'
+                            }],
+                            'id':
+                            'c713d252-3ba9-445e-a70e-1dda9609029f',
+                            'position':
+                            2,
+                            'title':
+                            'My Culture'
                         }]
                     }],
-                    'releaseevents': [{'country': 'XE', 'date': {'year': 2001}}],
-                    'title': '1 Giant Leap',
-                    'track_count': 12
+                    'releaseevents': [{
+                        'country': 'XE',
+                        'date': {
+                            'year': 2001
+                        }
+                    }],
+                    'title':
+                    '1 Giant Leap',
+                    'track_count':
+                    12
                 }]
             }]
         }]
@@ -98,14 +121,13 @@ async def test_join_phrases_multiartist(getacoustidmbplugin):  # pylint: disable
     ]
     assert metadata['title'] == 'My Culture'
     assert metadata['album'] == '1 Giant Leap'
-    assert metadata['musicbrainzrecordingid'] == (
-        'b366689f-4b81-4f1f-974b-3dff361d45a1')
+    assert metadata['musicbrainzrecordingid'] == ('b366689f-4b81-4f1f-974b-3dff361d45a1')
 
     # Verify multiple artist IDs are returned for multi-artist track
     assert len(metadata['musicbrainzartistid']) == 3
     expected_artist_ids = [
         '3eff5a3a-b011-4da3-81fe-bc8d4a11b28c',  # 1 Giant Leap
         'db4624cf-0e44-481e-a9dc-2142b833ec2f',  # Robbie Williams
-        'debd408d-72b3-4c14-a0eb-dd4fe526e240'   # Maxi Jazz
+        'debd408d-72b3-4c14-a0eb-dd4fe526e240'  # Maxi Jazz
     ]
     assert set(metadata['musicbrainzartistid']) == set(expected_artist_ids)

--- a/tests/test_artistextras_core.py
+++ b/tests/test_artistextras_core.py
@@ -8,7 +8,6 @@ import pytest
 
 from utils_artistextras import configureplugins, configuresettings
 
-
 PLUGINS = ['wikimedia']
 
 if os.environ.get('DISCOGS_API_KEY'):

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -387,13 +387,34 @@ async def test_discogs_malformed_json_handling(bootstrap):
 
 @pytest.mark.parametrize("metadata,test_id", [
     ({}, "empty-dict"),
-    ({'artist': None, 'album': 'Test'}, "none-values"),
-    ({'artist': '', 'album': ''}, "empty-strings"),
-    ({'artist': 'A' * 1000, 'album': 'B' * 1000}, "very-long-strings"),
-    ({'artist': 'Test\x00Artist', 'album': 'Test\x00Album'}, "null-bytes"),
-    ({'artist': '<script>alert("xss")</script>', 'album': 'Test'}, "xss-attempt"),
-    ({'artist': 'Björk', 'album': 'Homogénic'}, "unicode-characters"),
-    ({'artist': 'AC/DC', 'album': 'Back in Black'}, "special-characters"),
+    ({
+        'artist': None,
+        'album': 'Test'
+    }, "none-values"),
+    ({
+        'artist': '',
+        'album': ''
+    }, "empty-strings"),
+    ({
+        'artist': 'A' * 1000,
+        'album': 'B' * 1000
+    }, "very-long-strings"),
+    ({
+        'artist': 'Test\x00Artist',
+        'album': 'Test\x00Album'
+    }, "null-bytes"),
+    ({
+        'artist': '<script>alert("xss")</script>',
+        'album': 'Test'
+    }, "xss-attempt"),
+    ({
+        'artist': 'Björk',
+        'album': 'Homogénic'
+    }, "unicode-characters"),
+    ({
+        'artist': 'AC/DC',
+        'album': 'Back in Black'
+    }, "special-characters"),
 ])
 @pytest.mark.asyncio
 @skip_no_discogs_key
@@ -419,21 +440,18 @@ async def test_discogs_malformed_metadata_input(bootstrap, metadata, test_id):
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(f'Discogs plugin raised exception for malformed input ({test_id}): {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+                    f'Plugins must handle all errors gracefully for live performance.')
 
 
-@pytest.mark.parametrize("artist_name,test_id", [
-    ('Madonna', 'basic-name'),
-    ('Madonna feat. Justin Timberlake', 'featuring-feat'),
-    ('Madonna featuring Justin Timberlake', 'featuring-full'),
-    ('Madonna & Justin Timberlake', 'ampersand'),
-    ('Madonna and Justin Timberlake', 'and-word'),
-    ('Madonna (Artist)', 'parentheses'),
-    ('madonna', 'lowercase'),
-    ('MADONNA', 'uppercase'),
-    ('The Beatles', 'with-article'),
-    ('Beatles, The', 'inverted-article')
-])
+@pytest.mark.parametrize("artist_name,test_id",
+                         [('Madonna', 'basic-name'),
+                          ('Madonna feat. Justin Timberlake', 'featuring-feat'),
+                          ('Madonna featuring Justin Timberlake', 'featuring-full'),
+                          ('Madonna & Justin Timberlake', 'ampersand'),
+                          ('Madonna and Justin Timberlake', 'and-word'),
+                          ('Madonna (Artist)', 'parentheses'), ('madonna', 'lowercase'),
+                          ('MADONNA', 'uppercase'), ('The Beatles', 'with-article'),
+                          ('Beatles, The', 'inverted-article')])
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_artist_name_variations(bootstrap, artist_name, test_id):
@@ -465,22 +483,20 @@ async def test_discogs_artist_name_variations(bootstrap, artist_name, test_id):
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(
             f'Discogs plugin raised exception for artist variation "{artist_name}" '
-            f'({test_id}): {exc}. Plugins must handle all errors gracefully for live performance.'
-        )
+            f'({test_id}): {exc}. Plugins must handle all errors gracefully for live performance.')
 
 
-@pytest.mark.parametrize("test_urls,test_id", [
-    (['https://www.discogs.com/artist/'], 'missing-id'),
-    (['https://www.discogs.com/artist/abc'], 'non-numeric-id'),
-    (['https://discogs.com/artist/123456'], 'missing-www'),
-    (['http://www.discogs.com/artist/123456'], 'http-not-https'),
-    (['https://www.discogs.com/artist/123456?param=value'], 'with-query-params'),
-    (['https://www.discogs.com/artist/123456#fragment'], 'with-fragment'),
-    (['https://www.spotify.com/artist/123'], 'non-discogs-spotify'),
-    (['https://musicbrainz.org/artist/123'], 'non-discogs-musicbrainz'),
-    (['not-a-url'], 'invalid-url-format'),
-    ([''], 'empty-url')
-])
+@pytest.mark.parametrize(
+    "test_urls,test_id",
+    [(['https://www.discogs.com/artist/'], 'missing-id'),
+     (['https://www.discogs.com/artist/abc'], 'non-numeric-id'),
+     (['https://discogs.com/artist/123456'], 'missing-www'),
+     (['http://www.discogs.com/artist/123456'], 'http-not-https'),
+     (['https://www.discogs.com/artist/123456?param=value'], 'with-query-params'),
+     (['https://www.discogs.com/artist/123456#fragment'], 'with-fragment'),
+     (['https://www.spotify.com/artist/123'], 'non-discogs-spotify'),
+     (['https://musicbrainz.org/artist/123'], 'non-discogs-musicbrainz'),
+     (['not-a-url'], 'invalid-url-format'), ([''], 'empty-url')])
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_website_url_parsing(bootstrap, test_urls, test_id):
@@ -512,8 +528,7 @@ async def test_discogs_website_url_parsing(bootstrap, test_urls, test_id):
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(
             f'Discogs plugin raised exception for URL test case "{test_urls}" ({test_id}): {exc}. '
-            f'Plugins must handle all errors gracefully for live performance.'
-        )
+            f'Plugins must handle all errors gracefully for live performance.')
 
 
 # Configuration State Validation Tests
@@ -566,19 +581,36 @@ def test_discogs_invalid_api_key_format(bootstrap):
                 logging.info('Invalid API key %d setup result: %s', i, setup_result)
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 pytest.fail(f'Discogs plugin raised exception for invalid API key {i}: {exc}. '
-                           f'Plugins must handle all errors gracefully for live performance.')
+                            f'Plugins must handle all errors gracefully for live performance.')
 
         logging.info('Invalid API key %d handled gracefully', i)
 
 
-@pytest.mark.parametrize("features,test_id", [
-    ({'bio': True, 'fanart': False, 'thumbnails': False}, 'bio-only'),
-    ({'bio': False, 'fanart': True, 'thumbnails': False}, 'fanart-only'),
-    ({'bio': False, 'fanart': False, 'thumbnails': True}, 'thumbnails-only'),
-    ({'bio': True, 'fanart': True, 'thumbnails': False}, 'bio-fanart'),
-    ({'bio': False, 'fanart': False, 'thumbnails': False}, 'nothing-enabled'),
-    ({'bio': True, 'fanart': True, 'thumbnails': True}, 'everything-enabled')
-])
+@pytest.mark.parametrize("features,test_id", [({
+    'bio': True,
+    'fanart': False,
+    'thumbnails': False
+}, 'bio-only'), ({
+    'bio': False,
+    'fanart': True,
+    'thumbnails': False
+}, 'fanart-only'), ({
+    'bio': False,
+    'fanart': False,
+    'thumbnails': True
+}, 'thumbnails-only'), ({
+    'bio': True,
+    'fanart': True,
+    'thumbnails': False
+}, 'bio-fanart'), ({
+    'bio': False,
+    'fanart': False,
+    'thumbnails': False
+}, 'nothing-enabled'), ({
+    'bio': True,
+    'fanart': True,
+    'thumbnails': True
+}, 'everything-enabled')])
 @skip_no_discogs_key
 def test_discogs_selective_feature_disabling(bootstrap, features, test_id):
     ''' test plugin behavior when specific features are disabled '''
@@ -836,7 +868,7 @@ async def test_discogs_rapid_track_changes(bootstrap):
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(f'Discogs plugin raised exception during rapid track changes: {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+                    f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -920,7 +952,7 @@ async def test_discogs_common_dj_genres(bootstrap):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             pytest.fail(f'Discogs plugin raised exception for DJ track "{track["artist"]}": {exc}. '
-                       f'Plugins must handle all errors gracefully for live performance.')
+                        f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -1040,7 +1072,7 @@ async def test_discogs_memory_usage_stability(bootstrap):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             pytest.fail(f'Discogs plugin raised exception for memory test track {i}: {exc}. '
-                       f'Plugins must handle all errors gracefully for live performance.')
+                        f'Plugins must handle all errors gracefully for live performance.')
 
     logging.info('Memory stability test completed: %d/%d tracks processed successfully',
                  successful_lookups, len(tracks))
@@ -1150,8 +1182,7 @@ async def test_discogs_api_call_count(bootstrap):
 
             # Verify one API call was made
             assert api_call_count == 1, (
-                f'Expected 1 API call after first download, got {api_call_count}'
-            )
+                f'Expected 1 API call after first download, got {api_call_count}')
 
             # Second call - should use cached result, no additional API call
             result2 = await plugin.download_async(metadata.copy(),
@@ -1159,8 +1190,7 @@ async def test_discogs_api_call_count(bootstrap):
 
             # Verify still only one API call was made (cache hit)
             assert api_call_count == 1, (
-                f'Expected 1 API call after second download (cache hit), got {api_call_count}'
-            )
+                f'Expected 1 API call after second download (cache hit), got {api_call_count}')
 
             # Both results should be consistent
             assert (result1 is None) == (result2 is None)

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -5,10 +5,9 @@ import os
 
 import pytest
 
-from utils_artistextras import (
-    configureplugins, configuresettings, skip_no_fanarttv_key,
-    run_cache_consistency_test, run_api_call_count_test, run_failure_cache_test
-)
+from utils_artistextras import (configureplugins, configuresettings, skip_no_fanarttv_key,
+                                run_cache_consistency_test, run_api_call_count_test,
+                                run_failure_cache_test)
 
 
 def _setup_fanarttv_plugin(bootstrap):
@@ -40,8 +39,7 @@ async def test_fanarttv_apicache_usage(bootstrap):
         plugin=plugin,
         test_metadata=_get_test_metadata(),
         imagecache=imagecache,
-        success_message='FanartTV API call successful, caching verified'
-    )
+        success_message='FanartTV API call successful, caching verified')
 
 
 @pytest.mark.asyncio
@@ -50,13 +48,10 @@ async def test_fanarttv_apicache_api_call_count(bootstrap):
     ''' test that fanarttv plugin makes only one API call when cache is used '''
     plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
 
-    await run_api_call_count_test(
-        plugin=plugin,
-        test_metadata=_get_test_metadata(),
-        mock_method_name='_fetch_async',
-        imagecache=imagecache
-    )
-
+    await run_api_call_count_test(plugin=plugin,
+                                  test_metadata=_get_test_metadata(),
+                                  mock_method_name='_fetch_async',
+                                  imagecache=imagecache)
 
 
 @pytest.mark.asyncio
@@ -73,9 +68,7 @@ async def test_fanarttv_apicache_api_failure_behavior(bootstrap):
         'musicbrainzartistid': ['invalid-mbid-that-will-fail']  # Invalid MBID
     }
 
-    await run_failure_cache_test(
-        plugin=plugin,
-        test_metadata=test_metadata,
-        mock_method_name='_fetch_async',
-        imagecache=imagecache
-    )
+    await run_failure_cache_test(plugin=plugin,
+                                 test_metadata=test_metadata,
+                                 mock_method_name='_fetch_async',
+                                 imagecache=imagecache)

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -6,10 +6,8 @@ import os
 
 import pytest
 
-from utils_artistextras import (
-    configureplugins, configuresettings, skip_no_theaudiodb_key,
-    run_api_call_count_test
-)
+from utils_artistextras import (configureplugins, configuresettings, skip_no_theaudiodb_key,
+                                run_api_call_count_test)
 
 
 def _setup_theaudiodb_plugin(bootstrap):
@@ -39,8 +37,8 @@ async def test_theaudiodb_artist_name_correction(bootstrap):
     if result1:  # Only test if we got data back
         # Should have corrected the artist name to proper case
         assert result1['artist'] == 'Nine Inch Nails'
-        logging.info('Artist name corrected: %s -> %s',
-                    metadata_lowercase['artist'], result1['artist'])
+        logging.info('Artist name corrected: %s -> %s', metadata_lowercase['artist'],
+                     result1['artist'])
 
     # Test 2: With MusicBrainz ID (should NOT correct artist name)
     metadata_with_mbid = {
@@ -66,10 +64,7 @@ async def test_theaudiodb_apicache_duplicate_artists(bootstrap):
 
     # Test two different searches that might return different artists with similar names
     # First search - likely to match main "Madonna"
-    metadata_madonna1 = {
-        'artist': 'Madonna',
-        'imagecacheartist': 'madonna1'
-    }
+    metadata_madonna1 = {'artist': 'Madonna', 'imagecacheartist': 'madonna1'}
 
     # Second search - variation that might match different artist
     metadata_madonna2 = {
@@ -78,16 +73,12 @@ async def test_theaudiodb_apicache_duplicate_artists(bootstrap):
     }
 
     # Test both variations - first calls hit API, second calls use cache
-    result1a = await plugin.download_async(metadata_madonna1.copy(),
-                                          imagecache=imagecache)
-    result2a = await plugin.download_async(metadata_madonna2.copy(),
-                                          imagecache=imagecache)
+    result1a = await plugin.download_async(metadata_madonna1.copy(), imagecache=imagecache)
+    result2a = await plugin.download_async(metadata_madonna2.copy(), imagecache=imagecache)
 
     # Second calls - should use cached data
-    result1b = await plugin.download_async(metadata_madonna1.copy(),
-                                          imagecache=imagecache)
-    result2b = await plugin.download_async(metadata_madonna2.copy(),
-                                          imagecache=imagecache)
+    result1b = await plugin.download_async(metadata_madonna1.copy(), imagecache=imagecache)
+    result2b = await plugin.download_async(metadata_madonna2.copy(), imagecache=imagecache)
 
     # Verify caching works for both variations
     assert (result1a is None) == (result1b is None)
@@ -107,8 +98,8 @@ async def test_theaudiodb_apicache_duplicate_artists(bootstrap):
         artist2 = result2a.get('artist', '')
 
         if artist1 and artist2 and artist1 != artist2:
-            logging.info('TheAudioDB distinguished between different artists: %s vs %s',
-                     artist1, artist2)
+            logging.info('TheAudioDB distinguished between different artists: %s vs %s', artist1,
+                         artist2)
         else:
             logging.info('TheAudioDB returned same artist for both variations')
     else:
@@ -184,8 +175,7 @@ async def test_theaudiodb_invalid_musicbrainz_id_fallback(bootstrap):
         # Verify the call pattern: MBID tried first, then fallback to name-based
         assert mbid_call_count == 1, f'Expected 1 MBID call, got {mbid_call_count}'
         assert name_call_count >= 1, (
-            f'Expected at least 1 name call (fallback), got {name_call_count}'
-        )
+            f'Expected at least 1 name call (fallback), got {name_call_count}')
 
         # Should get a result from name-based fallback with corrected artist name
         assert result is not None, 'Expected result from name-based fallback'
@@ -193,13 +183,12 @@ async def test_theaudiodb_invalid_musicbrainz_id_fallback(bootstrap):
         # If name correction feature is enabled, verify corrected artist name
         if result and result.get('artist'):
             assert result['artist'] == 'Nine Inch Nails', (
-                f'Expected corrected artist name, got {result.get("artist")}'
-            )
+                f'Expected corrected artist name, got {result.get("artist")}')
             logging.info('TheAudioDB invalid MBID fallback verified: '
-                        'MBID failed, name-based succeeded with correction')
+                         'MBID failed, name-based succeeded with correction')
         else:
             logging.info('TheAudioDB invalid MBID fallback verified: '
-                        'MBID failed, name-based search attempted')
+                         'MBID failed, name-based search attempted')
 
         # Test without any MusicBrainz ID to ensure same name-based behavior
         mbid_call_count = 0
@@ -216,11 +205,9 @@ async def test_theaudiodb_invalid_musicbrainz_id_fallback(bootstrap):
 
         # Should skip MBID and go straight to name-based search
         assert mbid_call_count == 0, (
-            f'Expected 0 MBID calls when no MBID provided, got {mbid_call_count}'
-        )
+            f'Expected 0 MBID calls when no MBID provided, got {mbid_call_count}')
         assert name_call_count >= 1, (
-            f'Expected at least 1 name call when no MBID, got {name_call_count}'
-        )
+            f'Expected at least 1 name call when no MBID, got {name_call_count}')
 
         logging.info('TheAudioDB MBID fallback behavior test completed successfully')
 
@@ -238,13 +225,9 @@ async def test_theaudiodb_api_call_count(bootstrap):
     plugin, imagecache = _setup_theaudiodb_plugin(bootstrap)
 
     # Test with a known artist
-    metadata = {
-        'artist': 'Madonna',
-        'imagecacheartist': 'madonna'
-    }
+    metadata = {'artist': 'Madonna', 'imagecacheartist': 'madonna'}
 
-    await run_api_call_count_test(
-        plugin=plugin,
-        test_metadata=metadata,
-        mock_method_name='_fetch_async',
-        imagecache=imagecache)
+    await run_api_call_count_test(plugin=plugin,
+                                  test_metadata=metadata,
+                                  mock_method_name='_fetch_async',
+                                  imagecache=imagecache)

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -8,8 +8,7 @@ import ssl
 import pytest
 from aiohttp import ClientResponseError
 
-from utils_artistextras import (configureplugins, configuresettings,
-                               run_cache_consistency_test)
+from utils_artistextras import (configureplugins, configuresettings, run_cache_consistency_test)
 
 import nowplaying.apicache  # pylint: disable=import-error
 import nowplaying.wikiclient  # pylint: disable=import-error
@@ -275,16 +274,26 @@ async def test_wikimedia_malformed_urls(bootstrap, malformed_urls, test_id):
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(f'Wikimedia plugin raised exception for malformed URL case ({test_id}): {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+                    f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.parametrize("metadata,test_id", [
     ({}, "empty-metadata"),
-    ({'artist': 'Test Artist'}, "missing-artistwebsites"),
-    ({'artistwebsites': None}, "none-artistwebsites"),
-    ({'artistwebsites': []}, "empty-artistwebsites-list"),
-    ({'artistwebsites': ['']}, "empty-string-in-list"),
-    ({'artistwebsites': [None]}, "none-in-list"),
+    ({
+        'artist': 'Test Artist'
+    }, "missing-artistwebsites"),
+    ({
+        'artistwebsites': None
+    }, "none-artistwebsites"),
+    ({
+        'artistwebsites': []
+    }, "empty-artistwebsites-list"),
+    ({
+        'artistwebsites': ['']
+    }, "empty-string-in-list"),
+    ({
+        'artistwebsites': [None]
+    }, "none-in-list"),
 ])
 @pytest.mark.asyncio
 async def test_wikimedia_missing_metadata_fields(bootstrap, metadata, test_id):
@@ -308,21 +317,17 @@ async def test_wikimedia_missing_metadata_fields(bootstrap, metadata, test_id):
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(
             f'Wikimedia plugin raised exception for missing metadata case ({test_id}): {exc}. '
-            f'Plugins must handle all errors gracefully for live performance.'
-        )
+            f'Plugins must handle all errors gracefully for live performance.')
 
 
 # Language Handling Edge Cases
 
 
-@pytest.mark.parametrize("invalid_language,test_id", [
-    ('xx', 'unsupported-code'),
-    ('invalid-lang', 'hyphenated-invalid'),
-    ('', 'empty-string'),
-    ('toolong', 'too-long'),
-    ('123', 'numeric'),
-    ('en-US-invalid', 'complex-invalid')
-])
+@pytest.mark.parametrize("invalid_language,test_id", [('xx', 'unsupported-code'),
+                                                      ('invalid-lang', 'hyphenated-invalid'),
+                                                      ('', 'empty-string'), ('toolong', 'too-long'),
+                                                      ('123', 'numeric'),
+                                                      ('en-US-invalid', 'complex-invalid')])
 @pytest.mark.asyncio
 async def test_wikimedia_invalid_language_codes(bootstrap, invalid_language, test_id):
     ''' test handling of invalid language codes '''
@@ -354,8 +359,7 @@ async def test_wikimedia_invalid_language_codes(bootstrap, invalid_language, tes
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(
             f'Wikimedia plugin raised exception for invalid language "{invalid_language}" '
-            f'({test_id}): {exc}. Plugins must handle all errors gracefully for live performance.'
-        )
+            f'({test_id}): {exc}. Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -390,7 +394,7 @@ async def test_wikimedia_language_fallback_chain(bootstrap):
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(f'Wikimedia plugin raised exception during language fallback: {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+                    f'Plugins must handle all errors gracefully for live performance.')
 
 
 # Content Processing and Sanitization Tests
@@ -484,9 +488,11 @@ async def test_wikimedia_malformed_content_handling(bootstrap):
         original_get_page = nowplaying.wikiclient.get_page_async
 
         def create_mock_response(response_data):
+
             async def mock_malformed_response(*args, **kwargs):  # pylint: disable=unused-argument
                 """Return mock malformed response."""
                 return response_data
+
             return mock_malformed_response
 
         mock_func = create_mock_response(malformed_response)
@@ -509,7 +515,7 @@ async def test_wikimedia_malformed_content_handling(bootstrap):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             pytest.fail(f'Wikimedia plugin raised exception for malformed response {i}: {exc}. '
-                       f'Plugins must handle all errors gracefully for live performance.')
+                        f'Plugins must handle all errors gracefully for live performance.')
 
         finally:
             # Restore original function
@@ -646,7 +652,7 @@ async def test_wikimedia_rapid_entity_lookups(bootstrap):
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
         pytest.fail(f'Wikimedia plugin raised exception during rapid entity lookups: {exc}. '
-                   f'Plugins must handle all errors gracefully for live performance.')
+                    f'Plugins must handle all errors gracefully for live performance.')
 
 
 @pytest.mark.asyncio
@@ -733,7 +739,7 @@ async def test_wikimedia_memory_stability_long_session(bootstrap):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             pytest.fail(f'Wikimedia plugin raised exception for entity {i}: {exc}. '
-                       f'Plugins must handle all errors gracefully for live performance.')
+                        f'Plugins must handle all errors gracefully for live performance.')
 
     logging.info('Memory stability test completed: %d/%d entities processed successfully',
                  successful_lookups, len(entities))
@@ -776,16 +782,14 @@ async def test_wikimedia_api_call_count(bootstrap):
 
         # Verify one API call was made
         assert api_call_count == 1, (
-            f'Expected 1 API call after first download, got {api_call_count}'
-        )
+            f'Expected 1 API call after first download, got {api_call_count}')
 
         # Second call - should use cached result, no additional API call
         result2 = await plugin.download_async(metadata.copy(), imagecache=imagecaches['wikimedia'])
 
         # Verify still only one API call was made (cache hit)
         assert api_call_count == 1, (
-            f'Expected 1 API call after second download (cache hit), got {api_call_count}'
-        )
+            f'Expected 1 API call after second download (cache hit), got {api_call_count}')
 
         # Both results should be consistent
         assert (result1 is None) == (result2 is None)
@@ -833,6 +837,7 @@ async def test_wikimedia_failure_cache(bootstrap):
             return None
         # Second call: simulate successful response
         logging.debug('Simulating successful Wikipedia API response on second call')
+
         # Return a minimal WikiPage-like object
         class MockWikiPage:  # pylint: disable=too-few-public-methods
             """Mock WikiPage for testing."""
@@ -867,8 +872,7 @@ async def test_wikimedia_failure_cache(bootstrap):
 
         # Verify one API call was made and result is None (failure)
         assert api_call_count == 1, (
-            f'Expected 1 API call after first download, got {api_call_count}'
-        )
+            f'Expected 1 API call after first download, got {api_call_count}')
         assert result1 is None, 'Expected None result from failed Wikipedia API call'
 
         # Second call - should retry (not use cached failure) and succeed
@@ -877,8 +881,7 @@ async def test_wikimedia_failure_cache(bootstrap):
         # Verify second API call was made (failure wasn't cached)
         assert api_call_count == 2, (
             f'Expected 2 API calls after second download (retry after failure), '
-            f'got {api_call_count}'
-        )
+            f'got {api_call_count}')
 
         # Should get valid result from successful second call
         assert result2 is not None, ('Expected successful result from '
@@ -889,8 +892,7 @@ async def test_wikimedia_failure_cache(bootstrap):
 
         # Verify still only two API calls (third used cached success)
         assert api_call_count == 2, (
-            f'Expected 2 API calls after third download (cache hit), got {api_call_count}'
-        )
+            f'Expected 2 API calls after third download (cache hit), got {api_call_count}')
         # Results should be consistent for successful calls
         assert result2 == result3
         logging.info('Wikimedia cache failure test passed - '

--- a/tests/test_hostmeta.py
+++ b/tests/test_hostmeta.py
@@ -75,7 +75,7 @@ def test_socket_failure_graceful_degradation():
     with unittest.mock.patch('socket.gethostname', side_effect=OSError("Mock socket error")):
         with unittest.mock.patch('socket.getfqdn', side_effect=OSError("Mock socket error")):
             with unittest.mock.patch('socket.gethostbyname',
-                                      side_effect=OSError("Mock socket error")):
+                                     side_effect=OSError("Mock socket error")):
                 hostinfo = nowplaying.hostmeta.gethostmeta()
 
                 # Critical: Must not crash and must return proper structure
@@ -105,7 +105,7 @@ def test_netifaces_fallback():
 
     # Mock partial socket failure (hostname works, IP fails)
     with unittest.mock.patch('socket.gethostbyname',
-                              side_effect=OSError("Mock IP resolution error")):
+                             side_effect=OSError("Mock IP resolution error")):
         hostinfo = nowplaying.hostmeta.gethostmeta()
 
         # Should still get valid results (either from netifaces or fallback)
@@ -127,14 +127,13 @@ def test_extreme_network_failure_resilience():
     socket_error = OSError("Mock complete network failure")
     with unittest.mock.patch('socket.gethostname', side_effect=socket_error):
         with unittest.mock.patch('socket.getfqdn', side_effect=socket_error):
-            with unittest.mock.patch('socket.gethostbyname',
-                                      side_effect=socket_error):
+            with unittest.mock.patch('socket.gethostbyname', side_effect=socket_error):
                 # Mock netifaces complete failure if available
                 if nowplaying.hostmeta.IFACES:
                     # Mock netifaces module itself to fail internally
                     with unittest.mock.patch(
-                        'netifaces.gateways',
-                        side_effect=Exception("Mock netifaces module failure")):
+                            'netifaces.gateways',
+                            side_effect=Exception("Mock netifaces module failure")):
                         hostinfo = nowplaying.hostmeta.gethostmeta()
                 else:
                     hostinfo = nowplaying.hostmeta.gethostmeta()

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -123,7 +123,7 @@ def test_settings_ui_save_handles_empty_strings(jriver_bootstrap):  # pylint: di
     mock_qwidget.host_lineedit.text.return_value = 'localhost'
     mock_qwidget.port_lineedit.text.return_value = '52199'
     mock_qwidget.username_lineedit.text.return_value = '   '  # whitespace-only
-    mock_qwidget.password_lineedit.text.return_value = ''     # empty string
+    mock_qwidget.password_lineedit.text.return_value = ''  # empty string
     mock_qwidget.access_key_lineedit.text.return_value = '  '  # whitespace-only
 
     plugin.save_settingsui(mock_qwidget)
@@ -246,7 +246,7 @@ async def test_test_connection_success():
 
     with aioresponses() as mock_resp:
         mock_resp.get('http://localhost:52199/MCWS/v1/Alive',
-              body='''<Response Status="OK">
+                      body='''<Response Status="OK">
                         <Item Name="AccessKey">testkey</Item>
                       </Response>''')
 
@@ -268,7 +268,7 @@ async def test_test_connection_wrong_access_key():
 
     with aioresponses() as mock_resp:
         mock_resp.get('http://localhost:52199/MCWS/v1/Alive',
-              body='''<Response Status="OK">
+                      body='''<Response Status="OK">
                         <Item Name="AccessKey">correctkey</Item>
                       </Response>''')
 
@@ -329,7 +329,7 @@ async def test_authenticate_success():
     with aioresponses() as mock_resp:
         url = 'http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass'
         mock_resp.get(url,
-              body='''
+                      body='''
               <Response Status="OK">
                   <Item Name="Token">abc123token</Item>
               </Response>
@@ -367,7 +367,7 @@ async def test_authenticate_no_token():
     with aioresponses() as mock_resp:
         url = 'http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass'
         mock_resp.get(url,
-              body='''
+                      body='''
               <Response Status="OK">
               </Response>
               ''')
@@ -419,7 +419,7 @@ async def test_getplayingtrack_success(jriver_plugin_with_session):  # pylint: d
     with aioresponses() as mock_resp:
         # aioresponses matches the URL pattern, including query parameters
         mock_resp.get('http://localhost:52199/MCWS/v1/Playback/Info?Token=testtoken',
-              body='''<Response Status="OK">
+                      body='''<Response Status="OK">
                         <Item Name="State">Playing</Item>
                         <Item Name="Artist">The Beatles</Item>
                         <Item Name="Album">Abbey Road</Item>
@@ -446,7 +446,7 @@ async def test_getplayingtrack_minimal_data():
 
     with aioresponses() as mock_resp:
         mock_resp.get('http://localhost:52199/MCWS/v1/Playback/Info',
-              body='''
+                      body='''
               <Response Status="OK">
                   <Item Name="Name">Unknown Track</Item>
               </Response>
@@ -565,7 +565,7 @@ async def test_getplayingtrack_with_token():
     with aioresponses() as mock_resp:
         # aioresponses matches the exact URL including query parameters
         mock_resp.get('http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123',
-              body='<Response Status="OK"></Response>')
+                      body='<Response Status="OK"></Response>')
 
         await plugin.getplayingtrack()
 
@@ -585,7 +585,7 @@ async def test_getplayingtrack_without_token():
     with aioresponses() as mock_resp:
         # aioresponses matches the exact URL without query parameters
         mock_resp.get('http://localhost:52199/MCWS/v1/Playback/Info',
-              body='<Response Status="OK"></Response>')
+                      body='<Response Status="OK"></Response>')
 
         await plugin.getplayingtrack()
 
@@ -605,7 +605,7 @@ async def test_getplayingtrack_with_access_key():
     with aioresponses() as mock_resp:
         # aioresponses matches the exact URL including query parameters
         mock_resp.get('http://localhost:52199/MCWS/v1/Playback/Info?AccessKey=myaccesskey123',
-              body='<Response Status="OK"></Response>')
+                      body='<Response Status="OK"></Response>')
 
         await plugin.getplayingtrack()
 
@@ -648,7 +648,7 @@ async def test_get_filename_with_access_key():
     with aioresponses() as mock_resp:
         url = 'http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&AccessKey=myaccesskey123'
         mock_resp.get(url,
-              body='''<Response Status="OK">
+                      body='''<Response Status="OK">
                         <Item Name="Filename">test.mp3</Item>
                       </Response>''')
 
@@ -673,7 +673,7 @@ async def test_get_filename_with_token_and_access_key():
         url = ('http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&'
                'Token=mytoken123&AccessKey=myaccesskey123')
         mock_resp.get(url,
-              body='''<Response Status="OK">
+                      body='''<Response Status="OK">
                         <Item Name="Filename">test.mp3</Item>
                       </Response>''')
 
@@ -703,42 +703,44 @@ def test_connect_settingsui():
     assert plugin.uihelp == mock_uihelp
 
 
-@pytest.mark.parametrize("host,expected", [
-    # Localhost variants
-    ('localhost', True),
-    ('127.0.0.1', True),
-    ('::1', True),
-    # Private IPv4 ranges
-    ('192.168.1.100', True),
-    ('10.0.0.5', True),
-    ('172.16.1.10', True),
-    # Private IPv6 ranges
-    ('fe80::1', True),  # Link-local
-    ('fd00::1', True),  # Unique local
-    # Public IPv4 addresses
-    ('8.8.8.8', False),
-    ('1.1.1.1', False),
-    # Public IPv6 addresses
-    ('2001:4860:4860::8888', False),  # Google DNS
-    ('2606:4700:4700::1111', False),  # Cloudflare DNS
-    # Generic hostnames (should NOT be considered local - security risk)
-    ('jriver-server', False),
-    ('remote.example.com', False),
-    # Explicit local domain patterns
-    ('media-pc.local', True),
-    ('jriver.lan', True),
-    ('server.home', True),
-    ('media.internal', True),
-    # Remote hostnames (security test)
-    ('jriver.example.com', False),
-    ('music-server.net', False),
-    ('remote-jriver.org', False),
-    ('malicious-server.co.uk', False),
-    ('untrusted-host', False),
-    ('random-hostname', False),
-    # Edge case
-    (None, False),
-])
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        # Localhost variants
+        ('localhost', True),
+        ('127.0.0.1', True),
+        ('::1', True),
+        # Private IPv4 ranges
+        ('192.168.1.100', True),
+        ('10.0.0.5', True),
+        ('172.16.1.10', True),
+        # Private IPv6 ranges
+        ('fe80::1', True),  # Link-local
+        ('fd00::1', True),  # Unique local
+        # Public IPv4 addresses
+        ('8.8.8.8', False),
+        ('1.1.1.1', False),
+        # Public IPv6 addresses
+        ('2001:4860:4860::8888', False),  # Google DNS
+        ('2606:4700:4700::1111', False),  # Cloudflare DNS
+        # Generic hostnames (should NOT be considered local - security risk)
+        ('jriver-server', False),
+        ('remote.example.com', False),
+        # Explicit local domain patterns
+        ('media-pc.local', True),
+        ('jriver.lan', True),
+        ('server.home', True),
+        ('media.internal', True),
+        # Remote hostnames (security test)
+        ('jriver.example.com', False),
+        ('music-server.net', False),
+        ('remote-jriver.org', False),
+        ('malicious-server.co.uk', False),
+        ('untrusted-host', False),
+        ('random-hostname', False),
+        # Edge case
+        (None, False),
+    ])
 def test_is_local_connection(host, expected):
     """Test local connection detection for various hosts"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
@@ -753,28 +755,30 @@ def test_is_local_connection_ipv6_url_formatting():
     assert formatted_host == '[::1]'
 
 
-@pytest.mark.parametrize("input_host,expected", [
-    # IPv4 addresses (should remain unchanged)
-    ('192.168.1.100', '192.168.1.100'),
-    ('127.0.0.1', '127.0.0.1'),
-    ('10.0.0.1', '10.0.0.1'),
-    # IPv6 addresses (should be wrapped in brackets)
-    ('2001:db8::1', '[2001:db8::1]'),
-    ('::1', '[::1]'),
-    ('fe80::1%lo0', '[fe80::1%lo0]'),
-    ('2001:0db8:85a3:0000:0000:8a2e:0370:7334', '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]'),
-    # Already bracketed IPv6 (should remain unchanged)
-    ('[2001:db8::1]', '[2001:db8::1]'),
-    ('[::1]', '[::1]'),
-    # Hostnames (should remain unchanged)
-    ('localhost', 'localhost'),
-    ('jriver.local', 'jriver.local'),
-    ('media-server.lan', 'media-server.lan'),
-    # Edge cases
-    (None, None),
-    ('', ''),
-    ('invalid-ip', 'invalid-ip'),
-])
+@pytest.mark.parametrize(
+    "input_host,expected",
+    [
+        # IPv4 addresses (should remain unchanged)
+        ('192.168.1.100', '192.168.1.100'),
+        ('127.0.0.1', '127.0.0.1'),
+        ('10.0.0.1', '10.0.0.1'),
+        # IPv6 addresses (should be wrapped in brackets)
+        ('2001:db8::1', '[2001:db8::1]'),
+        ('::1', '[::1]'),
+        ('fe80::1%lo0', '[fe80::1%lo0]'),
+        ('2001:0db8:85a3:0000:0000:8a2e:0370:7334', '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]'),
+        # Already bracketed IPv6 (should remain unchanged)
+        ('[2001:db8::1]', '[2001:db8::1]'),
+        ('[::1]', '[::1]'),
+        # Hostnames (should remain unchanged)
+        ('localhost', 'localhost'),
+        ('jriver.local', 'jriver.local'),
+        ('media-server.lan', 'media-server.lan'),
+        # Edge cases
+        (None, None),
+        ('', ''),
+        ('invalid-ip', 'invalid-ip'),
+    ])
 def test_format_host_for_url(input_host, expected):
     """Test host formatting for URL construction"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
@@ -812,7 +816,7 @@ async def test_get_filename_success(jriver_plugin_with_session):  # pylint: disa
 
     with aioresponses() as mock_resp:
         mock_resp.get('http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&Token=testtoken',
-              body='''<Response Status="OK">
+                      body='''<Response Status="OK">
                         <Item Name="FileKey">12345</Item>
                         <Item Name="Name">Come Together</Item>
                         <Item Name="Artist">The Beatles</Item>
@@ -834,7 +838,7 @@ async def test_get_filename_not_found():
 
     with aioresponses() as mock_resp:
         mock_resp.get('http://localhost:52199/MCWS/v1/File/GetInfo?File=12345',
-              body='''
+                      body='''
               <Response Status="OK">
                   <Item Name="FileKey">12345</Item>
                   <Item Name="Name">Come Together</Item>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -723,42 +723,46 @@ async def test_preset_image(get_imagecache, getroot):  #pylint: disable=redefine
         assert row > 1
 
 
-@pytest.mark.parametrize("input_value,expected_output", [
-    # Base64 encoded JSON (MixedInKey format)
-    ('eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==',  # pragma: allowlist secret  # pylint: disable=line-too-long
-     '4A'),
-    # Direct JSON
-    ('{"algorithm":94,"key":"9B","source":"mixedinkey"}', '9B'),
-    # Simple string keys
-    ('Am', 'Am'),
-    ('C#m', 'C#m'),
-    ('12A', '12A'),
-    # Empty/None values
-    (None, None),
-    ('', None),
-    ('   ', ''),
-    # Malformed input
-    ('not-base64-or-json', 'not-base64-or-json'),
-    ('invalid-json{"key":"test"}', 'invalid-json{"key":"test"}'),
-    # Valid base64 that decodes to non-JSON text
-    ('SGVsbG8gV29ybGQ=', 'SGVsbG8gV29ybGQ='),  # "Hello World"
-    # Valid base64 that decodes to non-object JSON (array)
-    ('WyJ0ZXN0IiwiYXJyYXkiXQ==', 'WyJ0ZXN0IiwiYXJyYXkiXQ=='),  # ["test","array"]
-    # Valid base64 that decodes to non-object JSON (string)
-    ('InRlc3Qgc3RyaW5nIg==', 'InRlc3Qgc3RyaW5nIg=='),  # "test string"
-    # Valid base64 that decodes to JSON object missing 'key' field
-    ('eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0=',  # pragma: allowlist secret
-     'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0='),  # pragma: allowlist secret
-    # Direct JSON without 'key' field
-    ('{"algorithm":94,"source":"mixedinkey"}', '{"algorithm":94,"source":"mixedinkey"}'),
-    # Direct JSON array
-    ('["test","array"]', '["test","array"]'),
-    # Direct JSON string
-    ('"test string"', '"test string"'),
-    # JSON with null key value
-    ('{"algorithm":94,"key":null,"source":"mixedinkey"}',
-     '{"algorithm":94,"key":null,"source":"mixedinkey"}'),
-])
+@pytest.mark.parametrize(
+    "input_value,expected_output",
+    [
+        # Base64 encoded JSON (MixedInKey format)
+        (
+            'eyJhbGdvcml0aG0iOjk0LCJrZXkiOiI0QSIsInNvdXJjZSI6Im1peGVkaW5rZXkifQ==',  # pragma: allowlist secret  # pylint: disable=line-too-long
+            '4A'),
+        # Direct JSON
+        ('{"algorithm":94,"key":"9B","source":"mixedinkey"}', '9B'),
+        # Simple string keys
+        ('Am', 'Am'),
+        ('C#m', 'C#m'),
+        ('12A', '12A'),
+        # Empty/None values
+        (None, None),
+        ('', None),
+        ('   ', ''),
+        # Malformed input
+        ('not-base64-or-json', 'not-base64-or-json'),
+        ('invalid-json{"key":"test"}', 'invalid-json{"key":"test"}'),
+        # Valid base64 that decodes to non-JSON text
+        ('SGVsbG8gV29ybGQ=', 'SGVsbG8gV29ybGQ='),  # "Hello World"
+        # Valid base64 that decodes to non-object JSON (array)
+        ('WyJ0ZXN0IiwiYXJyYXkiXQ==', 'WyJ0ZXN0IiwiYXJyYXkiXQ=='),  # ["test","array"]
+        # Valid base64 that decodes to non-object JSON (string)
+        ('InRlc3Qgc3RyaW5nIg==', 'InRlc3Qgc3RyaW5nIg=='),  # "test string"
+        # Valid base64 that decodes to JSON object missing 'key' field
+        (
+            'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0=',  # pragma: allowlist secret
+            'eyJhbGdvcml0aG0iOjk0LCJzb3VyY2UiOiJtaXhlZGlua2V5In0='),  # pragma: allowlist secret
+        # Direct JSON without 'key' field
+        ('{"algorithm":94,"source":"mixedinkey"}', '{"algorithm":94,"source":"mixedinkey"}'),
+        # Direct JSON array
+        ('["test","array"]', '["test","array"]'),
+        # Direct JSON string
+        ('"test string"', '"test string"'),
+        # JSON with null key value
+        ('{"algorithm":94,"key":null,"source":"mixedinkey"}',
+         '{"algorithm":94,"key":null,"source":"mixedinkey"}'),
+    ])
 def test_decode_musical_key(input_value, expected_output):
     """Test the _decode_musical_key method handles various key formats."""
     result = nowplaying.metadata.TinyTagRunner._decode_musical_key(input_value)  # pylint: disable=protected-access

--- a/tests/test_mpris2.py
+++ b/tests/test_mpris2.py
@@ -149,7 +149,7 @@ async def test_getplayingtrack_with_vlc_metadata(getroot):
                     'mpris:artUrl':
                     Variant(
                         's',
-                        'file:///tmp/.cache/vlc/art/artistalbum/Nine%20Inch%20Nails/Ghosts%20I-IV/art' #pylint: disable=line-too-long
+                        'file:///tmp/.cache/vlc/art/artistalbum/Nine%20Inch%20Nails/Ghosts%20I-IV/art'  #pylint: disable=line-too-long
                     ),
                     'vlc:encodedby':
                     Variant('s', 'Lavf61.1.100'),

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -95,8 +95,8 @@ async def test_recordingid_api_cache_call_count(getmusicbrainz, temp_api_cache):
         async def mock_recordingid_uncached(recordingid):
             nonlocal api_call_count
             api_call_count += 1
-            logging.debug('MusicBrainz API call #%d for recording ID: %s',
-                         api_call_count, recordingid)
+            logging.debug('MusicBrainz API call #%d for recording ID: %s', api_call_count,
+                          recordingid)
             # Call the original method to get real data
             return await original_recordingid_uncached(recordingid)
 
@@ -112,8 +112,7 @@ async def test_recordingid_api_cache_call_count(getmusicbrainz, temp_api_cache):
 
             # Verify one API call was made
             assert api_call_count == 1, (
-                f'Expected 1 API call after first recordingid lookup, got {api_call_count}'
-            )
+                f'Expected 1 API call after first recordingid lookup, got {api_call_count}')
             assert result1 is not None, 'Expected valid result from first MusicBrainz lookup'
 
             # Second call - should use cached result, no additional API call
@@ -122,8 +121,7 @@ async def test_recordingid_api_cache_call_count(getmusicbrainz, temp_api_cache):
             # Verify still only one API call was made (cache hit)
             assert api_call_count == 1, (
                 f'Expected 1 API call after second recordingid lookup (cache hit), '
-                f'got {api_call_count}'
-            )
+                f'got {api_call_count}')
 
             # Both results should be identical
             assert result1 == result2, 'Results should be identical when using cache'
@@ -139,8 +137,7 @@ async def test_recordingid_api_cache_call_count(getmusicbrainz, temp_api_cache):
             # Verify still only one API call total
             assert api_call_count == 1, (
                 f'Expected 1 API call after third recordingid lookup (cache hit), '
-                f'got {api_call_count}'
-            )
+                f'got {api_call_count}')
             assert result1 == result3, 'Third result should also be identical (cached)'
 
             logging.info('MusicBrainz recordingid API cache verified: 1 API call for 3 lookups')
@@ -413,13 +410,28 @@ async def test_musicbrainz_missing_metadata_fields(getmusicbrainz):  # pylint: d
     # Test various missing metadata scenarios for lastditcheffort
     metadata_cases = [
         {},  # Empty metadata
-        {'artist': ''},  # Empty artist
-        {'title': ''},  # Empty title
-        {'artist': None},  # None artist
-        {'title': None},  # None title
-        {'artist': 'Valid Artist'},  # Missing title
-        {'title': 'Valid Title'},  # Missing artist
-        {'artist': '   ', 'title': '   '},  # Whitespace only
+        {
+            'artist': ''
+        },  # Empty artist
+        {
+            'title': ''
+        },  # Empty title
+        {
+            'artist': None
+        },  # None artist
+        {
+            'title': None
+        },  # None title
+        {
+            'artist': 'Valid Artist'
+        },  # Missing title
+        {
+            'title': 'Valid Title'
+        },  # Missing artist
+        {
+            'artist': '   ',
+            'title': '   '
+        },  # Whitespace only
     ]
 
     for i, metadata in enumerate(metadata_cases):

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -13,8 +13,8 @@ import lxml.html
 
 import nowplaying.inputs.serato  # pylint: disable=import-error
 
+MONEYSTRING = 'Money Thats What I Want'  # codespell:ignore
 
-MONEYSTRING = 'Money Thats What I Want' # codespell:ignore
 
 @pytest.fixture
 def serato_bootstrap(bootstrap):

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -42,7 +42,7 @@ def test_version_1():
     ver2 = nowplaying.upgradeutils.Version('3.1.3-rc1')
 
     assert ver1 > ver2
-    assert not ver1 < ver2
+    assert ver1 >= ver2
 
 
 def test_version_2():
@@ -51,7 +51,7 @@ def test_version_2():
     ver2 = nowplaying.upgradeutils.Version('4.0.0')
 
     assert ver1 < ver2
-    assert not ver1 > ver2
+    assert ver1 <= ver2
 
 
 def test_version_3():
@@ -60,7 +60,7 @@ def test_version_3():
     ver2 = nowplaying.upgradeutils.Version('4.0.0-rc1')
 
     assert ver1 < ver2
-    assert not ver1 > ver2
+    assert ver1 <= ver2
 
 
 def test_version_4():
@@ -69,7 +69,105 @@ def test_version_4():
     ver2 = nowplaying.upgradeutils.Version('4.0.0-rc2')
 
     assert ver1 < ver2
-    assert not ver1 > ver2
+    assert ver1 <= ver2
+
+
+def test_version_equality():
+    ''' test equality operators '''
+    ver1 = nowplaying.upgradeutils.Version('3.1.3')
+    ver2 = nowplaying.upgradeutils.Version('3.1.3')
+    ver3 = nowplaying.upgradeutils.Version('3.1.4')
+
+    # Test equality
+    assert ver1 == ver2
+    assert ver1 != ver3
+
+    # Test inequality
+    assert ver1 != ver3
+    assert ver1 == ver2
+
+
+def test_version_greater_than_equal():
+    ''' test greater than or equal operators '''
+    ver1 = nowplaying.upgradeutils.Version('3.1.3')
+    ver2 = nowplaying.upgradeutils.Version('3.1.3')
+    ver3 = nowplaying.upgradeutils.Version('3.1.2')
+    ver4 = nowplaying.upgradeutils.Version('3.1.4')
+
+    # Test greater than or equal (equal case)
+    assert ver1 >= ver2
+    assert ver2 >= ver1
+
+    # Test greater than or equal (greater case)
+    assert ver1 >= ver3
+    assert ver3 < ver1
+
+    # Test greater than or equal (less case)
+    assert ver1 < ver4
+    assert ver4 >= ver1
+
+
+def test_version_less_than_equal():
+    ''' test less than or equal operators '''
+    ver1 = nowplaying.upgradeutils.Version('3.1.3')
+    ver2 = nowplaying.upgradeutils.Version('3.1.3')
+    ver3 = nowplaying.upgradeutils.Version('3.1.2')
+    ver4 = nowplaying.upgradeutils.Version('3.1.4')
+
+    # Test less than or equal (equal case)
+    assert ver1 <= ver2
+    assert ver2 <= ver1
+
+    # Test less than or equal (less case)
+    assert ver3 <= ver1
+    assert ver1 > ver3
+
+    # Test less than or equal (greater case)
+    assert ver1 <= ver4
+    assert ver4 > ver1
+
+
+def test_version_greater_than():
+    ''' test greater than operator '''
+    ver1 = nowplaying.upgradeutils.Version('3.1.3')
+    ver2 = nowplaying.upgradeutils.Version('3.1.2')
+    ver3 = nowplaying.upgradeutils.Version('3.1.3')
+    ver4 = nowplaying.upgradeutils.Version('3.1.4')
+
+    # Test greater than
+    assert ver1 > ver2
+    assert ver2 <= ver1
+
+    # Test not greater than (equal)
+    assert ver1 <= ver3
+    assert ver3 <= ver1
+
+    # Test not greater than (less)
+    assert ver1 <= ver4
+    assert ver4 > ver1
+
+
+def test_version_equality_with_rc():
+    ''' test equality with release candidates '''
+    ver1 = nowplaying.upgradeutils.Version('3.1.3-rc1')
+    ver2 = nowplaying.upgradeutils.Version('3.1.3-rc1')
+    ver3 = nowplaying.upgradeutils.Version('3.1.3-rc2')
+    ver4 = nowplaying.upgradeutils.Version('3.1.3')
+
+    # Test equality with rc
+    assert ver1 == ver2
+    assert ver1 != ver3
+    assert ver1 != ver4
+
+
+def test_version_equality_with_non_version():
+    ''' test equality with non-Version objects '''
+    ver1 = nowplaying.upgradeutils.Version('3.1.3')
+
+    # Test equality with non-Version objects
+    assert ver1 != "3.1.3"
+    assert ver1 != 3.13
+    assert ver1 is not None
 
 
 @pytest.mark.xfail(reason="API limit exceeded may happen")

--- a/tests/test_utils_chat.py
+++ b/tests/test_utils_chat.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Test chat utilities in utils.py"""
+# pylint: disable=no-member
+
+from unittest.mock import patch
+
+import pytest
+
+import nowplaying.utils
+
+
+def test_ensure_nltk_data_already_available():
+    """Test NLTK data initialization when punkt is already available"""
+    with patch('nltk.data.find') as mock_find:
+        # NLTK data already available
+        mock_find.return_value = True
+
+        # Should not raise exception
+        nowplaying.utils.ensure_nltk_data()
+
+        # Should check for punkt tokenizer
+        mock_find.assert_called_once_with('tokenizers/punkt')
+
+
+def test_ensure_nltk_data_download_needed():
+    """Test NLTK data initialization when download is needed"""
+    with patch('nltk.data.find') as mock_find, \
+         patch('nltk.download') as mock_download:
+
+        # Simulate punkt not found
+        mock_find.side_effect = LookupError("Resource punkt not found")
+        mock_download.return_value = True
+
+        # Should download punkt data
+        nowplaying.utils.ensure_nltk_data()
+
+        mock_find.assert_called_once_with('tokenizers/punkt')
+        mock_download.assert_called_once_with('punkt', quiet=True)
+
+
+def test_ensure_nltk_data_download_fails():
+    """Test NLTK data initialization when download fails"""
+    with patch('nltk.data.find') as mock_find, \
+         patch('nltk.download') as mock_download:
+
+        # Simulate punkt not found and download failure
+        mock_find.side_effect = LookupError("Resource punkt not found")
+        mock_download.side_effect = Exception("Download failed")
+
+        # Should not raise exception (graceful failure)
+        nowplaying.utils.ensure_nltk_data()
+
+        mock_find.assert_called_once_with('tokenizers/punkt')
+        mock_download.assert_called_once_with('punkt', quiet=True)
+
+
+def test_smart_split_message_short_message():
+    """Test message splitting with message shorter than limit"""
+    message = "This is a short message"
+    result = nowplaying.utils.smart_split_message(message, max_length=100)
+
+    assert result == [message]
+
+
+def test_smart_split_message_sentence_boundaries():
+    """Test message splitting at sentence boundaries"""
+    message = "First sentence. Second sentence! Third sentence?"
+    result = nowplaying.utils.smart_split_message(message, max_length=20)
+
+    # Should split at sentence boundaries
+    assert len(result) == 3
+    assert "First sentence." in result[0]
+    assert "Second sentence!" in result[1]
+    assert "Third sentence?" in result[2]
+
+
+def test_smart_split_message_word_boundaries():
+    """Test message splitting at word boundaries for long sentences"""
+    message = ("This is a very long sentence that exceeds the maximum "
+               "length limit and should be split at word boundaries")
+    result = nowplaying.utils.smart_split_message(message, max_length=30)
+
+    # Should split at word boundaries
+    assert len(result) > 1
+    for part in result:
+        assert len(part) <= 30
+        # Check that words aren't broken (except for truncated words ending in ...)
+        if not part.endswith('...'):
+            assert ' ' not in part or part.count(
+                ' ') > 0  # Either single word or multiple complete words
+
+
+def test_smart_split_message_very_long_word():
+    """Test message splitting with single word longer than limit"""
+    message = "Supercalifragilisticexpialidocious"
+    result = nowplaying.utils.smart_split_message(message, max_length=10)
+
+    # Should truncate long word
+    assert len(result) == 1
+    assert result[0].endswith('...')
+    assert len(result[0]) == 10
+
+
+def test_smart_split_message_mixed_content():
+    """Test message splitting with mixed sentence and word content"""
+    message = ("Short sentence. This is a much longer sentence that will "
+               "need to be split at word boundaries because it exceeds the "
+               "limit. Final short sentence.")
+    result = nowplaying.utils.smart_split_message(message, max_length=40)
+
+    # Should handle mixed content appropriately
+    assert len(result) >= 3
+    for part in result:
+        assert len(part) <= 40
+        assert part.strip()  # No empty parts
+
+
+def test_smart_split_message_nltk_failure_fallback():
+    """Test message splitting fallback when NLTK fails"""
+    with patch('nowplaying.utils.ensure_nltk_data'), \
+         patch('nltk.sent_tokenize') as mock_tokenize:
+
+        # Simulate NLTK failure
+        mock_tokenize.side_effect = Exception("NLTK error")
+
+        message = "This is a test message that should be split using fallback logic."
+        result = nowplaying.utils.smart_split_message(message, max_length=30)
+
+        # Should still split the message using fallback
+        assert len(result) > 1
+        for part in result:
+            assert len(part) <= 30
+
+
+def test_smart_split_message_empty_parts_removed():
+    """Test that empty message parts are removed"""
+    with patch('nowplaying.utils.ensure_nltk_data'), \
+         patch('nltk.sent_tokenize') as mock_tokenize:
+
+        # Simulate tokenization that might create empty parts
+        mock_tokenize.return_value = ["Valid sentence.", "", "   ", "Another sentence."]
+
+        message = "Test message"
+        result = nowplaying.utils.smart_split_message(message, max_length=50)
+
+        # Should not contain empty parts
+        for part in result:
+            assert part.strip()
+
+
+def test_smart_split_message_preserve_content():
+    """Test that message splitting preserves all content"""
+    message = "First sentence. Second sentence. Third sentence."
+    result = nowplaying.utils.smart_split_message(message, max_length=20)
+
+    # Reconstruct message from parts
+    reconstructed = ' '.join(result)
+
+    # Should preserve most content (allowing for spacing differences)
+    assert "First sentence" in reconstructed
+    assert "Second sentence" in reconstructed
+    assert "Third sentence" in reconstructed
+
+
+def test_tokenize_sentences_success():
+    """Test sentence tokenization with NLTK success"""
+    with patch('nowplaying.utils.ensure_nltk_data'), \
+         patch('nltk.sent_tokenize') as mock_tokenize:
+
+        mock_tokenize.return_value = ["First sentence.", "Second sentence!"]
+
+        text = "First sentence. Second sentence!"
+        result = nowplaying.utils.tokenize_sentences(text)
+
+        assert result == ["First sentence.", "Second sentence!"]
+        mock_tokenize.assert_called_once_with(text)
+
+
+def test_tokenize_sentences_fallback():
+    """Test sentence tokenization fallback when NLTK fails"""
+    with patch('nowplaying.utils.ensure_nltk_data'), \
+         patch('nltk.sent_tokenize') as mock_tokenize:
+
+        # Simulate NLTK failure
+        mock_tokenize.side_effect = Exception("NLTK error")
+
+        text = "First sentence. Second sentence! Third sentence?"
+        result = nowplaying.utils.tokenize_sentences(text)
+
+        # Should use fallback splitting
+        assert len(result) > 1
+        # Fallback adds periods, so check basic splitting occurred
+        assert any("First sentence" in sent for sent in result)
+        assert any("Second sentence" in sent for sent in result)
+        assert any("Third sentence" in sent for sent in result)
+
+
+def test_tokenize_sentences_empty_input():
+    """Test sentence tokenization with empty input"""
+    result = nowplaying.utils.tokenize_sentences("")
+    assert not result
+
+
+def test_tokenize_sentences_single_sentence():
+    """Test sentence tokenization with single sentence"""
+    text = "This is a single sentence"
+    result = nowplaying.utils.tokenize_sentences(text)
+
+    # Should return list with one sentence
+    assert len(result) >= 1
+    assert "single sentence" in ' '.join(result)
+
+
+def test_tokenize_sentences_fallback_no_double_periods():
+    """Test that fallback tokenization doesn't add extra periods to sentences with punctuation"""
+    with patch('nowplaying.utils.ensure_nltk_data'), \
+         patch('nltk.sent_tokenize') as mock_tokenize:
+
+        # Simulate NLTK failure
+        mock_tokenize.side_effect = Exception("NLTK error")
+
+        text = "Already ends with period. Another ends with exclamation! Third ends with question?"
+        result = nowplaying.utils.tokenize_sentences(text)
+
+        # Should not have double periods
+        for sentence in result:
+            assert not sentence.endswith('..'), f"Double period found in: {sentence}"
+            assert not sentence.endswith('!.'), \
+                f"Exclamation followed by period found in: {sentence}"
+            assert not sentence.endswith('?.'), \
+                f"Question mark followed by period found in: {sentence}"
+
+
+@pytest.mark.parametrize("max_length", [25, 50, 100, 500])
+def test_smart_split_message_various_limits(max_length):
+    """Test message splitting with various length limits"""
+    message = ("This is a test message with multiple sentences. "
+               "Each sentence should be handled based on the length limit. "
+               "The splitting should work correctly.")
+
+    result = nowplaying.utils.smart_split_message(message, max_length=max_length)
+
+    # Verify all parts respect the limit (allowing for truncated words ending in ...)
+    for part in result:
+        assert len(part) <= max_length
+
+    # Verify we got some result
+    assert len(result) >= 1
+    assert all(part.strip() for part in result)
+
+
+def test_smart_split_message_default_limit():
+    """Test message splitting uses default limit"""
+    message = "A" * 1000  # Very long message
+
+    result = nowplaying.utils.smart_split_message(message)
+
+    # Should use default limit of 500
+    for part in result:
+        assert len(part) <= 500
+
+
+def test_smart_split_message_unicode_handling():
+    """Test message splitting handles Unicode characters correctly"""
+    message = ("This message contains émojis 🎵 and spëcial characters. "
+               "Ït should be handled correctly! 中文 text as well.")
+
+    result = nowplaying.utils.smart_split_message(message, max_length=50)
+
+    # Should handle Unicode without errors
+    assert len(result) >= 1
+    for part in result:
+        assert len(part) <= 50
+
+    # Verify Unicode content is preserved
+    combined = ' '.join(result)
+    assert '🎵' in combined
+    assert 'émojis' in combined
+    assert '中文' in combined

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -181,6 +181,8 @@ async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-out
     assert req.text == ' artisthtm2 - titlehtm2'
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Windows SQLite file locking issues with multiprocess webserver")
 @pytest.mark.asyncio
 async def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-outer-name
     ''' start webserver, read existing data, add new data, then read that '''

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -78,14 +78,22 @@ def shared_webserver_config(pytestconfig):  # pylint: disable=redefined-outer-na
                 manager.stop_all_processes()
                 # Give Windows more time for process shutdown and cleanup
                 time.sleep(5)
-                # Don't vacuum on Windows - causes file locking issues in tests
-                if sys.platform != "win32":
+
+                # Explicitly close database connections on Windows
+                if sys.platform == "win32":
+                    try:
+                        metadb.close_connection()
+                    except (AttributeError, Exception):  # pylint: disable=broad-exception-caught
+                        pass  # Database might already be closed
+                    # Give Windows extra time to release file handles
+                    time.sleep(5)
+                else:
+                    # Don't vacuum on Windows - causes file locking issues in tests
                     try:
                         metadb.vacuum_database()
                     except Exception as error: # pylint: disable=broad-exception-caught
                         logging.warning("Could not vacuum database during cleanup: %s", error)
-                # Give Windows additional time to release file handles
-                time.sleep(2)
+                    time.sleep(2)
                 dbinit_mock.stop()
 
 
@@ -115,9 +123,14 @@ async def getwebserver(shared_webserver_config):  # pylint: disable=redefined-ou
 
     # Stop the webserver again for next test
     manager.stop_all_processes()
-    # Give Windows time to release resources between tests
+
+    # Explicitly close database connection on Windows to prevent file locking
     if sys.platform == "win32":
-        await asyncio.sleep(3)
+        try:
+            metadb.close_connection()
+        except (AttributeError, Exception):  # pylint: disable=broad-exception-caught
+            pass  # Database might already be closed
+        await asyncio.sleep(5)  # Increased delay for Windows
     else:
         await asyncio.sleep(1)
 

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -2,14 +2,22 @@
 ''' test webserver '''
 
 import asyncio
+import contextlib
 import logging
+import os
+import pathlib
 import socket
 import sys
+import tempfile
+import time
+import unittest.mock
 
 import pytest
 import pytest_asyncio
 import requests
 
+import nowplaying.bootstrap  # pylint: disable=import-error
+import nowplaying.config  # pylint: disable=import-error
 import nowplaying.db  # pylint: disable=import-error
 import nowplaying.subprocesses  # pylint: disable=import-error
 import nowplaying.processes.webserver  # pylint: disable=import-error
@@ -21,35 +29,103 @@ def is_port_in_use(port: int) -> bool:
         return sock.connect_ex(('localhost', port)) == 0
 
 
-@pytest_asyncio.fixture
-async def getwebserver(bootstrap):
-    ''' configure the webserver, dependents with prereqs '''
-    config = bootstrap
-    metadb = nowplaying.db.MetadataDB(initialize=True)
-    logging.debug("test_webserver databasefile = %s", metadb.databasefile)
-    config.cparser.setValue('weboutput/httpenabled', 'true')
-    config.cparser.sync()
-    port = config.cparser.value('weboutput/httpport', type=int)
-    logging.debug('checking %s for use', port)
-    while is_port_in_use(port):
-        logging.debug('%s is in use; waiting', port)
-        await asyncio.sleep(2)
+@pytest.fixture(scope="module")
+def shared_webserver_config(pytestconfig):  # pylint: disable=redefined-outer-name
+    ''' module-scoped webserver configuration for main webserver tests '''
+    with contextlib.suppress(PermissionError):  # Windows blows
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as newpath:
 
-    manager = nowplaying.subprocesses.SubprocessManager(config=config, testmode=True)
+            dbinit_patch = unittest.mock.patch('nowplaying.db.MetadataDB.init_db_var')
+            dbinit_mock = dbinit_patch.start()
+            dbdir = pathlib.Path(newpath).joinpath('mdb')
+            dbdir.mkdir()
+            dbfile = dbdir.joinpath('test.db')
+            dbinit_mock.return_value = dbfile
+
+            with unittest.mock.patch.dict(os.environ, {
+                    "WNP_CONFIG_TEST_DIR": str(newpath),
+                    "WNP_METADB_TEST_FILE": str(dbfile)
+            }):
+                bundledir = pathlib.Path(pytestconfig.rootpath).joinpath('nowplaying')
+                nowplaying.bootstrap.set_qt_names(domain='com.github.whatsnowplaying.testsuite',
+                                                  appname='testsuite')
+                config = nowplaying.config.ConfigFile(bundledir=bundledir,
+                                                      logpath=newpath,
+                                                      testmode=True)
+                config.cparser.setValue('acoustidmb/enabled', False)
+                config.cparser.setValue('weboutput/httpenabled', 'true')
+                config.cparser.sync()
+
+                metadb = nowplaying.db.MetadataDB(initialize=True) #pylint: disable=no-member
+                logging.debug("shared webserver databasefile = %s", metadb.databasefile)
+
+                port = config.cparser.value('weboutput/httpport', type=int)
+                logging.debug('checking %s for use', port)
+                while is_port_in_use(port):
+                    logging.debug('%s is in use; waiting', port)
+                    time.sleep(2)
+
+                manager = nowplaying.subprocesses.SubprocessManager(config=config, testmode=True)
+                manager.start_webserver()
+                time.sleep(5)
+
+                req = requests.get(f'http://localhost:{port}/internals', timeout=5)
+                logging.debug("internals = %s", req.json())
+
+                # Store the actual port since config gets cleared by autouse fixtures
+                yield config, metadb, manager, port
+
+                manager.stop_all_processes()
+                # Give Windows more time for process shutdown and cleanup
+                time.sleep(5)
+                # Don't vacuum on Windows - causes file locking issues in tests
+                if sys.platform != "win32":
+                    try:
+                        metadb.vacuum_database()
+                    except Exception as error: # pylint: disable=broad-exception-caught
+                        logging.warning("Could not vacuum database during cleanup: %s", error)
+                # Give Windows additional time to release file handles
+                time.sleep(2)
+                dbinit_mock.stop()
+
+
+@pytest_asyncio.fixture
+async def getwebserver(shared_webserver_config):  # pylint: disable=redefined-outer-name
+    ''' configure the webserver, dependents with prereqs '''
+    config, metadb, manager, port = shared_webserver_config  # pylint: disable=unused-variable
+
+    # Stop the shared webserver to avoid config conflicts with autouse fixture
+    manager.stop_all_processes()
+    await asyncio.sleep(1)
+
+    # Re-enable webserver settings (in case autouse clear_old_testsuite cleared them)
+    config.cparser.setValue('weboutput/httpenabled', 'true')
+    config.cparser.setValue('weboutput/httpport', port)  # Restore the actual port
+    config.cparser.setValue('acoustidmb/enabled', False)  # Ensure this is disabled for tests
+    config.cparser.sync()
+
+    # Recreate the database for clean test isolation
+    metadb.setupsql()
+
+    # Start a fresh webserver process with current config
     manager.start_webserver()
     await asyncio.sleep(5)
 
-    req = requests.get(f'http://localhost:{port}/internals', timeout=5)
-    logging.debug("internals = %s", req.json())
-
     yield config, metadb
+
+    # Stop the webserver again for next test
     manager.stop_all_processes()
+    # Give Windows time to release resources between tests
+    if sys.platform == "win32":
+        await asyncio.sleep(3)
+    else:
+        await asyncio.sleep(1)
 
 
 @pytest.mark.asyncio
 async def test_startstopwebserver(getwebserver):  # pylint: disable=redefined-outer-name
     ''' test a simple start/stop '''
-    config, metadb = getwebserver  #pylint: disable=unused-variable
+    config, metadb = getwebserver  # pylint: disable=unused-variable
     config.cparser.setValue('weboutput/httpenabled', 'true')
     config.cparser.sync()
     await asyncio.sleep(5)
@@ -59,6 +135,7 @@ async def test_startstopwebserver(getwebserver):  # pylint: disable=redefined-ou
 async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-outer-name
     ''' start webserver, read existing data, add new data, then read that '''
     config, metadb = getwebserver
+    port = config.cparser.value('weboutput/httpport', type=int)
     config.cparser.setValue('weboutput/htmltemplate',
                             config.getbundledir().joinpath('templates', 'basic-plain.txt'))
     config.cparser.setValue('weboutput/once', True)
@@ -68,7 +145,7 @@ async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-out
     logging.debug(config.cparser.value('weboutput/htmltemplate'))
     # handle no data, should return refresh
 
-    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.html', timeout=5)
     assert req.status_code == 202
     assert req.text == nowplaying.processes.webserver.INDEXREFRESH
 
@@ -76,14 +153,14 @@ async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-out
 
     await metadb.write_to_metadb(metadata={'title': 'testhtmtitle', 'artist': 'testhtmartist'})
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.html', timeout=5)
     assert req.status_code == 200
     assert req.text == ' testhtmartist - testhtmtitle'
 
     # another read should give us refresh
 
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.html', timeout=5)
     assert req.status_code == 200
     assert req.text == nowplaying.processes.webserver.INDEXREFRESH
 
@@ -93,7 +170,7 @@ async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-out
     # flipping once to false should give us back same info
 
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.html', timeout=5)
     assert req.status_code == 200
     assert req.text == ' testhtmartist - testhtmtitle'
 
@@ -104,7 +181,7 @@ async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-out
         'title': 'titlehtm2',
     })
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.html', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.html', timeout=5)
     assert req.status_code == 200
     assert req.text == ' artisthtm2 - titlehtm2'
 
@@ -113,6 +190,7 @@ async def test_webserver_htmtest(getwebserver):  # pylint: disable=redefined-out
 async def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-outer-name
     ''' start webserver, read existing data, add new data, then read that '''
     config, metadb = getwebserver
+    port = config.cparser.value('weboutput/httpport', type=int)
     config.cparser.setValue('weboutput/httpenabled', 'true')
     config.cparser.setValue('weboutput/htmltemplate',
                             config.getbundledir().joinpath('templates', 'basic-plain.txt'))
@@ -124,23 +202,23 @@ async def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-out
 
     # handle no data, should return refresh
 
-    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.txt', timeout=5)
     assert req.status_code == 200
     assert req.text == ''  # sourcery skip: simplify-empty-collection-comparison
 
     # should return empty
-    req = requests.get('http://localhost:8899/v1/last', timeout=5)
+    req = requests.get(f'http://localhost:{port}/v1/last', timeout=5)
     assert req.status_code == 200
     assert req.json() == {}
     # handle first write
 
     await metadb.write_to_metadb(metadata={'title': 'testtxttitle', 'artist': 'testtxtartist'})
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.txt', timeout=5)
     assert req.status_code == 200
     assert req.text == ' testtxtartist - testtxttitle'
 
-    req = requests.get('http://localhost:8899/v1/last', timeout=5)
+    req = requests.get(f'http://localhost:{port}/v1/last', timeout=5)
     assert req.status_code == 200
     checkdata = req.json()
     assert checkdata['artist'] == 'testtxtartist'
@@ -150,11 +228,11 @@ async def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-out
     # another read should give us same info
 
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.txt', timeout=5)
     assert req.status_code == 200
     assert req.text == ' testtxtartist - testtxttitle'
 
-    req = requests.get('http://localhost:8899/v1/last', timeout=5)
+    req = requests.get(f'http://localhost:{port}/v1/last', timeout=5)
     assert req.status_code == 200
     checkdata = req.json()
     assert checkdata['artist'] == 'testtxtartist'
@@ -168,11 +246,11 @@ async def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-out
         'title': 'titletxt2',
     })
     await asyncio.sleep(1)
-    req = requests.get('http://localhost:8899/index.txt', timeout=5)
+    req = requests.get(f'http://localhost:{port}/index.txt', timeout=5)
     assert req.status_code == 200
     assert req.text == ' artisttxt2 - titletxt2'
 
-    req = requests.get('http://localhost:8899/v1/last', timeout=5)
+    req = requests.get(f'http://localhost:{port}/v1/last', timeout=5)
     assert req.status_code == 200
     checkdata = req.json()
     assert checkdata['artist'] == 'artisttxt2'
@@ -184,55 +262,20 @@ async def test_webserver_txttest(getwebserver):  # pylint: disable=redefined-out
 def test_webserver_gifwordstest(getwebserver):  # pylint: disable=redefined-outer-name
     ''' make sure gifwords works '''
     config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value('weboutput/httpport', type=int)
     config.cparser.setValue('weboutput/once', True)
     config.cparser.sync()
 
-    req = requests.get('http://localhost:8899/gifwords.htm', timeout=5)
+    req = requests.get(f'http://localhost:{port}/gifwords.htm', timeout=5)
     assert req.status_code == 200
 
 
 def test_webserver_coverpng(getwebserver):  # pylint: disable=redefined-outer-name
     ''' make sure coverpng works '''
     config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value('weboutput/httpport', type=int)
     config.cparser.setValue('weboutput/once', True)
     config.cparser.sync()
 
-    req = requests.get('http://localhost:8899/cover.png', timeout=5)
-    assert req.status_code == 200
-
-
-def test_webserver_artistfanart_test(getwebserver):  # pylint: disable=redefined-outer-name
-    ''' make sure artistfanart works '''
-    config, metadb = getwebserver  # pylint: disable=unused-variable
-    config.cparser.setValue('weboutput/once', True)
-    config.cparser.sync()
-
-    req = requests.get('http://localhost:8899/artistfanart.htm', timeout=5)
-    assert req.status_code == 202
-
-
-def test_webserver_banner_test(getwebserver):  # pylint: disable=redefined-outer-name
-    ''' make sure banner works '''
-    config, metadb = getwebserver  # pylint: disable=unused-variable
-    config.cparser.setValue('weboutput/once', True)
-    config.cparser.sync()
-
-    req = requests.get('http://localhost:8899/artistbanner.htm', timeout=5)
-    assert req.status_code == 202
-
-    req = requests.get('http://localhost:8899/artistbanner.png', timeout=5)
-    assert req.status_code == 200
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows cannot close fast enough")
-def test_webserver_logo_test(getwebserver):  # pylint: disable=redefined-outer-name
-    ''' make sure banner works '''
-    config, metadb = getwebserver  # pylint: disable=unused-variable
-    config.cparser.setValue('weboutput/once', True)
-    config.cparser.sync()
-
-    req = requests.get('http://localhost:8899/artistlogo.htm', timeout=5)
-    assert req.status_code == 202
-
-    req = requests.get('http://localhost:8899/artistlogo.png', timeout=5)
+    req = requests.get(f'http://localhost:{port}/cover.png', timeout=5)
     assert req.status_code == 200

--- a/tests/test_webserver_artist_endpoints.py
+++ b/tests/test_webserver_artist_endpoints.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+''' test webserver artist-related endpoints '''
+
+import contextlib
+import logging
+import os
+import pathlib
+import socket
+import sys
+import tempfile
+import time
+import unittest.mock
+
+import pytest
+import requests
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+import nowplaying.config  # pylint: disable=import-error
+import nowplaying.db  # pylint: disable=import-error
+import nowplaying.subprocesses  # pylint: disable=import-error
+
+
+def is_port_in_use(port: int) -> bool:
+    ''' check if a port is in use '''
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex(('localhost', port)) == 0
+
+
+@pytest.fixture(scope="module")
+def shared_webserver_config(pytestconfig):  # pylint: disable=redefined-outer-name
+    ''' module-scoped webserver configuration for artist endpoint tests '''
+    with contextlib.suppress(PermissionError):  # Windows blows
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as newpath:
+
+            dbinit_patch = unittest.mock.patch('nowplaying.db.MetadataDB.init_db_var')
+            dbinit_mock = dbinit_patch.start()
+            dbdir = pathlib.Path(newpath).joinpath('mdb')
+            dbdir.mkdir()
+            dbfile = dbdir.joinpath('test.db')
+            dbinit_mock.return_value = dbfile
+
+            with unittest.mock.patch.dict(os.environ, {
+                    "WNP_CONFIG_TEST_DIR": str(newpath),
+                    "WNP_METADB_TEST_FILE": str(dbfile)
+            }):
+                bundledir = pathlib.Path(pytestconfig.rootpath).joinpath('nowplaying')
+                nowplaying.bootstrap.set_qt_names(domain='com.github.whatsnowplaying.testsuite',
+                                                  appname='testsuite')
+                config = nowplaying.config.ConfigFile(bundledir=bundledir,
+                                                      logpath=newpath,
+                                                      testmode=True)
+                config.cparser.setValue('acoustidmb/enabled', False)
+                config.cparser.setValue('weboutput/httpenabled', 'true')
+                config.cparser.sync()
+
+                metadb = nowplaying.db.MetadataDB(initialize=True) # pylint: disable=no-member
+                logging.debug("shared webserver databasefile = %s", metadb.databasefile)
+
+                port = config.cparser.value('weboutput/httpport', type=int)
+                logging.debug('checking %s for use', port)
+                while is_port_in_use(port):
+                    logging.debug('%s is in use; waiting', port)
+                    time.sleep(2)
+
+                manager = nowplaying.subprocesses.SubprocessManager(config=config, testmode=True)
+                manager.start_webserver()
+                time.sleep(5)
+
+                req = requests.get(f'http://localhost:{port}/internals', timeout=5)
+                logging.debug("internals = %s", req.json())
+
+                # Store the actual port since config gets cleared by autouse fixtures
+                yield config, metadb, manager, port
+
+                manager.stop_all_processes()
+                # Give Windows more time for process shutdown and cleanup
+                time.sleep(5)
+                # Don't vacuum on Windows - causes file locking issues in tests
+                if sys.platform != "win32":
+                    try:
+                        metadb.vacuum_database()
+                    except Exception as error: # pylint: disable=broad-exception-caught
+                        logging.warning("Could not vacuum database during cleanup: %s", error)
+                # Give Windows additional time to release file handles
+                time.sleep(2)
+                dbinit_mock.stop()
+
+
+@pytest.fixture
+def getwebserver(shared_webserver_config):  # pylint: disable=redefined-outer-name
+    ''' configure the webserver, dependents with prereqs '''
+    config, metadb, manager, port = shared_webserver_config  # pylint: disable=unused-variable
+
+    # Stop the shared webserver to avoid config conflicts with autouse fixture
+    manager.stop_all_processes()
+    time.sleep(1)
+
+    # Re-enable webserver settings (in case autouse clear_old_testsuite cleared them)
+    config.cparser.setValue('weboutput/httpenabled', 'true')
+    config.cparser.setValue('weboutput/httpport', port)  # Restore the actual port
+    config.cparser.setValue('acoustidmb/enabled', False)  # Ensure this is disabled for tests
+    config.cparser.setValue('weboutput/once', True)
+    config.cparser.sync()
+
+    # Recreate the database for clean test isolation
+    metadb.setupsql()
+
+    # Start a fresh webserver process with current config
+    manager.start_webserver()
+    time.sleep(5)
+
+    yield config, metadb
+
+    # Stop the webserver again for next test
+    manager.stop_all_processes()
+    # Give Windows time to release resources between tests
+    if sys.platform == "win32":
+        time.sleep(3)
+    else:
+        time.sleep(1)
+
+
+def test_webserver_artistfanart_test(getwebserver):  # pylint: disable=redefined-outer-name
+    ''' make sure artistfanart works '''
+    config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value('weboutput/httpport', type=int)
+    config.cparser.setValue('weboutput/once', True)
+    config.cparser.sync()
+
+    req = requests.get(f'http://localhost:{port}/artistfanart.htm', timeout=5)
+    assert req.status_code == 202
+
+
+def test_webserver_banner_test(getwebserver):  # pylint: disable=redefined-outer-name
+    ''' make sure banner works '''
+    config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value('weboutput/httpport', type=int)
+    config.cparser.setValue('weboutput/once', True)
+    config.cparser.sync()
+
+    req = requests.get(f'http://localhost:{port}/artistbanner.htm', timeout=5)
+    assert req.status_code == 202
+
+    req = requests.get(f'http://localhost:{port}/artistbanner.png', timeout=5)
+    assert req.status_code == 200
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows cannot close fast enough")
+def test_webserver_logo_test(getwebserver):  # pylint: disable=redefined-outer-name
+    ''' make sure banner works '''
+    config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value('weboutput/httpport', type=int)
+    config.cparser.setValue('weboutput/once', True)
+    config.cparser.sync()
+
+    req = requests.get(f'http://localhost:{port}/artistlogo.htm', timeout=5)
+    assert req.status_code == 202
+
+    req = requests.get(f'http://localhost:{port}/artistlogo.png', timeout=5)
+    assert req.status_code == 200

--- a/tests/test_webserver_oauth.py
+++ b/tests/test_webserver_oauth.py
@@ -6,7 +6,6 @@ import logging
 import os
 import pathlib
 import socket
-import sys
 import tempfile
 import time
 import unittest.mock
@@ -73,24 +72,13 @@ def shared_webserver_config(pytestconfig):  # pylint: disable=redefined-outer-na
                 yield config, metadb, manager, port
 
                 manager.stop_all_processes()
-                # Give Windows more time for process shutdown and cleanup
-                time.sleep(5)
+                time.sleep(2)
 
-                # Explicitly close database connections on Windows
-                if sys.platform == "win32":
-                    try:
-                        metadb.close_connection()
-                    except (AttributeError, Exception):  # pylint: disable=broad-exception-caught
-                        pass  # Database might already be closed
-                    # Give Windows extra time to release file handles
-                    time.sleep(5)
-                else:
-                    # Try to vacuum database, but handle file locking gracefully
-                    try:
-                        metadb.vacuum_database()
-                    except Exception as error: # pylint: disable=broad-exception-caught
-                        logging.warning("Could not vacuum database during cleanup: %s", error)
-                    time.sleep(1)
+                # Try to vacuum database, but handle file locking gracefully
+                try:
+                    metadb.vacuum_database()
+                except Exception as error: # pylint: disable=broad-exception-caught
+                    logging.warning("Could not vacuum database during cleanup: %s", error)
                 dbinit_mock.stop()
 
 

--- a/tests/test_webserver_oauth.py
+++ b/tests/test_webserver_oauth.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+''' test webserver OAuth and security functionality '''
+
+import contextlib
+import logging
+import os
+import pathlib
+import socket
+import tempfile
+import time
+import unittest.mock
+
+import pytest
+import requests
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+import nowplaying.config  # pylint: disable=import-error
+import nowplaying.db  # pylint: disable=import-error
+import nowplaying.subprocesses  # pylint: disable=import-error
+
+
+def is_port_in_use(port: int) -> bool:
+    ''' check if a port is in use '''
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex(('localhost', port)) == 0
+
+
+@pytest.fixture(scope="module")
+def shared_webserver_config(pytestconfig):  # pylint: disable=redefined-outer-name
+    ''' module-scoped webserver configuration - sync to avoid event loop issues '''
+    with contextlib.suppress(PermissionError):  # Windows blows
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as newpath:
+
+            dbinit_patch = unittest.mock.patch('nowplaying.db.MetadataDB.init_db_var')
+            dbinit_mock = dbinit_patch.start()
+            dbdir = pathlib.Path(newpath).joinpath('mdb')
+            dbdir.mkdir()
+            dbfile = dbdir.joinpath('test.db')
+            dbinit_mock.return_value = dbfile
+
+            with unittest.mock.patch.dict(os.environ, {
+                    "WNP_CONFIG_TEST_DIR": str(newpath),
+                    "WNP_METADB_TEST_FILE": str(dbfile)
+            }):
+                bundledir = pathlib.Path(pytestconfig.rootpath).joinpath('nowplaying')
+                nowplaying.bootstrap.set_qt_names(domain='com.github.whatsnowplaying.testsuite',
+                                                  appname='testsuite')
+                config = nowplaying.config.ConfigFile(bundledir=bundledir,
+                                                      logpath=newpath,
+                                                      testmode=True)
+                config.cparser.setValue('acoustidmb/enabled', False)
+                config.cparser.setValue('weboutput/httpenabled', 'true')
+                config.cparser.sync()
+
+                metadb = nowplaying.db.MetadataDB(initialize=True) # pylint: disable=no-member
+                logging.debug("shared webserver databasefile = %s", metadb.databasefile)
+
+                port = config.cparser.value('weboutput/httpport', type=int)
+                logging.debug('checking %s for use', port)
+                while is_port_in_use(port):
+                    logging.debug('%s is in use; waiting', port)
+                    time.sleep(2)
+
+                manager = nowplaying.subprocesses.SubprocessManager(config=config, testmode=True)
+                manager.start_webserver()
+                time.sleep(5)
+
+                req = requests.get(f'http://localhost:{port}/internals', timeout=5)
+                logging.debug("internals = %s", req.json())
+
+                # Store the actual port since config gets cleared by autouse fixtures
+                yield config, metadb, manager, port
+
+                manager.stop_all_processes()
+                # Give Windows more time for process shutdown and cleanup
+                time.sleep(3)
+                # Try to vacuum database, but handle Windows file locking gracefully
+                try:
+                    metadb.vacuum_database()
+                except Exception as error: # pylint: disable=broad-exception-caught
+                    logging.warning("Could not vacuum database during cleanup: %s", error)
+                # Give Windows additional time to release file handles
+                time.sleep(1)
+                dbinit_mock.stop()
+
+
+@pytest.fixture
+def reset_oauth_state(shared_webserver_config):  # pylint: disable=redefined-outer-name
+    ''' reset OAuth state before each test '''
+    config, metadb, manager, port = shared_webserver_config  # pylint: disable=unused-variable
+
+    # Re-enable webserver settings (in case autouse clear_old_testsuite cleared them)
+    config.cparser.setValue('weboutput/httpenabled', 'true')
+    config.cparser.setValue('weboutput/httpport', port)  # Restore the actual port
+    config.cparser.sync()
+
+    # Clear any kick OAuth state
+    config.cparser.remove('kick/temp_state')
+    config.cparser.remove('kick/temp_code_verifier')
+    config.cparser.remove('kick/clientid')
+    config.cparser.remove('kick/redirecturi')
+    config.cparser.sync()
+
+    yield config, metadb
+
+
+# Kick OAuth CSRF protection tests
+
+def test_kickredirect_valid_state(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test OAuth callback with valid state parameter"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Set up valid OAuth session state
+    valid_state = 'valid_state_12345678'
+    config.cparser.setValue('kick/temp_state', valid_state)
+    config.cparser.setValue('kick/temp_code_verifier', 'test_verifier')
+    config.cparser.setValue('kick/clientid', 'test_client')
+    config.cparser.setValue('kick/redirecturi', 'http://localhost:8899/kickredirect')
+    config.cparser.sync()
+
+    # Test valid state parameter - should attempt token exchange (will fail but that's expected)
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(
+        f'http://localhost:{port}/kickredirect?code=test_code&state={valid_state}', timeout=5)
+
+    # Should get HTML response (not error page)
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    # Should attempt token exchange (will fail due to invalid credentials, but CSRF check passed)
+    assert ('Token Exchange Failed' in req.text or 'Authentication Successful' in req.text)
+
+
+def test_kickredirect_invalid_state_csrf_attack(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test OAuth callback with invalid state parameter (CSRF attack simulation)"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Set up valid OAuth session state
+    valid_state = 'valid_state_12345678'
+    malicious_state = 'malicious_state_attacker'
+    config.cparser.setValue('kick/temp_state', valid_state)
+    config.cparser.setValue('kick/temp_code_verifier', 'test_verifier')
+    config.cparser.sync()
+
+    # Test invalid state parameter (CSRF attack)
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(
+        f'http://localhost:{port}/kickredirect?code=test_code&state={malicious_state}',
+        timeout=5)
+
+    # Should return security error page
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    assert 'OAuth2 State Mismatch' in req.text
+    assert 'Security Warning' in req.text
+    assert 'CSRF' in req.text
+
+
+def test_kickredirect_missing_state_parameter(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test OAuth callback with missing state parameter"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Set up valid OAuth session state
+    valid_state = 'valid_state_12345678'
+    config.cparser.setValue('kick/temp_state', valid_state)
+    config.cparser.setValue('kick/temp_code_verifier', 'test_verifier')
+    config.cparser.sync()
+
+    # Test missing state parameter
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(f'http://localhost:{port}/kickredirect?code=test_code', timeout=5)
+
+    # Should return security error page
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    assert 'OAuth2 State Mismatch' in req.text
+    assert 'Security Warning' in req.text
+
+
+def test_kickredirect_no_stored_state_expired_session(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test OAuth callback when no state is stored (expired session)"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Ensure no stored state (simulating expired session)
+    config.cparser.remove('kick/temp_state')
+    config.cparser.sync()
+
+    # Test callback with state but no stored session
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(f'http://localhost:{port}/kickredirect?code=test_code&state=some_state',
+                       timeout=5)
+
+    # Should return invalid session error
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    assert 'Invalid OAuth2 Session' in req.text
+    assert 'authentication session has expired' in req.text
+
+
+def test_kickredirect_missing_authorization_code(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test OAuth callback with missing authorization code"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Set up valid OAuth session state
+    valid_state = 'valid_state_12345678'
+    config.cparser.setValue('kick/temp_state', valid_state)
+    config.cparser.sync()
+
+    # Test missing authorization code
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(f'http://localhost:{port}/kickredirect?state={valid_state}', timeout=5)
+
+    # Should return no authorization code error
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    assert 'No Authorization Code Received' in req.text
+
+
+def test_kickredirect_oauth_error_response(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test OAuth callback with OAuth error response"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Test OAuth error response
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(
+        f'http://localhost:{port}/kickredirect?error=access_denied&'
+        'error_description=User denied access',
+        timeout=5)
+
+    # Should return OAuth error page
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    assert 'OAuth2 Authentication Failed' in req.text
+    assert 'access_denied' in req.text
+    assert 'User denied access' in req.text
+
+
+def test_kickredirect_xss_protection_in_error_parameters(reset_oauth_state):  # pylint: disable=redefined-outer-name
+    """Test that OAuth error parameters are properly escaped to prevent XSS"""
+    config, metadb = reset_oauth_state  # pylint: disable=unused-variable
+
+    # Test XSS attempt in OAuth error parameters
+    xss_payload = '<script>alert("XSS")</script>'
+    xss_description = '<img src=x onerror=alert("XSS2")>'
+
+    port = config.cparser.value('weboutput/httpport', type=int)
+    req = requests.get(f'http://localhost:{port}/kickredirect',
+                       params={
+                           'error': xss_payload,
+                           'error_description': xss_description
+                       },
+                       timeout=5)
+
+    # Should return escaped HTML (no script execution)
+    assert req.status_code == 200
+    assert 'text/html' in req.headers.get('content-type', '')
+    assert 'OAuth2 Authentication Failed' in req.text
+
+    # Verify XSS payloads are escaped
+    assert '<script>' not in req.text  # Raw script tags should be escaped
+    assert '&lt;script&gt;' in req.text  # Should be HTML-escaped
+    assert '<img' not in req.text  # Raw img tags should be escaped
+    assert '&lt;img' in req.text  # Should be HTML-escaped

--- a/tests/test_wikiclient_batch_live.py
+++ b/tests/test_wikiclient_batch_live.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Live integration test for wikiclient batch processing functionality.
+Tests against real Wikimedia APIs to verify batch optimization works.
+"""
+
+#pylint: disable=protected-access
+
+import pytest
+import nowplaying.wikiclient
+
+
+@pytest.mark.asyncio
+async def test_commons_batch_processing_live():
+    """Test batch processing with real Commons API."""
+    async with nowplaying.wikiclient.AsyncWikiClient(timeout=10) as client:
+        # Test with a known real file
+        results = await client._get_commons_image_urls_batch(['Test.jpg'])
+
+        assert len(results) == 1
+        assert results[0] is not None
+        assert results[0].startswith('https://')
+        print(f"Batch processing works: {results[0]}")
+
+
+@pytest.mark.asyncio
+async def test_single_file_uses_batch():
+    """Test that single file method uses batch internally."""
+    async with nowplaying.wikiclient.AsyncWikiClient(timeout=10) as client:
+        result = await client._get_commons_image_url('Test.jpg')
+
+        assert result is not None
+        assert result.startswith('https://')
+        print(f"Single file method works: {result}")
+
+
+@pytest.mark.asyncio
+async def test_wikidata_batch_with_real_entity():
+    """Test Wikidata batch processing with real entity."""
+    async with nowplaying.wikiclient.AsyncWikiClient(timeout=10) as client:
+        # Q11647 is "The Beatles" - known to have images
+        images = await client._get_wikidata_images('Q11647')
+
+        # Should get some images
+        if images:
+            for image in images:
+                assert 'kind' in image
+                assert 'url' in image
+                assert image['kind'] == 'wikidata-image'
+                assert image['url'].startswith('https://')
+            print(f"Wikidata batch processing works: found {len(images)} images")
+        else:
+            print("Wikidata batch processing works: no images found (that's okay)")
+
+
+@pytest.mark.asyncio
+async def test_batch_empty_cases():
+    """Test batch processing edge cases."""
+    async with nowplaying.wikiclient.AsyncWikiClient(timeout=10) as client:
+        # Empty list
+        results = await client._get_commons_image_urls_batch([])
+        assert results == []
+
+        # Non-existent file
+        results = await client._get_commons_image_urls_batch(['ThisFileDoesNotExist12345.jpg'])
+        assert len(results) == 1
+        assert results[0] is None
+
+        print("Edge cases handled correctly")

--- a/tests/twitch/test_twitch_chat.py
+++ b/tests/twitch/test_twitch_chat.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import nowplaying.twitch.chat   # pylint: disable=import-error
-from nowplaying.exceptions import PluginVerifyError # pylint: disable=import-error
+import nowplaying.twitch.chat  # pylint: disable=import-error
+from nowplaying.exceptions import PluginVerifyError  # pylint: disable=import-error
 
 
 class MockUser:  # pylint: disable=too-few-public-methods

--- a/tests/utils_artistextras.py
+++ b/tests/utils_artistextras.py
@@ -13,26 +13,17 @@ import typing as t
 import pytest
 
 # Shared pytest.mark.skipif decorators for API key requirements
-skip_no_discogs_key = pytest.mark.skipif(
-    not os.environ.get('DISCOGS_API_KEY'),
-    reason="Discogs API key not available"
-)
+skip_no_discogs_key = pytest.mark.skipif(not os.environ.get('DISCOGS_API_KEY'),
+                                         reason="Discogs API key not available")
 
-skip_no_fanarttv_key = pytest.mark.skipif(
-    not os.environ.get('FANARTTV_API_KEY'),
-    reason="FanartTV API key not available"
-)
+skip_no_fanarttv_key = pytest.mark.skipif(not os.environ.get('FANARTTV_API_KEY'),
+                                          reason="FanartTV API key not available")
 
-skip_no_theaudiodb_key = pytest.mark.skipif(
-    not os.environ.get('THEAUDIODB_API_KEY'),
-    reason="TheAudioDB API key not available"
-)
+skip_no_theaudiodb_key = pytest.mark.skipif(not os.environ.get('THEAUDIODB_API_KEY'),
+                                            reason="TheAudioDB API key not available")
 
-skip_no_acoustid_key = pytest.mark.skipif(
-    not os.environ.get('ACOUSTID_TEST_APIKEY'),
-    reason="AcoustID test API key not available"
-)
-
+skip_no_acoustid_key = pytest.mark.skipif(not os.environ.get('ACOUSTID_TEST_APIKEY'),
+                                          reason="AcoustID test API key not available")
 
 
 class FakeImageCache:  # pylint: disable=too-few-public-methods
@@ -153,16 +144,14 @@ async def run_api_call_count_test(plugin, test_metadata, mock_method_name, image
 
         # Verify one API call was made
         assert api_call_count == 1, (
-            f'Expected 1 API call after first download, got {api_call_count}'
-        )
+            f'Expected 1 API call after first download, got {api_call_count}')
 
         # Second call - should use cached result, no additional API call
         result2 = await plugin.download_async(test_metadata.copy(), imagecache=imagecache)
 
         # Verify still only one API call was made (cache hit)
         assert api_call_count == 1, (
-            f'Expected 1 API call after second download (cache hit), got {api_call_count}'
-        )
+            f'Expected 1 API call after second download (cache hit), got {api_call_count}')
 
         # Both results should be consistent
         assert (result1 is None) == (result2 is None)
@@ -225,8 +214,7 @@ async def run_failure_cache_test(plugin, test_metadata, mock_method_name, imagec
 
         # Verify one API call was made and result is None (failure)
         assert api_call_count == 1, (
-            f'Expected 1 API call after first download, got {api_call_count}'
-        )
+            f'Expected 1 API call after first download, got {api_call_count}')
         assert result1 is None, 'Expected None result from failed API call'
 
         # Second call - should retry API (not use cached failure), API succeeds this time
@@ -242,8 +230,7 @@ async def run_failure_cache_test(plugin, test_metadata, mock_method_name, imagec
 
         # Verify still only two API calls (success result was cached)
         assert api_call_count == 2, (
-            f'Expected 2 API calls after third download (success cached), got {api_call_count}'
-        )
+            f'Expected 2 API calls after third download (success cached), got {api_call_count}')
 
         # Results should show the pattern: None (failure), data (success), data (cached success)
         assert result1 is None, 'First result should be None (API failure)'

--- a/updateshas.py
+++ b/updateshas.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 ''' build a new upgradetable.py '''
 
+import argparse
 import hashlib
 import json
+import logging
 import os
 import pathlib
-import sys
 import subprocess
+import sys
 
 
 def checksum(filename):
@@ -20,31 +22,93 @@ def checksum(filename):
 
 def main():
     ''' build a new file '''
+    parser = argparse.ArgumentParser(description='Build template hash file for upgrade detection')
+    parser.add_argument('shafile', help='Path to the updateshas.json file')
+    parser.add_argument('versions', nargs='+', help='Git versions to process')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose output')
 
-    shafile = sys.argv[1]
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+    if not pathlib.Path(args.shafile).parent.exists():
+        logging.error('Directory for shafile does not exist: %s', pathlib.Path(args.shafile).parent)
+        sys.exit(1)
+
+    # Load existing hashes
     oldshas = {}
+    if os.path.exists(args.shafile):
+        try:
+            with open(args.shafile, encoding='utf-8') as fhin:
+                oldshas = json.loads(fhin.read())
+            logging.info('Loaded existing hashes from %s', args.shafile)
+        except (json.JSONDecodeError, OSError) as error:
+            logging.error('Failed to load existing hash file: %s', error)
+            sys.exit(1)
 
-    if os.path.exists(shafile):
-        with open(shafile, encoding='utf-8') as fhin:
-            oldshas = json.loads(fhin.read())
+    # Process each version
+    for version in args.versions:
+        logging.info('Processing version: %s', version)
+        try:
+            # Use safer git checkout without --force
+            subprocess.check_call(['git', 'checkout', version],
+                                  stdout=subprocess.DEVNULL if not args.verbose else None,
+                                  stderr=subprocess.STDOUT if not args.verbose else None)
+        except subprocess.CalledProcessError as error:
+            logging.error('Failed to checkout version %s: %s', version, error)
+            continue
 
-    for version in sys.argv[2:]:
-        subprocess.check_call(['git', 'checkout', '--force', version])
-        for apppath in pathlib.Path(os.path.join('nowplaying', 'templates')).iterdir():
-            filename = os.path.basename(apppath)
-            if filename not in oldshas:
-                oldshas[filename] = {}
+        templates_dir = pathlib.Path('nowplaying', 'templates')
+        if not templates_dir.exists():
+            logging.warning('Templates directory not found for version %s', version)
+            continue
+
+        try:
+            _process_template_directory(templates_dir, templates_dir, oldshas, version)
+        except OSError as error:
+            logging.error('Failed to process templates for version %s: %s', version, error)
+            continue
+
+    # Write updated hashes
+    try:
+        with open(args.shafile, 'w', encoding='utf-8') as fhout:
+            fhout.write(json.dumps(oldshas, indent=2, sort_keys=True))
+        logging.info('Updated hash file written to %s', args.shafile)
+    except OSError as error:
+        logging.error('Failed to write hash file: %s', error)
+        sys.exit(1)
+
+
+def _process_template_directory(base_dir, current_dir, oldshas, version):
+    ''' recursively process template directories '''
+
+    for apppath in current_dir.iterdir():
+        if apppath.is_dir():
+            # Recursively process subdirectories
+            _process_template_directory(base_dir, apppath, oldshas, version)
+            continue
+
+        # Use relative path from base templates directory
+        relative_path = str(apppath.relative_to(base_dir))
+
+        if relative_path not in oldshas:
+            oldshas[relative_path] = {}
+
+        try:
             hexd = checksum(apppath)
-            try:
-                for vers, sha in oldshas[filename].items():  # pylint: disable=unused-variable
-                    if sha == hexd:
-                        raise ValueError
-            except ValueError:
-                continue
+        except OSError as error:
+            logging.warning('Failed to read %s: %s', relative_path, error)
+            continue
 
-            oldshas[filename][version] = hexd
-    with open(shafile, 'w', encoding='utf-8') as fhout:
-        fhout.write(json.dumps(oldshas, indent=2))
+        # Check if this hash already exists for any version
+        hash_exists = any(sha == hexd for sha in oldshas[relative_path].values())
+        if hash_exists:
+            logging.debug('Hash for %s already exists, skipping', relative_path)
+            continue
+
+        oldshas[relative_path][version] = hexd
+        logging.debug('Added hash for %s version %s', relative_path, version)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add Kick streaming platform support and wikiclient batch processing

- Complete Kick.com integration with OAuth2 PKCE authentication
- Kick chat bot with customizable commands and templates
- Kick posting support with message handling
- Browser-based OAuth2 flow with CSRF protection
- New kick settings UI with authentication status

- Wikiclient batch processing optimization for Wikidata Commons images
- Batch Commons API calls reduce N requests to 1 for multiple P18 images
- Preserve UI icon fix while adding performance optimization

- Fixed pylint naming issues in webserver tests
- Cross-platform Unicode fixes in test output

## Summary by Sourcery

Add full Kick streaming platform support, optimize wikiclient batch image processing, refactor process and chat utilities, update lint configurations, and expand coverage with new and enhanced tests.

New Features:
- Add Kick.com integration with OAuth2 PKCE flow, CSRF-protected redirect handler, and web settings UI
- Introduce Kick chat bot with customizable commands, Jinja2 templates, and smart message splitting
- Enable Kick posting support via official API with multi-part message handling
- Implement wikiclient batch Commons image processing to consolidate multiple P18 calls into one API request

Bug Fixes:
- Fix broad-exception pylint annotations and cross-platform Unicode issues in tests

Enhancements:
- Consolidate NLTK data initialization and smart message splitting shared between Kick and Twitch
- Refactor SubprocessManager to unified start/stop/restart methods and include Kick bot
- Upgrade template handling to process nested directories and preserve existing upgrades
- Add default Kick settings and integrate into settings UI alongside Twitch

Documentation:
- Update CHANGELOG with Kick integration and enhanced Twitch chat splitting

Tests:
- Add comprehensive unit and integration tests for Kick OAuth2, chat messaging, settings, launch, and utils
- Expand tests for smart message splitting, wikiclient batch processing, and webserver OAuth endpoints

Chores:
- Configure ruff/pyproject.toml linting rules and init-hook
- Adjust formatting and lint compliance across multiple modules