### PR TITLE
refactor kick a bit: consolidate token refresh and fix failing tests

### DIFF
--- a/docs/output/kickbot.rst
+++ b/docs/output/kickbot.rst
@@ -19,12 +19,13 @@ Authentication
 
 To use Kick.com integration, you'll need to set up OAuth2 authentication with your Kick account.
 
-#. Go to the Kick Developer Portal to register **What's Now Playing** as an application.
-#. Create a new OAuth2 application and note down:
+#. Go to your Kick streamer settings and navigate to the **Developer** tab to create an application.
+#. Create a new OAuth2 application with these important settings:
 
-   * Client ID
-   * Client Secret
-   * Redirect URI (typically ``http://localhost:8899/kickredirect``)
+   * **Application Type**: Set to **Bot** (required for chat functionality)
+   * **Application Name**: This will be the name displayed in chat when the bot sends messages
+   * Note down your Client ID and Client Secret
+   * Set Redirect URI to ``http://localhost:8899/kickredirect`` (port must match your webserver settings, default is 8899)
 
 #. Scopes Requested should include the following for current and future features:
 

--- a/nowplaying/kick/oauth2.py
+++ b/nowplaying/kick/oauth2.py
@@ -260,7 +260,7 @@ class KickOAuth2:  # pylint: disable=too-many-instance-attributes
                     logging.error('Failed to revoke token: %s - %s', response.status, error_text)
 
     async def validate_token(self, token: str | None = None) -> dict[str, Any] | None:
-        ''' Validate an access token (async version for non-UI components) 
+        ''' Validate an access token (async version for non-UI components)
         Note: utils.py provides sync wrapper for Qt UI components '''
         if not token:
             token = self.access_token or self.config.cparser.value('kick/accesstoken')

--- a/nowplaying/kick/oauth2.py
+++ b/nowplaying/kick/oauth2.py
@@ -260,7 +260,8 @@ class KickOAuth2:  # pylint: disable=too-many-instance-attributes
                     logging.error('Failed to revoke token: %s - %s', response.status, error_text)
 
     async def validate_token(self, token: str | None = None) -> dict[str, Any] | None:
-        ''' Validate an access token '''
+        ''' Validate an access token (async version for non-UI components) 
+        Note: utils.py provides sync wrapper for Qt UI components '''
         if not token:
             token = self.access_token or self.config.cparser.value('kick/accesstoken')
 
@@ -268,18 +269,29 @@ class KickOAuth2:  # pylint: disable=too-many-instance-attributes
             logging.warning("No token to validate")
             return None
 
-        headers = {'Authorization': f'Bearer {token}', 'Accept': 'application/json'}
+        # Use Kick's token introspect endpoint (same as sync version)
+        url = 'https://api.kick.com/public/v1/token/introspect'
+        headers = {'Authorization': f'Bearer {token}'}
 
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"{self.OAUTH_HOST}/oauth/validate",
-                                   headers=headers,
+            async with session.post(url, headers=headers,
                                    timeout=aiohttp.ClientTimeout(total=10)) as response:
                 if response.status == 200:
                     validation_response = await response.json()
-                    logging.debug('Token validation successful')
-                    return validation_response
+                    data = validation_response.get('data', {})
 
-                logging.debug('Token validation failed: %s', response.status)
+                    # Check if token is active
+                    if data.get('active'):
+                        logging.debug('Token validation successful')
+                        return validation_response
+
+                    logging.debug('Token is inactive')
+                    return None
+
+                if response.status == 401:
+                    logging.debug('Token validation failed: invalid/expired')
+                else:
+                    logging.debug('Token validation failed: %s', response.status)
                 return None
 
     def get_stored_tokens(self) -> tuple[str | None, str | None]:

--- a/nowplaying/kick/settings.py
+++ b/nowplaying/kick/settings.py
@@ -178,14 +178,12 @@ class KickSettings:
             if nowplaying.kick.utils.qtsafe_validate_kick_token(access_token):
                 self.widget.oauth_status_label.setText('Authenticated')
                 self.widget.authenticate_button.setText('Re-authenticate')
+            elif refresh_token:
+                self.widget.oauth_status_label.setText('Refreshing expired token...')
             else:
-                # Check if we can refresh automatically
-                if refresh_token:
-                    self.widget.oauth_status_label.setText('Refreshing expired token...')
-                else:
-                    self.widget.oauth_status_label.setText(
-                        'Token expired - re-authentication needed')
-                    self.widget.authenticate_button.setText('Authenticate')
+                self.widget.oauth_status_label.setText(
+                    'Token expired - re-authentication needed')
+                self.widget.authenticate_button.setText('Authenticate')
         else:
             self.widget.oauth_status_label.setText('Not authenticated')
 

--- a/nowplaying/kick/utils.py
+++ b/nowplaying/kick/utils.py
@@ -58,7 +58,7 @@ async def validate_kick_token_async(config: nowplaying.config.ConfigFile,
     return await oauth.validate_token(access_token)
 
 
-def qtsafe_validate_kick_token(access_token: str) -> bool:
+def qtsafe_validate_kick_token(access_token: str) -> bool:  # pylint: disable=too-many-return-statements
     ''' Validate kick token synchronously (Qt-safe for UI components) '''
     if not access_token:
         return False
@@ -69,8 +69,11 @@ def qtsafe_validate_kick_token(access_token: str) -> bool:
 
     try:
         req = requests.post(url, headers=headers, timeout=10)
+    except (requests.ConnectionError, requests.Timeout) as error:
+        logging.warning('Kick token validation network error (token status unknown): %s', error)
+        return False
     except Exception as error:  # pylint: disable=broad-except
-        logging.error('Kick token validation check failed: %s', error)
+        logging.error('Kick token validation unexpected error: %s', error)
         return False
 
     if req.status_code != 200:

--- a/nowplaying/kick/utils.py
+++ b/nowplaying/kick/utils.py
@@ -2,16 +2,68 @@
 ''' kick utils '''
 
 import logging
+from typing import Any
 
 import requests
 
+import nowplaying.config
+import nowplaying.kick.oauth2
+
+
+async def attempt_token_refresh(config: nowplaying.config.ConfigFile) -> bool:
+    ''' Try to refresh existing tokens '''
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+
+    try:
+        # Check if we have stored tokens
+        access_token, refresh_token = oauth.get_stored_tokens()
+        logging.debug('Retrieved stored tokens: access_token=%s, refresh_token=%s',
+                     'present' if access_token else 'missing',
+                     'present' if refresh_token else 'missing')
+
+        if access_token:
+            # Validate current token
+            logging.debug('Validating stored access token')
+            validation = await oauth.validate_token(access_token)
+            if validation:
+                oauth.access_token = access_token
+                oauth.refresh_token = refresh_token
+                logging.debug('Existing Kick token is valid')
+                return True
+            logging.debug('Stored access token is invalid')
+
+        if refresh_token:
+            # Try to refresh the token
+            logging.debug('Attempting to refresh token using refresh_token')
+            await oauth.refresh_access_token(refresh_token)
+            logging.info('Successfully refreshed Kick OAuth2 tokens')
+            return True
+        logging.debug('No refresh_token available')
+
+    except Exception as error:  # pylint: disable=broad-except
+        logging.error('Token refresh failed: %s', error)
+
+    return False
+
+
+# Token Validation - Dual Implementation for Different Use Cases:
+# 1. async version for chat/launch components (non-blocking)
+# 2. sync version for UI components (Qt-safe, immediate feedback)
+# Both use the same Kick introspect endpoint for consistency
+
+async def validate_kick_token_async(config: nowplaying.config.ConfigFile,
+                                   access_token: str | None = None) -> dict[str, Any] | None:
+    ''' Async wrapper for token validation (for non-UI components) '''
+    oauth = nowplaying.kick.oauth2.KickOAuth2(config)
+    return await oauth.validate_token(access_token)
+
 
 def qtsafe_validate_kick_token(access_token: str) -> bool:
-    ''' validate kick token synchronously (shared by settings and launch) '''
+    ''' Validate kick token synchronously (Qt-safe for UI components) '''
     if not access_token:
         return False
 
-    # Use Kick's token introspect endpoint to validate the token
+    # Use Kick's token introspect endpoint
     url = 'https://api.kick.com/public/v1/token/introspect'
     headers = {'Authorization': f'Bearer {access_token}'}
 

--- a/nowplaying/resources/kick_ui.ui
+++ b/nowplaying/resources/kick_ui.ui
@@ -109,10 +109,7 @@
      </widget>
     </item>
     <item row="3" column="1">
-     <widget class="QLineEdit" name="redirecturi_lineedit">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
+     <widget class="QLabel" name="redirecturi_label">
       <property name="minimumSize">
        <size>
         <width>496</width>
@@ -187,7 +184,7 @@ li.unchecked::marker { content: &quot;\2610&quot;; }
 li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Kick.com Integration Setup:&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;1. Create a Kick application at &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;https://id.kick.com/developers&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;1. Create a Kick application in your &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Developer tab&lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt; in streamer settings&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;2. Copy the &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Client ID&lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt; and &lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont'; font-weight:700;&quot;&gt;Client Secret&lt;/span&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt; from your application&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;3. Set the redirect URI in your Kick application to match the one shown above&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.AppleSystemUIFont';&quot;&gt;4. Enter your channel name (username where you want to monitor/send messages)&lt;/span&gt;&lt;/p&gt;

--- a/tests/kick/test_kick_oauth2.py
+++ b/tests/kick/test_kick_oauth2.py
@@ -247,11 +247,15 @@ async def test_refresh_access_token_scenarios(
     "response_status,response_data,expected_result",
     [
         (200, {
-            'valid': True,
-            'client_id': 'test_client'
+            'data': {
+                'active': True,
+                'client_id': 'test_client'
+            }
         }, {
-            'valid': True,
-            'client_id': 'test_client'
+            'data': {
+                'active': True,
+                'client_id': 'test_client'
+            }
         }),
         (401, {}, None),  # Unauthorized
         (500, {}, None),  # Server error
@@ -266,12 +270,14 @@ async def test_validate_token_scenarios(
     """Test token validation with various responses."""
     oauth = configured_oauth
 
+    # Use the correct introspect endpoint and POST method
+    introspect_url = 'https://api.kick.com/public/v1/token/introspect'
     if response_status == 200:
-        mock_responses.get(f"{oauth.OAUTH_HOST}/oauth/validate",
+        mock_responses.post(introspect_url,
                            status=response_status,
                            payload=response_data)
     else:
-        mock_responses.get(f"{oauth.OAUTH_HOST}/oauth/validate",
+        mock_responses.post(introspect_url,
                            status=response_status,
                            body='Error')
 

--- a/tests/kick/test_kick_settings.py
+++ b/tests/kick/test_kick_settings.py
@@ -106,6 +106,28 @@ def test_kick_settings_load_default_redirect_uri(bootstrap, mock_kick_widget):
 
 
 @pytest.mark.parametrize(
+    "webserver_port,expected_redirect_uri",
+    [
+        ('8080', 'http://localhost:8080/kickredirect'),
+        ('3000', 'http://localhost:3000/kickredirect'),
+        ('9999', 'http://localhost:9999/kickredirect'),
+        ('80', 'http://localhost:80/kickredirect'),
+        (None, 'http://localhost:8899/kickredirect'),  # None defaults to 8899
+    ])
+def test_kick_settings_load_non_default_webserver_ports(bootstrap, mock_kick_widget,
+                                                        webserver_port, expected_redirect_uri):
+    """Test settings loading with non-default webserver ports to verify redirect URI logic."""
+    config = bootstrap
+    if webserver_port is not None:
+        config.cparser.setValue('weboutput/httpport', webserver_port)
+
+    settings = nowplaying.kick.settings.KickSettings()
+    settings.load(config, mock_kick_widget)
+
+    mock_kick_widget.redirecturi_label.setText.assert_called_with(expected_redirect_uri)
+
+
+@pytest.mark.parametrize(
     "has_changes,should_restart",
     [
         (False, False),  # No changes - no restart


### PR DESCRIPTION
* Consolidate duplicated token refresh logic from chat.py/launch.py into utils.py
* Add attempt_token_refresh() function to replace individual OAuth method calls
* Change redirect URI from user-editable lineedit to auto-generated label
* Update OAuth2 to use correct /public/v1/token/introspect endpoint (POST)
* Fix broken help URL reference to use "Developer tab in streamer settings"
* Add real-time OAuth status updates with 30s QTimer
* Update tests to mock consolidated function instead of individual OAuth methods
* Fix test expectations for redirecturi_label and port 8899 default
* Remove 6 obsolete tests that were testing implementation details
* Simplify authentication test scenarios from complex flows to success/failure

## Summary by Sourcery

Centralize OAuth token handling by consolidating refresh and validation logic into a single utility function, auto-generate the redirect URI, add live status polling, update chat and launch flows to use the new function, and adjust tests and UI accordingly.

New Features:
- Add attempt_token_refresh() in utils to unify token validation and refresh across components
- Auto-generate and display redirect URI based on webserver port instead of user input
- Introduce a QTimer to provide real-time OAuth status updates every 30 seconds
- Include application version and platform info in the chat connection message

Bug Fixes:
- Fix failing tests by updating expectations for redirect URI label and default port
- Correct help URL reference text to "Developer tab in streamer settings"

Enhancements:
- Refactor chat and launch authentication to use the consolidated token refresh utility
- Update OAuth2 validation to use POST against /public/v1/token/introspect endpoint
- Remove manual redirect URI handling and persistence in settings

Tests:
- Remove obsolete tests targeting internal OAuth methods and simplify scenarios to success/failure
- Update tests to mock attempt_token_refresh() instead of individual validation and refresh calls
- Parameterize authentication tests to cover both refresh success and failure