### PR TITLE
change the UI to be a heirarchy. still need to update the docs gfx

### DIFF
--- a/nowplaying/resources/artistextras_discogs_ui.ui
+++ b/nowplaying/resources/artistextras_discogs_ui.ui
@@ -20,7 +20,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>90</y>
+     <y>40</y>
      <width>311</width>
      <height>16</height>
     </rect>
@@ -36,9 +36,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>120</y>
+     <y>60</y>
      <width>611</width>
-     <height>51</height>
+     <height>30</height>
     </rect>
    </property>
    <layout class="QFormLayout" name="discogs_auth_layout">
@@ -80,9 +80,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>40</y>
+     <y>10</y>
      <width>361</width>
-     <height>23</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -92,10 +92,10 @@
   <widget class="QLabel" name="discogs_desclabel">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>360</y>
-     <width>591</width>
-     <height>101</height>
+     <x>10</x>
+     <y>190</y>
+     <width>611</width>
+     <height>80</height>
     </rect>
    </property>
    <property name="text">
@@ -108,10 +108,10 @@
   <widget class="QWidget" name="horizontalLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>240</y>
-     <width>541</width>
-     <height>80</height>
+     <x>10</x>
+     <y>130</y>
+     <width>611</width>
+     <height>50</height>
     </rect>
    </property>
    <layout class="QHBoxLayout" name="checkbox_layout">
@@ -153,10 +153,10 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>200</y>
+     <x>10</x>
+     <y>100</y>
      <width>88</width>
-     <height>24</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">

--- a/nowplaying/resources/artistextras_ui.ui
+++ b/nowplaying/resources/artistextras_ui.ui
@@ -19,10 +19,10 @@
   <widget class="QCheckBox" name="artistextras_checkbox">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>30</y>
+     <x>10</x>
+     <y>10</y>
      <width>82</width>
-     <height>24</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -32,17 +32,17 @@
   <widget class="QWidget" name="formLayoutWidget_2">
    <property name="geometry">
     <rect>
-     <x>30</x>
-     <y>130</y>
-     <width>591</width>
-     <height>231</height>
+     <x>10</x>
+     <y>150</y>
+     <width>611</width>
+     <height>180</height>
     </rect>
    </property>
    <layout class="QFormLayout" name="artistextras_layout">
     <item row="0" column="0">
-     <widget class="QLabel" name="banenrs_label">
+     <widget class="QLabel" name="banners_label">
       <property name="text">
-       <string>Maximum artist banners </string>
+       <string>Maximum artist banners</string>
       </property>
      </widget>
     </item>
@@ -160,10 +160,10 @@
   <widget class="QLabel" name="artistextras_desc_label">
    <property name="geometry">
     <rect>
-     <x>50</x>
-     <y>50</y>
-     <width>511</width>
-     <height>81</height>
+     <x>10</x>
+     <y>40</y>
+     <width>611</width>
+     <height>100</height>
     </rect>
    </property>
    <property name="text">
@@ -176,8 +176,8 @@
   <widget class="QCheckBox" name="missingfanart_checkbox">
    <property name="geometry">
     <rect>
-     <x>260</x>
-     <y>390</y>
+     <x>220</x>
+     <y>348</y>
      <width>71</width>
      <height>24</height>
     </rect>
@@ -192,8 +192,8 @@
   <widget class="QCheckBox" name="missinglogos_checkbox">
    <property name="geometry">
     <rect>
-     <x>360</x>
-     <y>390</y>
+     <x>300</x>
+     <y>348</y>
      <width>71</width>
      <height>24</height>
     </rect>
@@ -208,8 +208,8 @@
   <widget class="QLabel" name="missingcoverart_label">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>390</y>
+     <x>10</x>
+     <y>350</y>
      <width>201</width>
      <height>18</height>
     </rect>
@@ -221,8 +221,8 @@
   <widget class="QCheckBox" name="missingthumbs_checkbox">
    <property name="geometry">
     <rect>
-     <x>450</x>
-     <y>390</y>
+     <x>380</x>
+     <y>348</y>
      <width>101</width>
      <height>24</height>
     </rect>
@@ -237,10 +237,10 @@
   <widget class="QPushButton" name="clearcache_button">
    <property name="geometry">
     <rect>
-     <x>330</x>
-     <y>30</y>
+     <x>520</x>
+     <y>10</y>
      <width>101</width>
-     <height>26</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -250,8 +250,8 @@
   <widget class="QLabel" name="label">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>420</y>
+     <x>10</x>
+     <y>380</y>
      <width>191</width>
      <height>18</height>
     </rect>
@@ -264,7 +264,7 @@
    <property name="geometry">
     <rect>
      <x>210</x>
-     <y>420</y>
+     <y>378</y>
      <width>181</width>
      <height>26</height>
     </rect>

--- a/nowplaying/resources/artistextras_wikimedia_ui.ui
+++ b/nowplaying/resources/artistextras_wikimedia_ui.ui
@@ -17,9 +17,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>40</y>
+     <y>10</y>
      <width>361</width>
-     <height>23</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -32,10 +32,10 @@
   <widget class="QLabel" name="wikimedia_desclabel">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>240</y>
-     <width>591</width>
-     <height>101</height>
+     <x>10</x>
+     <y>135</y>
+     <width>611</width>
+     <height>80</height>
     </rect>
    </property>
    <property name="text">
@@ -48,10 +48,10 @@
   <widget class="QWidget" name="horizontalLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>120</y>
-     <width>541</width>
-     <height>80</height>
+     <x>10</x>
+     <y>40</y>
+     <width>611</width>
+     <height>30</height>
     </rect>
    </property>
    <layout class="QHBoxLayout" name="checkbox_layout">
@@ -84,72 +84,98 @@
     </item>
    </layout>
   </widget>
-  <widget class="QLabel" name="bio_iso_label">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
+  <widget class="QLabel" name="bio_settings_label">
    <property name="geometry">
     <rect>
-     <x>150</x>
-     <y>80</y>
-     <width>121</width>
-     <height>26</height>
+     <x>10</x>
+     <y>75</y>
+     <width>150</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
-    <string>Language ISO Code</string>
+    <string>Biography Settings</string>
    </property>
   </widget>
-  <widget class="QCheckBox" name="bio_iso_en_checkbox">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
+  <widget class="QGroupBox" name="bio_groupbox">
    <property name="geometry">
     <rect>
-     <x>440</x>
-     <y>80</y>
-     <width>111</width>
-     <height>24</height>
+     <x>10</x>
+     <y>95</y>
+     <width>611</width>
+     <height>30</height>
     </rect>
    </property>
-   <property name="text">
-    <string>Fallback to EN</string>
+   <property name="title">
+    <string></string>
    </property>
-   <property name="checked">
-    <bool>false</bool>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="bio_checkbox">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>40</x>
-     <y>80</y>
-     <width>88</width>
-     <height>24</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Biography</string>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-  </widget>
-  <widget class="QLineEdit" name="bio_iso_lineedit">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>280</x>
-     <y>80</y>
-     <width>121</width>
-     <height>26</height>
-    </rect>
-   </property>
+   <widget class="QCheckBox" name="bio_checkbox">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>8</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Biography</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="bio_iso_label">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>125</x>
+      <y>8</y>
+      <width>121</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Language ISO Code</string>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="bio_iso_lineedit">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>255</x>
+      <y>8</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="bio_iso_en_checkbox">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>370</x>
+      <y>8</y>
+      <width>111</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Fallback to EN</string>
+    </property>
+    <property name="checked">
+     <bool>false</bool>
+    </property>
+   </widget>
   </widget>
  </widget>
  <resources/>
@@ -231,6 +257,22 @@
     <hint type="destinationlabel">
      <x>340</x>
      <y>92</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bio_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>bio_iso_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>83</x>
+     <y>91</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>180</x>
+     <y>91</y>
     </hint>
    </hints>
   </connection>

--- a/nowplaying/resources/destroy_ui.ui
+++ b/nowplaying/resources/destroy_ui.ui
@@ -17,13 +17,29 @@
    <iconset resource="settings.qrc">
     <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
+  <widget class="QLabel" name="header_label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>251</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>**Destroy Configuration**</string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::MarkdownText</enum>
+   </property>
+  </widget>
   <widget class="QPushButton" name="startover_button">
    <property name="geometry">
     <rect>
-     <x>50</x>
-     <y>70</y>
+     <x>10</x>
+     <y>50</y>
      <width>131</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -33,8 +49,8 @@
   <widget class="QCheckBox" name="areyousure_checkbox">
    <property name="geometry">
     <rect>
-     <x>220</x>
-     <y>70</y>
+     <x>150</x>
+     <y>53</y>
      <width>251</width>
      <height>20</height>
     </rect>
@@ -46,10 +62,10 @@
   <widget class="QTextBrowser" name="description">
    <property name="geometry">
     <rect>
-     <x>30</x>
-     <y>130</y>
-     <width>571</width>
-     <height>231</height>
+     <x>10</x>
+     <y>90</y>
+     <width>611</width>
+     <height>200</height>
     </rect>
    </property>
    <property name="html">

--- a/nowplaying/resources/discordbot_ui.ui
+++ b/nowplaying/resources/discordbot_ui.ui
@@ -139,8 +139,18 @@ p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
 li.unchecked::marker { content: &quot;\2610&quot;; }
 li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'.AppleSystemUIFont'; font-size:13pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:8px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Discord Integration Setup:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:4px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Client Mode&lt;/span&gt; - Updates your Discord user status with currently playing song:&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Go to &lt;a href=&quot;https://discord.com/developers/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Discord Developers&lt;/span&gt;&lt;/a&gt; and create an application&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Copy the Application ID to the &lt;span style=&quot; font-weight:600;&quot;&gt;Client ID&lt;/span&gt; field above&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:8px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Restart What's Now Playing (Discord app must be running)&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:4px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bot Mode&lt;/span&gt; - Bot posts track updates to Discord channels:&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• In your Discord application, go to &quot;Bot&quot; section and create a bot&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Copy the bot &lt;span style=&quot; font-weight:600;&quot;&gt;Token&lt;/span&gt; to the Token field above&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Invite your bot to your Discord server&lt;/p&gt;
+&lt;p style=&quot;margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• Restart What's Now Playing&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </widget>
  </widget>

--- a/nowplaying/resources/general_ui.ui
+++ b/nowplaying/resources/general_ui.ui
@@ -46,7 +46,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>70</y>
+     <y>60</y>
      <width>361</width>
      <height>16</height>
     </rect>
@@ -62,7 +62,7 @@
    <property name="geometry">
     <rect>
      <x>380</x>
-     <y>100</y>
+     <y>87</y>
      <width>113</width>
      <height>21</height>
     </rect>
@@ -75,9 +75,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>90</y>
+     <y>80</y>
      <width>351</width>
-     <height>41</height>
+     <height>32</height>
     </rect>
    </property>
    <property name="text">
@@ -91,9 +91,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>230</y>
+     <y>180</y>
      <width>141</width>
-     <height>20</height>
+     <height>17</height>
     </rect>
    </property>
    <property name="text">
@@ -107,9 +107,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>270</y>
+     <y>200</y>
      <width>59</width>
-     <height>16</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -120,9 +120,9 @@
    <property name="geometry">
     <rect>
      <x>130</x>
-     <y>260</y>
+     <y>200</y>
      <width>91</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <item>
@@ -155,7 +155,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>160</y>
+     <y>120</y>
      <width>201</width>
      <height>17</height>
     </rect>
@@ -171,9 +171,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>190</y>
+     <y>140</y>
      <width>91</width>
-     <height>23</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -184,9 +184,9 @@
    <property name="geometry">
     <rect>
      <x>130</x>
-     <y>190</y>
+     <y>140</y>
      <width>71</width>
-     <height>23</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -197,9 +197,9 @@
    <property name="geometry">
     <rect>
      <x>250</x>
-     <y>190</y>
+     <y>140</y>
      <width>171</width>
-     <height>24</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -210,7 +210,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>320</y>
+     <y>240</y>
      <width>201</width>
      <height>17</height>
     </rect>
@@ -226,9 +226,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>350</y>
+     <y>260</y>
      <width>150</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -242,9 +242,9 @@
    <property name="geometry">
     <rect>
      <x>170</x>
-     <y>350</y>
+     <y>260</y>
      <width>150</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -258,9 +258,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>390</y>
+     <y>295</y>
      <width>610</width>
-     <height>32</height>
+     <height>40</height>
     </rect>
    </property>
    <property name="text">

--- a/nowplaying/resources/kickchat_ui.ui
+++ b/nowplaying/resources/kickchat_ui.ui
@@ -150,7 +150,7 @@
      <x>10</x>
      <y>170</y>
      <width>611</width>
-     <height>261</height>
+     <height>230</height>
     </rect>
    </property>
    <property name="alternatingRowColors">
@@ -199,7 +199,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>440</y>
+     <y>410</y>
      <width>621</width>
      <height>32</height>
     </rect>

--- a/nowplaying/resources/obsws_ui.ui
+++ b/nowplaying/resources/obsws_ui.ui
@@ -22,8 +22,8 @@
   <widget class="QLabel" name="header_label">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>20</y>
+     <x>10</x>
+     <y>10</y>
      <width>281</width>
      <height>16</height>
     </rect>
@@ -38,8 +38,8 @@
   <widget class="QCheckBox" name="enable_checkbox">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>60</y>
+     <x>10</x>
+     <y>30</y>
      <width>86</width>
      <height>20</height>
     </rect>
@@ -51,10 +51,10 @@
   <widget class="QTextBrowser" name="desc_textbrowser">
    <property name="geometry">
     <rect>
-     <x>180</x>
-     <y>50</y>
-     <width>441</width>
-     <height>81</height>
+     <x>10</x>
+     <y>260</y>
+     <width>611</width>
+     <height>80</height>
     </rect>
    </property>
    <property name="html">
@@ -64,16 +64,18 @@ p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
 li.unchecked::marker { content: &quot;\2610&quot;; }
 li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.SF NS Text'; font-size:13pt;&quot;&gt;Enables support OBS Websocket v5 for OBS Studio and compatible software.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:4px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Most OBS users prefer the &lt;span style=&quot; font-weight:600;&quot;&gt;Webserver&lt;/span&gt; output method with OBS Browser Source for cover art and advanced customization.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;OBS WebSocket v5 support provides &lt;span style=&quot; font-style:italic;&quot;&gt;text-only&lt;/span&gt; output to OBS Text sources. Requires OBS Studio v28+.&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </widget>
   <widget class="QWidget" name="formLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>150</y>
-     <width>561</width>
+     <x>10</x>
+     <y>80</y>
+     <width>611</width>
      <height>131</height>
     </rect>
    </property>
@@ -175,8 +177,8 @@ li.checked::marker { content: &quot;\2612&quot;; }
    </property>
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>330</y>
+     <x>10</x>
+     <y>225</y>
      <width>111</width>
      <height>16</height>
     </rect>
@@ -191,10 +193,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
    </property>
    <property name="geometry">
     <rect>
-     <x>150</x>
-     <y>320</y>
+     <x>130</x>
+     <y>222</y>
      <width>141</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -204,10 +206,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
   <widget class="QLineEdit" name="template_lineedit">
    <property name="geometry">
     <rect>
-     <x>310</x>
-     <y>320</y>
-     <width>281</width>
-     <height>21</height>
+     <x>280</x>
+     <y>222</y>
+     <width>341</width>
+     <height>25</height>
     </rect>
    </property>
   </widget>

--- a/nowplaying/resources/settings_ui.ui
+++ b/nowplaying/resources/settings_ui.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Settings</string>
   </property>
-  <widget class="QListWidget" name="settings_list">
+  <widget class="QTreeWidget" name="settings_tree">
    <property name="geometry">
     <rect>
      <x>0</x>
@@ -21,6 +21,12 @@
      <width>141</width>
      <height>501</height>
     </rect>
+   </property>
+   <property name="headerHidden">
+    <bool>true</bool>
+   </property>
+   <property name="rootIsDecorated">
+    <bool>true</bool>
    </property>
   </widget>
   <widget class="QStackedWidget" name="settings_stack">

--- a/nowplaying/resources/textoutput_ui.ui
+++ b/nowplaying/resources/textoutput_ui.ui
@@ -23,7 +23,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>20</y>
+     <y>10</y>
      <width>261</width>
      <height>16</height>
     </rect>
@@ -39,7 +39,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>60</y>
+     <y>35</y>
      <width>111</width>
      <height>16</height>
     </rect>
@@ -52,9 +52,9 @@
    <property name="geometry">
     <rect>
      <x>140</x>
-     <y>50</y>
+     <y>32</y>
      <width>161</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -64,10 +64,10 @@
   <widget class="QPushButton" name="textoutput_button">
    <property name="geometry">
     <rect>
-     <x>160</x>
-     <y>100</y>
+     <x>140</x>
+     <y>62</y>
      <width>113</width>
-     <height>32</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -78,7 +78,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>110</y>
+     <y>65</y>
      <width>111</width>
      <height>16</height>
     </rect>
@@ -90,20 +90,20 @@
   <widget class="QLineEdit" name="texttemplate_lineedit">
    <property name="geometry">
     <rect>
-     <x>340</x>
-     <y>50</y>
-     <width>281</width>
-     <height>31</height>
+     <x>310</x>
+     <y>32</y>
+     <width>311</width>
+     <height>25</height>
     </rect>
    </property>
   </widget>
   <widget class="QLineEdit" name="textoutput_lineedit">
    <property name="geometry">
     <rect>
-     <x>340</x>
-     <y>100</y>
-     <width>281</width>
-     <height>31</height>
+     <x>260</x>
+     <y>62</y>
+     <width>361</width>
+     <height>25</height>
     </rect>
    </property>
   </widget>
@@ -111,9 +111,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>250</y>
+     <y>180</y>
      <width>111</width>
-     <height>24</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -124,7 +124,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>150</y>
+     <y>100</y>
      <width>211</width>
      <height>20</height>
     </rect>
@@ -140,7 +140,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>180</y>
+     <y>125</y>
      <width>211</width>
      <height>20</height>
     </rect>
@@ -156,7 +156,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>220</y>
+     <y>160</y>
      <width>261</width>
      <height>16</height>
     </rect>

--- a/nowplaying/resources/twitchchat_ui.ui
+++ b/nowplaying/resources/twitchchat_ui.ui
@@ -150,7 +150,7 @@
      <x>10</x>
      <y>170</y>
      <width>611</width>
-     <height>261</height>
+     <height>230</height>
     </rect>
    </property>
    <property name="alternatingRowColors">
@@ -209,7 +209,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>440</y>
+     <y>410</y>
      <width>621</width>
      <height>32</height>
     </rect>

--- a/nowplaying/settings/__init__.py
+++ b/nowplaying/settings/__init__.py
@@ -1,0 +1,1 @@
+"""Settings organization modules"""

--- a/nowplaying/settings/categories.py
+++ b/nowplaying/settings/categories.py
@@ -1,0 +1,147 @@
+"""Settings categories and tree structure management"""
+
+import logging
+from dataclasses import dataclass, field
+from PySide6.QtWidgets import QTreeWidgetItem  # pylint: disable=no-name-in-module
+
+
+@dataclass
+class SettingsCategory:
+    """Represents a settings category in the tree"""
+
+    name: str
+    display_name: str
+    items: list[str] = field(default_factory=list)
+    tree_item: QTreeWidgetItem | None = None
+
+    def add_item(self, item_name: str) -> None:
+        """Add an item to this category"""
+        if item_name not in self.items:
+            self.items.append(item_name)
+
+
+@dataclass
+class TabGroup:
+    """Represents a tabbed group within a category"""
+
+    name: str
+    display_name: str
+    tabs: dict[str, str]  # {tab_key: display_name}
+
+
+class SettingsCategoryManager:
+    """Manages the hierarchical structure of settings categories"""
+
+    def __init__(self):
+        self.categories: list[SettingsCategory] = []
+        self.tab_groups: list[TabGroup] = []
+        # Mapping of plugin types to their target category names
+        self.plugin_type_mapping = {
+            "inputs": "inputs",
+            "recognition": "recognition",
+            "artistextras": "artistdata",
+            "notifications": "output",
+        }
+        self._init_categories()
+
+    def _init_categories(self):
+        """Initialize the default category structure"""
+
+        # About will be handled separately as a standalone item, not a category
+
+        # Core Settings
+        self.categories.append(
+            SettingsCategory("core", "Core Settings", ["general", "source", "filter", "trackskip"])
+        )
+
+        # Output & Display
+        self.categories.append(
+            SettingsCategory("output", "Output & Display", ["textoutput", "webserver", "obsws"])
+        )
+
+        # Streaming & Chat (with tab groups)
+        streaming_category = SettingsCategory("streaming", "Streaming & Chat", [])
+        self.categories.append(streaming_category)
+
+        # Define tab groups for streaming platforms
+        self.tab_groups.extend(
+            [
+                TabGroup("twitch_group", "Twitch", {"twitch": "Settings", "twitchchat": "Chat"}),
+                TabGroup("kick_group", "Kick", {"kick": "Settings", "kickchat": "Chat"}),
+            ]
+        )
+
+        # Add individual items for streaming category
+        streaming_category.add_item("requests")
+        streaming_category.add_item("discordbot")
+
+        # Artist Data
+        self.categories.append(SettingsCategory("artistdata", "Artist Data", ["artistextras"]))
+
+        # Input Sources
+        self.categories.append(
+            SettingsCategory(
+                "inputs",
+                "Input Sources",
+                [],  # Will be populated dynamically with plugin inputs
+            )
+        )
+
+        # Recognition
+        self.categories.append(
+            SettingsCategory(
+                "recognition",
+                "Recognition",
+                [],  # Will be populated dynamically with recognition plugins
+            )
+        )
+
+        # System
+        self.categories.append(SettingsCategory("system", "System", ["quirks", "destroy"]))
+
+    def get_category_for_item(self, item_name: str) -> SettingsCategory | None:
+        """Find which category contains the given item"""
+        # Check tab groups first
+        for tab_group in self.tab_groups:
+            if item_name in tab_group.tabs:
+                # Find the streaming category
+                for category in self.categories:
+                    if category.name == "streaming":
+                        return category
+
+        # Check regular categories
+        for category in self.categories:
+            if item_name in category.items:
+                return category
+
+        return None
+
+    def get_tab_group_for_item(self, item_name: str) -> TabGroup | None:
+        """Find which tab group contains the given item"""
+        for tab_group in self.tab_groups:
+            if item_name in tab_group.tabs:
+                return tab_group
+        return None
+
+    def add_plugin_item(self, plugin_type: str, item_name: str):
+        """Add a plugin item to the appropriate category"""
+        target_category_name = self.plugin_type_mapping.get(plugin_type)
+        if target_category_name:
+            if target_category := next(
+                (c for c in self.categories if c.name == target_category_name), None
+            ):
+                target_category.add_item(f"{plugin_type}_{item_name}")
+        else:
+            # Log unknown plugin types for future extension
+            logging.debug("Unknown plugin type '%s', skipping item '%s'", plugin_type, item_name)
+
+    def get_item_hierarchy(self, item_name: str) -> tuple[str | None, str | None, str | None]:
+        """Get the hierarchy path for an item (category, tab_group, item)"""
+
+        if tab_group := self.get_tab_group_for_item(item_name):
+            return ("streaming", tab_group.name, item_name)
+
+        if category := self.get_category_for_item(item_name):
+            return (category.name, None, item_name)
+
+        return (None, None, item_name)

--- a/nowplaying/settings/tabs.py
+++ b/nowplaying/settings/tabs.py
@@ -1,0 +1,57 @@
+"""Tab widget management for settings groups"""
+
+from PySide6.QtWidgets import QTabWidget, QWidget  # pylint: disable=no-name-in-module
+
+
+class SettingsTabWidget(QTabWidget):
+    """Custom tab widget for settings groups like Twitch/Kick"""
+
+    def __init__(self, group_name: str, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.group_name = group_name
+        self.tab_widgets: dict[str, QWidget] = {}
+
+    def add_settings_tab(self, tab_key: str, widget: QWidget, tab_title: str):
+        """Add a settings widget as a tab. If tab_key exists, replace the old tab."""
+        if tab_key in self.tab_widgets:
+            old_widget = self.tab_widgets[tab_key]
+            old_index = self.indexOf(old_widget)
+            if old_index != -1:
+                self.removeTab(old_index)
+        index = self.addTab(widget, tab_title)
+        self.tab_widgets[tab_key] = widget
+        return index
+
+    def get_tab_widget(self, tab_key: str) -> QWidget | None:
+        """Get the widget for a specific tab"""
+        return self.tab_widgets.get(tab_key)
+
+    def get_current_tab_key(self) -> str | None:
+        """Get the key of the currently selected tab"""
+        current_widget = self.currentWidget()
+        for key, widget in self.tab_widgets.items():
+            if widget == current_widget:
+                return key
+        return None
+
+
+class TabWidgetManager:
+    """Manages tab widgets for settings groups"""
+
+    def __init__(self):
+        self.tab_widgets: dict[str, SettingsTabWidget] = {}
+
+    def create_tab_widget(self, group_name: str) -> SettingsTabWidget:
+        """Create and store a new tab widget for a group"""
+        tab_widget = SettingsTabWidget(group_name)
+        self.tab_widgets[group_name] = tab_widget
+        return tab_widget
+
+    def get_tab_widget(self, group_name: str) -> SettingsTabWidget | None:
+        """Get an existing tab widget"""
+        return self.tab_widgets.get(group_name)
+
+    def remove_tab_widget(self, group_name: str):
+        """Remove a tab widget"""
+        if group_name in self.tab_widgets:
+            del self.tab_widgets[group_name]

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -106,11 +106,17 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             self._show_installation_error("settings UI files")
             self.settingswindow = None
 
+    def _show_settings(self) -> None:
+        """Show settings window and bring it to the front."""
+        self.settingswindow.show()
+        self.settingswindow.raise_()
+        self.settingswindow.activateWindow()
+
     def _setup_tray_menu(self) -> None:
         """Setup all tray menu actions and structure."""
         # Settings and Requests actions
         self.settings_action = QAction("Settings")
-        self.settings_action.triggered.connect(self.settingswindow.show)
+        self.settings_action.triggered.connect(self._show_settings)
         self.menu.addAction(self.settings_action)
 
         self.request_action = QAction("Requests")
@@ -252,14 +258,14 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         """If the web server gets in trouble, we need to tell the user"""
         if not status:
             self.settingswindow.disable_web()
-            self.settingswindow.show()
+            self._show_settings()
             self.pause()
 
     def obswsenable(self, status: bool) -> None:
         """If the OBS WebSocket gets in trouble, we need to tell the user"""
         if not status:
             self.settingswindow.disable_obsws()
-            self.settingswindow.show()
+            self._show_settings()
             self.pause()
 
     def unpause(self) -> None:
@@ -427,4 +433,4 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         msgbox.show()
         msgbox.exec()
 
-        self.settingswindow.show()
+        self._show_settings()

--- a/tests-qt/test_settingsui.py
+++ b/tests-qt/test_settingsui.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """test settingsui"""
 
+# pylint: disable=redefined-outer-name,unused-argument,protected-access, unused-variable
+
 from PySide6.QtCore import Qt  # pylint: disable=import-error, no-name-in-module
 from PySide6.QtGui import QAction  # pylint: disable=import-error, no-name-in-module
+from PySide6.QtWidgets import QLabel, QWidget  # pylint: disable=import-error, no-name-in-module
 
 import nowplaying.settingsui  # pylint: disable=import-error
+from nowplaying.settings.tabs import SettingsTabWidget
 
 
 class MockSubprocesses:
@@ -72,3 +76,72 @@ def test_settingsui_save(bootstrap, qtbot):
         settingsui.widgets["source"].sourcelist.viewport(), Qt.MouseButton.LeftButton, pos=center
     )
     qtbot.mouseClick(settingsui.qtui.save_button, Qt.MouseButton.LeftButton)
+
+
+def test_settingsui_tree_navigation(bootstrap, qtbot):
+    """test tree navigation"""
+    config = bootstrap
+    tray = MockTray(config)
+    settingsui = nowplaying.settingsui.SettingsUI(tray=tray)
+    qtbot.addWidget(settingsui.qtui)
+
+    # Test that tree has items
+    tree = settingsui.qtui.settings_tree
+    assert tree.topLevelItemCount() > 0
+
+    # Test clicking on About item
+    about_items = tree.findItems("About", Qt.MatchRecursive)
+    assert len(about_items) > 0
+
+    about_item = about_items[0]
+    qtbot.mouseClick(tree, Qt.MouseButton.LeftButton, pos=tree.visualItemRect(about_item).center())
+
+    # Test that stack index changed
+    assert settingsui.qtui.settings_stack.currentIndex() >= 0
+
+
+def test_settingsui_keyboard_navigation(bootstrap, qtbot):
+    """test keyboard navigation accessibility"""
+    config = bootstrap
+    tray = MockTray(config)
+    settingsui = nowplaying.settingsui.SettingsUI(tray=tray)
+    qtbot.addWidget(settingsui.qtui)
+
+    tree = settingsui.qtui.settings_tree
+    tree.setFocus()
+
+    # Test programmatic selection (simulates keyboard navigation)
+    about_items = tree.findItems("About", Qt.MatchRecursive)
+    assert len(about_items) > 0
+
+    initial_index = settingsui.qtui.settings_stack.currentIndex()
+
+    # Programmatically select the About item (simulates keyboard selection)
+    tree.setCurrentItem(about_items[0])
+
+    # Verify the stack changed
+    new_index = settingsui.qtui.settings_stack.currentIndex()
+    assert new_index != initial_index or new_index >= 0
+
+
+def test_settingsui_tab_duplicate_handling(bootstrap, qtbot):
+    """test tab widget duplicate key handling"""
+
+    tab_widget = SettingsTabWidget("test_group")
+    qtbot.addWidget(tab_widget)
+
+    # Create two different widgets
+    widget1 = QWidget()
+    label1 = QLabel("Widget 1", widget1)
+    widget2 = QWidget()
+    label2 = QLabel("Widget 2", widget2)
+
+    # Add first tab
+    tab_widget.add_settings_tab("test_key", widget1, "Tab 1")
+    assert tab_widget.count() == 1
+    assert tab_widget.get_tab_widget("test_key") == widget1
+
+    # Add second tab with same key - should replace first
+    tab_widget.add_settings_tab("test_key", widget2, "Tab 2")
+    assert tab_widget.count() == 1  # Still only 1 tab
+    assert tab_widget.get_tab_widget("test_key") == widget2  # Points to new widget

--- a/tests-qt/test_systemtray.py
+++ b/tests-qt/test_systemtray.py
@@ -6,8 +6,15 @@ import pathlib
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtGui import QAction, QActionGroup, QIcon  # pylint: disable=import-error, no-name-in-module
-from PySide6.QtWidgets import QMenu, QSystemTrayIcon  # pylint: disable=import-error, no-name-in-module
+from PySide6.QtGui import (  # pylint: disable=import-error, no-name-in-module
+    QAction,
+    QActionGroup,
+    QIcon,
+)
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QMenu,
+    QSystemTrayIcon,
+)
 
 import nowplaying.systemtray  # pylint: disable=import-error
 

--- a/tests-qt/test_systemtray.py
+++ b/tests-qt/test_systemtray.py
@@ -118,6 +118,14 @@ class MockSettingsUI:
         """Show settings UI"""
         self.shown = True
 
+    def raise_(self):
+        """Raise settings window to front"""
+        # Mock implementation - no action needed
+
+    def activateWindow(self):  # pylint: disable=invalid-name
+        """Activate settings window"""
+        # Mock implementation - no action needed
+
     def post_tray_init(self):
         """Post tray initialization"""
         # No implementation needed for mock


### PR DESCRIPTION
## Summary by Sourcery

Implement a hierarchical settings UI by replacing the flat list with a tree view organized into categories and tab groups, and ensure the system tray correctly shows and raises the settings window.

New Features:
- Introduce SettingsCategoryManager and TabWidgetManager to organize settings into a category and tab hierarchy.
- Build the settings tree in SettingsUI and handle tree item clicks to switch the settings stack accordingly.
- Add _show_settings in systemtray to show, raise, and activate the settings window.
- Add a test for tree navigation in settings UI to validate the new hierarchical layout.

Enhancements:
- Remove legacy list-based navigation and defer widget loading until after the tree is built.
- Automatically select and display the About item by default in the settings tree.
- Refactor widget setup signature and streamline SettingsUI load sequence.

Tests:
- Add test_settingsui_tree_navigation to verify tree population and navigation behavior.