### PR TITLE
remote output sending too much

### DIFF
--- a/docs/reference/templatevariables.md
+++ b/docs/reference/templatevariables.md
@@ -63,6 +63,9 @@ data.
 | hostfqdn | Fully qualified hostname of the machine running **What's Now Playing** |
 | hostname | Short hostname of the machine running **What's Now Playing** |
 | httpport | Port number that is running the web server |
+| twitchchannel | Twitch channel name (if configured) |
+| kickchannel | Kick channel name (if configured) |
+| discordguild | Discord guild/server name (if bot is connected) |
 | isrc | List of [International Standard Recording Code](https://isrc.ifpi.org/en/) |
 | key | Key of the song |
 | label | Label of the media. |

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -222,6 +222,15 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         for key, value in hostmeta.items():
             self.metadata[key] = value
 
+        # Add streaming platform channel information
+        if twitchchannel := self.config.cparser.value("twitchbot/channel"):
+            self.metadata["twitchchannel"] = twitchchannel
+        if kickchannel := self.config.cparser.value("kick/channel"):
+            self.metadata["kickchannel"] = kickchannel
+        # Discord guild (server) information - captured dynamically by bot
+        if discordguild := self.config.cparser.value("discord/guild"):
+            self.metadata["discordguild"] = discordguild
+
     def _process_tinytag(self) -> None:
         try:
             tempdata = TinyTagRunner(imagecache=self.imagecache).process(

--- a/nowplaying/notifications/remote.py
+++ b/nowplaying/notifications/remote.py
@@ -106,7 +106,7 @@ class Plugin(NotificationPlugin):
 
     @staticmethod
     def _strip_blobs_metadata(metadata: TrackMetadata) -> TrackMetadata:
-        """Strip binary blob data for remote transmission"""
+        """Strip binary blob data and local system metadata for remote transmission"""
         remote_data = metadata.copy()
 
         # Remove all blob fields
@@ -119,9 +119,19 @@ class Plugin(NotificationPlugin):
             logging.error("%s was dropped from remote_data (bytes)", key)
             remote_data.pop(key, None)
 
-        # Remove dbid if present
-        if remote_data.get("dbid"):
-            del remote_data["dbid"]
+        # Remove local system metadata that shouldn't be sent to remote systems
+        local_system_fields = [
+            "httpport",
+            "hostname",
+            "hostfqdn",
+            "hostip",
+            "ipaddress",
+            "previoustrack",
+            "dbid",
+            "cache_warmed",
+        ]
+        for key in local_system_fields:
+            remote_data.pop(key, None)
 
         return remote_data
 

--- a/nowplaying/processes/discordbot.py
+++ b/nowplaying/processes/discordbot.py
@@ -83,6 +83,13 @@ class DiscordSupport:
             await asyncio.sleep(1)
         logging.debug("bot setup")
 
+        # Capture Discord guild information now that bot is ready
+        if self.clients.bot.guilds and self.config:
+            guild = self.clients.bot.guilds[0]  # Get the first guild the bot is in
+            logging.info("Discord bot connected to guild: %s", guild.name)
+            self.config.cparser.setValue("discord/guild", guild.name)
+            self.config.cparser.sync()
+
     async def _setup_ipc_client(self) -> None:  # pylint: disable=too-many-return-statements
         if not self.config:
             return

--- a/nowplaying/types.py
+++ b/nowplaying/types.py
@@ -75,6 +75,9 @@ class TrackMetadata(TypedDict, total=False):
     hostfqdn: str
     hostip: str
     ipaddress: str
+    twitchchannel: str
+    kickchannel: str
+    discordguild: str
 
     # Request system
     requester: str

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -378,6 +378,44 @@ async def test_year_not_date(bootstrap):
 
 
 @pytest.mark.asyncio
+async def test_streaming_channel_metadata(bootstrap):
+    """test that streaming channel information gets added to metadata"""
+    config = bootstrap
+    config.cparser.setValue("acoustidmb/enabled", False)
+    config.cparser.setValue("musicbrainz/enabled", False)
+    config.cparser.setValue("twitchbot/channel", "teststreamer")
+    config.cparser.setValue("kick/channel", "kickstreamer")
+    config.cparser.setValue("discord/guild", "My Discord Server")
+
+    metadatain = {"artist": "Test Artist", "title": "Test Title"}
+    metadataout = await nowplaying.metadata.MetadataProcessors(config=config).getmoremetadata(
+        metadata=metadatain
+    )
+
+    assert metadataout["twitchchannel"] == "teststreamer"
+    assert metadataout["kickchannel"] == "kickstreamer"
+    assert metadataout["discordguild"] == "My Discord Server"
+
+
+@pytest.mark.asyncio
+async def test_streaming_channel_metadata_missing(bootstrap):
+    """test that missing streaming channel configs don't add empty fields"""
+    config = bootstrap
+    config.cparser.setValue("acoustidmb/enabled", False)
+    config.cparser.setValue("musicbrainz/enabled", False)
+    # Don't set any streaming channel configs
+
+    metadatain = {"artist": "Test Artist", "title": "Test Title"}
+    metadataout = await nowplaying.metadata.MetadataProcessors(config=config).getmoremetadata(
+        metadata=metadatain
+    )
+
+    assert "twitchchannel" not in metadataout
+    assert "kickchannel" not in metadataout
+    assert "discordguild" not in metadataout
+
+
+@pytest.mark.asyncio
 async def test_url_dedupe1(bootstrap):
     """automated integration test"""
     config = bootstrap


### PR DESCRIPTION
## Summary by Sourcery

Include user-configured streaming channel identifiers in metadata and preserve them in remote notifications while stripping local system details from outgoing payloads

New Features:
- Add support for Twitch, Kick, and Discord guild channel names in metadata processors and extend TrackMetadata types accordingly
- Persist Discord guild name from the bot client into the configuration at runtime

Enhancements:
- Expand remote notification logic to strip additional local system metadata fields alongside binary blobs

Documentation:
- Document new template variables for twitchchannel, kickchannel, and discordguild

Tests:
- Add tests for streaming channel metadata inclusion and omission
- Extend remote plugin tests to verify stripping of new local system fields and retention of streaming channel data