### PR TITLE
try out folder mode for windows

### DIFF
--- a/NowPlaying.spec
+++ b/NowPlaying.spec
@@ -204,17 +204,25 @@ for execname, execpy in executables.items():
         exe = EXE(  # pylint: disable=undefined-variable
             pyz,
             a.scripts,
-            a.binaries,
-            a.zipfiles,
-            a.datas, [],
+            splash,  # Include splash screen
+            [],
+            exclude_binaries=True,
             name=execname,
             debug=False,
             bootloader_ignore_signals=False,
             strip=False,
             upx=True,
-            upx_exclude=[],
-            runtime_tmpdir=None,
             console=False,
             version=WINVERSFILE,
             icon=f'bincomponents/{geticon()}')
+        coll = COLLECT(  # pylint: disable=undefined-variable
+            exe,
+            a.binaries,
+            a.zipfiles,
+            a.datas,
+            splash.binaries,  # Include splash screen binaries
+            strip=False,
+            upx=True,
+            upx_exclude=[],
+            name=execname)
         os.unlink(WINVERSFILE)

--- a/NowPlaying.spec
+++ b/NowPlaying.spec
@@ -152,13 +152,14 @@ for execname, execpy in executables.items():
                  cipher=block_cipher,
                  noarchive=False)
 
-    if sys.platform != 'darwin':
-        splash = Splash('docs/images/meerkatdj_256x256.png',
-                        binaries=a.binaries,
-                        datas=a.datas,
-                        text_pos=(10, 50),
-                        text_size=12,
-                        text_color='black')
+    # Splash screen disabled for folder mode
+    # if sys.platform != 'darwin':
+    #     splash = Splash('docs/images/meerkatdj_256x256.png',
+    #                     binaries=a.binaries,
+    #                     datas=a.datas,
+    #                     text_pos=(10, 50),
+    #                     text_size=12,
+    #                     text_color='black')
 
     pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)  # pylint: disable=undefined-variable
 
@@ -204,7 +205,6 @@ for execname, execpy in executables.items():
         exe = EXE(  # pylint: disable=undefined-variable
             pyz,
             a.scripts,
-            splash,  # Include splash screen
             [],
             exclude_binaries=True,
             name=execname,
@@ -220,7 +220,6 @@ for execname, execpy in executables.items():
             a.binaries,
             a.zipfiles,
             a.datas,
-            splash.binaries,  # Include splash screen binaries
             strip=False,
             upx=True,
             upx_exclude=[],


### PR DESCRIPTION
## Summary by Sourcery

Switch the PyInstaller spec to folder mode on Windows by splitting the EXE and collecting assets externally and including the splash screen binaries

Enhancements:
- Refactor spec file to use COLLECT for folder-based distribution instead of bundling everything into a single EXE
- Exclude binaries from the EXE build step and move them into the COLLECT output
- Include splash screen resources and binaries in the collection stage