### PR TITLE
win11 fixes for traktor, vdj; doc fix

### DIFF
--- a/.github/workflows/mkdocs-deploy.yaml
+++ b/.github/workflows/mkdocs-deploy.yaml
@@ -34,8 +34,14 @@ jobs:
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
-            mike deploy --push --update-aliases $VERSION latest
-            mike set-default --push latest
+            if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              # Stable release (e.g., 5.0.0) - deploy as latest
+              mike deploy --push --update-aliases $VERSION latest
+              mike set-default --push latest
+            else
+              # Preview/pre-release (e.g., 5.0.0-preview1) - deploy version only
+              mike deploy --push $VERSION
+            fi
           else
             mike deploy --push dev
           fi

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -316,12 +316,24 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
 
     def install(self):
         """locate Virtual DJ"""
-        vdjdir = self.config.userdocs.joinpath("VirtualDJ")
-        if vdjdir.exists():
-            self.config.cparser.value("settings/input", "virtualdj")
-            self.config.cparser.value("virtualdj/history", str(vdjdir.joinpath("History")))
-            self.config.cparser.value("virtualdj/playlists", str(vdjdir.joinpath("Playlists")))
-            return True
+        # Check multiple possible VirtualDJ locations
+        possible_locations = [
+            # Traditional Documents/VirtualDJ location
+            self.config.userdocs.joinpath("VirtualDJ"),
+            # Windows 11 AppData\Local\VirtualDJ location
+            pathlib.Path(
+                QStandardPaths.standardLocations(QStandardPaths.AppLocalDataLocation)[0]
+            ).parent.joinpath("VirtualDJ"),
+        ]
+
+        for vdjdir in possible_locations:
+            if vdjdir.exists():
+                self.config.cparser.setValue("settings/input", "virtualdj")
+                self.config.cparser.setValue("virtualdj/history", str(vdjdir.joinpath("History")))
+                self.config.cparser.setValue(
+                    "virtualdj/playlists", str(vdjdir.joinpath("Playlists"))
+                )
+                return True
 
         return False
 


### PR DESCRIPTION
## Summary by Sourcery

Improve auto-install routines for Traktor and VirtualDJ by searching both Documents and Windows 11 AppData locations and streamline config calls, and enhance the documentation deployment workflow to distinguish stable and prerelease tags.

New Features:
- Support Windows 11 AppData paths when auto-detecting Traktor and VirtualDJ installations

Enhancements:
- Use QStandardPaths and setValue instead of value for consistent config setting in Traktor and VirtualDJ inputs

CI:
- Update mkdocs-deploy workflow to deploy stable releases with latest alias and preview prereleases without alias