### PR TITLE
cut some debug stuff out

### DIFF
--- a/nowplaying/notifications/remote.py
+++ b/nowplaying/notifications/remote.py
@@ -2,7 +2,6 @@
 """Remote Output Notification Plugin"""
 
 import contextlib
-import json
 import logging
 from typing import TYPE_CHECKING
 

--- a/nowplaying/notifications/remote.py
+++ b/nowplaying/notifications/remote.py
@@ -64,13 +64,13 @@ class Plugin(NotificationPlugin):
             debug_data["secret"] = "***REDACTED***"
 
         # Debug: write JSON to file to inspect
-        try:
-            debug_file = "/tmp/remote_debug.json"
-            with open(debug_file, "w", encoding="utf-8") as fnout:
-                json.dump(debug_data, fnout, indent=2)
-            logging.info("Debug: wrote remote data to %s", debug_file)
-        except Exception:  # pylint: disable=broad-except
-            logging.exception("Failed to write debug JSON")
+        # try:
+        #     debug_file = "/tmp/remote_debug.json"
+        #     with open(debug_file, "w", encoding="utf-8") as fnout:
+        #         json.dump(debug_data, fnout, indent=2)
+        #     logging.info("Debug: wrote remote data to %s", debug_file)
+        # except Exception:  # pylint: disable=broad-except
+        #     logging.exception("Failed to write debug JSON")
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -50,7 +50,6 @@ import nowplaying.kick.oauth2
 import nowplaying.metadata
 import nowplaying.oauth2
 import nowplaying.twitch.oauth2
-import nowplaying.trackrequests
 import nowplaying.utils
 from nowplaying.types import TrackMetadata
 
@@ -159,7 +158,6 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                 await asyncio.sleep(30)  # Refresh every 30 seconds
                 if not nowplaying.utils.safe_stopevent_check(self.stopevent):
                     app[CONFIG_KEY].get()
-                    logging.debug("Webserver config refreshed")
             except Exception as error:  # pylint: disable=broad-except
                 logging.error("Config refresh task error: %s", error)
 


### PR DESCRIPTION
## Summary by Sourcery

Remove leftover debug statements from remote notifications and webserver config refresh

Chores:
- Comment out temporary JSON dump in remote notifications
- Remove debug log in webserver config refresh task