### PR TITLE
minor text issues

### DIFF
--- a/nowplaying/kick/chat.py
+++ b/nowplaying/kick/chat.py
@@ -216,7 +216,7 @@ class KickChat:  # pylint: disable=too-many-instance-attributes
 
                 test_message = (
                     f"🤖 whatsnowplaying v{self.config.version} by @modernmeerkat "
-                    f"connected! Using {inputsource} on {plat}."
+                    "connected!"
                 )
                 test_sent = await self._send_message(test_message)
                 if test_sent:

--- a/nowplaying/kick/chat.py
+++ b/nowplaying/kick/chat.py
@@ -5,7 +5,6 @@ import asyncio
 import datetime
 import logging
 import pathlib
-import platform
 from typing import Any
 
 import aiohttp
@@ -209,10 +208,6 @@ class KickChat:  # pylint: disable=too-many-instance-attributes
                     continue
 
                 logging.info("Successfully authenticated with Kick. Channel: %s", channel_name)
-
-                # Send connection message with version info (like Twitch !whatsnowplayingversion)
-                inputsource = self.config.cparser.value("settings/input")
-                plat = platform.platform()
 
                 test_message = (
                     f"🤖 whatsnowplaying v{self.config.version} by @modernmeerkat "

--- a/nowplaying/kick/chat.py
+++ b/nowplaying/kick/chat.py
@@ -210,8 +210,7 @@ class KickChat:  # pylint: disable=too-many-instance-attributes
                 logging.info("Successfully authenticated with Kick. Channel: %s", channel_name)
 
                 test_message = (
-                    f"🤖 whatsnowplaying v{self.config.version} by @modernmeerkat "
-                    "connected!"
+                    f"🤖 whatsnowplaying v{self.config.version} by @modernmeerkat connected!"
                 )
                 test_sent = await self._send_message(test_message)
                 if test_sent:

--- a/nowplaying/twitch/chat.py
+++ b/nowplaying/twitch/chat.py
@@ -390,7 +390,7 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
             self.modernmeerkat_greeted = True
             try:
                 await self.chat.send_message(
-                    self.config.cparser.value("twitchbot/channel"), f"hi @{msg.user.display_name}"
+                    self.config.cparser.value("twitchbot/channel"), f"Hello @{msg.user.display_name}"
                 )
                 logging.info("Greeted modernmeerkat user: %s", msg.user.display_name)
             except Exception as error:  # pylint: disable=broad-except

--- a/nowplaying/twitch/chat.py
+++ b/nowplaying/twitch/chat.py
@@ -390,7 +390,8 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
             self.modernmeerkat_greeted = True
             try:
                 await self.chat.send_message(
-                    self.config.cparser.value("twitchbot/channel"), f"Hello @{msg.user.display_name}"
+                    self.config.cparser.value("twitchbot/channel"),
+                    f"Hello @{msg.user.display_name}",
                 )
                 logging.info("Greeted modernmeerkat user: %s", msg.user.display_name)
             except Exception as error:  # pylint: disable=broad-except

--- a/tests/twitch/test_twitch_chat.py
+++ b/tests/twitch/test_twitch_chat.py
@@ -50,7 +50,7 @@ async def test_modernmeerkat_greeting_sent_once(bootstrap):
     await chat.on_twitchchat_incoming_message(message)  # pylint: disable=no-member
 
     # Verify greeting was sent
-    chat.chat.send_message.assert_called_once_with("testchannel", "hi @modernmeerkat")
+    chat.chat.send_message.assert_called_once_with("testchannel", "Hello @modernmeerkat")
     assert chat.modernmeerkat_greeted is True
 
 

--- a/tests/twitch/test_twitch_chat.py
+++ b/tests/twitch/test_twitch_chat.py
@@ -104,7 +104,7 @@ async def test_modernmeerkat_case_insensitive(bootstrap):
         await chat.on_twitchchat_incoming_message(message)  # pylint: disable=no-member
 
         # Verify greeting was sent
-        chat.chat.send_message.assert_called_once_with("testchannel", f"hi @{username}")
+        chat.chat.send_message.assert_called_once_with("testchannel", f"Hello @{username}")
         assert chat.modernmeerkat_greeted is True
 
 


### PR DESCRIPTION
## Summary by Sourcery

Simplify Kick chat connection message and standardize Twitch greeting wording

Enhancements:
- Simplify Kick chat test message to only show "connected!"
- Update Twitch greeting from "hi @user" to "Hello @user"