### PR TITLE
document remoteinput; add GET; fix a few bugs; 

### DIFF
--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -9,4 +9,5 @@ tests/audio/
 tests/seratolive/
 tests/upgrade/releasedata.json
 docs/_static/basic.css
+docs/input/remote.md
 tests/playlists/traktor/collection.nml

--- a/docs/input/remote.md
+++ b/docs/input/remote.md
@@ -53,14 +53,13 @@ accept metadata submissions from external sources beyond the built-in Remote Out
   "artist": "Artist Name",
   "title": "Track Title",
   "album": "Album Name",
-  "filename": "/path/to/file.mp3",
   "secret": "your_secret_key"
 }
 ```
 
 **GET (Query Parameters):**
 
-```
+```url
 /v1/remoteinput?artist=Artist%20Name&title=Track%20Title&album=Album%20Name&secret=your_secret_key
 ```
 
@@ -79,9 +78,14 @@ accept metadata submissions from external sources beyond the built-in Remote Out
     "coverurl": "cover.png",
     "date": "2023",
     "genre": "Electronic"
-  }
+  },
+  "warnings": [
+    "Field 'title' truncated from 1500 to 1000 characters"
+  ]
 }
 ```
+
+> **Note:** The `warnings` field is only included if data validation issues occurred (e.g., field truncation).
 
 **Error Responses:**
 
@@ -107,24 +111,23 @@ The API includes several validation and processing features:
 
 The API accepts any metadata fields that the Remote Output plugin sends, including:
 
-* Basic track info: `artist`, `title`, `album`, `filename`
+* Basic track info: `artist`, `title`, `album`
 * Identifiers: `isrc`, `musicbrainzartistid`, `musicbrainzrecordingid`
 * Additional: `genre`, `date`, `composer`, `lyricist`, `bpm`, `key`
 * And many others (see Remote Output plugin for complete list)
 
-Fields like `coverimageraw`, `hostname`, `httpport`, and other system/binary data are automatically filtered out.
+Fields like `coverimageraw`, `hostname`, `httpport`, `filename`, and other system/binary data are automatically filtered out for security reasons.
 
 #### DJ Software Integration Examples
 
-> **Configuration Notes:**
-> Replace `localhost:8899` with your server's hostname and webserver port
-> If a secret is configured, add `&secret=your_secret_key` to the URL
-> The `filename` parameter is included for future compatibility but currently cannot be processed when sent from remote sources
+**Configuration Notes:**
+- Replace `localhost:8899` with your server's hostname and webserver port
+- If a secret is configured, add `&secret=your_secret_key` to the URL
 
 **MegaSeg (Logging → Send track info to server):**
 
 ```url
-http://localhost:8899/v1/remoteinput?title=%Title%&artist=%Artist%&album=%Album%&year=%Year%&duration=%LengthSeconds%&bpm=%BPM%&composer=%Composer%&lyricist=%Lyricist%&publisher=%Publisher%&filename=%Path%
+http://localhost:8899/v1/remoteinput?title=%Title%&artist=%Artist%&album=%Album%&year=%Year%&duration=%LengthSeconds%&bpm=%BPM%&composer=%Composer%&lyricist=%Lyricist%&publisher=%Publisher%
 ```
 
 **Radiologik (Publishing → Network & Serial → GET URL):**

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -194,8 +194,13 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
             for url in self.metadata["artistwebsites"]:
                 try:
                     newlist.append(url_normalize.url_normalize(url))
-                except (ValueError, Exception) as error:  # pylint: disable=broad-except
+                except ValueError as error:
                     logging.warning("Cannot normalize URL '%s': %s", url, error)
+                    newlist.append(url)  # Keep original URL if normalization fails
+                except Exception as error:  # pylint: disable=broad-except
+                    logging.error(
+                        "Unexpected error normalizing URL '%s': %s", url, error, exc_info=True
+                    )
                     newlist.append(url)  # Keep original URL if normalization fails
             self.metadata["artistwebsites"] = newlist
 

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -7,8 +7,9 @@ import binascii
 import copy
 import json
 import logging
-import re
 import os
+import pathlib
+import re
 import string
 import sys
 import textwrap
@@ -189,7 +190,13 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
             return
 
         if self.metadata.get("artistwebsites"):
-            newlist = [url_normalize.url_normalize(url) for url in self.metadata["artistwebsites"]]
+            newlist = []
+            for url in self.metadata["artistwebsites"]:
+                try:
+                    newlist.append(url_normalize.url_normalize(url))
+                except (ValueError, Exception) as error:  # pylint: disable=broad-except
+                    logging.warning("Cannot normalize URL '%s': %s", url, error)
+                    newlist.append(url)  # Keep original URL if normalization fails
             self.metadata["artistwebsites"] = newlist
 
         lists = ["artistwebsites", "isrc", "musicbrainzartistid"]
@@ -497,10 +504,21 @@ class TinyTagRunner:  # pylint: disable=too-few-public-methods
         if not metadata or not metadata.get("filename"):
             return metadata
 
+        # Create pathlib Path object for tinytag processing
         try:
-            tag = tinytag.TinyTag.get(self.metadata["filename"], image=True)
+            file_path = pathlib.Path(self.metadata["filename"])
+        except (ValueError, OSError) as error:
+            logging.debug("Cannot create Path object for %s: %s", self.metadata["filename"], error)
+            return metadata
+
+        try:
+            # Pass pathlib Path directly to tinytag - it will handle the path conversion
+            tag = tinytag.TinyTag.get(file_path, image=True)
         except tinytag.TinyTagException as error:
-            logging.error("tinytag could not process %s: %s", self.metadata["filename"], error)
+            logging.error("tinytag could not process %s: %s", file_path, error)
+            return metadata
+        except (FileNotFoundError, OSError, PermissionError) as error:
+            logging.debug("Cannot access file for tinytag processing %s: %s", file_path, error)
             return metadata
 
         if tag:

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -407,17 +407,6 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             },
         )
 
-    @staticmethod
-    async def handle_404(request: web.Request):
-        """Handle unknown endpoints with logging"""
-        logging.warning(
-            "404 - Unknown endpoint accessed: %s %s from %s",
-            request.method,
-            request.path,
-            request.remote,
-        )
-        raise web.HTTPNotFound()
-
     def create_runner(self):
         """setup http routing"""
         threading.current_thread().name = "WebServer-runner"
@@ -458,8 +447,6 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                 web.get("/nowplaying-websocket.js", self.static_handler.nowplaying_js_handler),
                 web.get(r"/{template_name:.+\.htm}", self.static_handler.template_handler),
                 web.get(f"/{self.magicstopurl}", self.stop_server),
-                # Catch-all 404 handler - must be last
-                web.route("*", r"/{path:.*}", self.handle_404),
             ]
         )
         return web.AppRunner(app)

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -70,7 +70,9 @@ class Version:
     def __str__(self) -> str:
         return self.textversion
 
-    def __lt__(self, other: t.Any) -> bool:
+    def __lt__(  # pylint: disable=too-many-return-statements
+        self, other: t.Any
+    ) -> bool:
         """version compare
         do the easy stuff, major > minor > micro"""
         for key in ["major", "minor", "micro"]:
@@ -86,10 +88,10 @@ class Version:
             other.chunk.get("rc") or other.chunk.get("preview") or other.chunk.get("prerelease")
         )
 
-        if self_has_pre and not other_has_pre:
-            return True
+        if self_has_pre:
+            if not other_has_pre:
+                return True
 
-        if self_has_pre and other_has_pre:
             # Compare rc numbers if both have rc
             if (
                 self.chunk.get("rc")

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -22,12 +22,12 @@ VERSION_REGEX = re.compile(
         (?P<minor>0|[1-9]\d*)
         \.
         (?P<micro>0|[1-9]\d*)
-        (?:-rc(?P<rc>(?:0|\d*)))?
+        (?:-(?:rc(?P<rc>(?:0|\d*))|preview(?P<preview>\d*)|(?P<prerelease>[a-zA-Z]+\d*)))?
         (?:[-+](?P<commitnum>
             (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
             (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
         ))?
-        (?:-(?P<identifier>
+        (?:\.(?P<identifier>
             [0-9a-zA-Z-]+
             (?:\.[0-9a-zA-Z-]+)*
         ))?
@@ -55,7 +55,12 @@ class Version:
             if isinstance(value, str) and value.isdigit():
                 self.chunk[key] = int(value)
 
-        if self.chunk.get("rc") or self.chunk.get("commitnum"):
+        if (
+            self.chunk.get("rc")
+            or self.chunk.get("preview")
+            or self.chunk.get("prerelease")
+            or self.chunk.get("commitnum")
+        ):
             self.pre = True
 
     def is_prerelease(self) -> bool:
@@ -73,16 +78,39 @@ class Version:
                 continue
             return self.chunk.get(key) < other.chunk.get(key)
 
-        # rc < no rc
-        if self.chunk.get("rc") and not other.chunk.get("rc"):
+        # rc/preview/prerelease < no rc/preview/prerelease
+        self_has_pre = (
+            self.chunk.get("rc") or self.chunk.get("preview") or self.chunk.get("prerelease")
+        )
+        other_has_pre = (
+            other.chunk.get("rc") or other.chunk.get("preview") or other.chunk.get("prerelease")
+        )
+
+        if self_has_pre and not other_has_pre:
             return True
 
-        if (
-            self.chunk.get("rc")
-            and other.chunk.get("rc")
-            and self.chunk.get("rc") != other.chunk.get("rc")
-        ):
-            return self.chunk.get("rc") < other.chunk.get("rc")
+        if self_has_pre and other_has_pre:
+            # Compare rc numbers if both have rc
+            if (
+                self.chunk.get("rc")
+                and other.chunk.get("rc")
+                and self.chunk.get("rc") != other.chunk.get("rc")
+            ):
+                return self.chunk.get("rc") < other.chunk.get("rc")
+            # Compare preview numbers if both have preview
+            if (
+                self.chunk.get("preview")
+                and other.chunk.get("preview")
+                and self.chunk.get("preview") != other.chunk.get("preview")
+            ):
+                return self.chunk.get("preview") < other.chunk.get("preview")
+            # Compare prerelease strings if both have prerelease
+            if (
+                self.chunk.get("prerelease")
+                and other.chunk.get("prerelease")
+                and self.chunk.get("prerelease") != other.chunk.get("prerelease")
+            ):
+                return self.chunk.get("prerelease") < other.chunk.get("prerelease")
 
         # but commitnum > no commitnum at this point
         if self.chunk.get("commitnum") and not other.chunk.get("commitnum"):
@@ -110,6 +138,8 @@ class Version:
             and self.chunk.get("minor") == other.chunk.get("minor")
             and self.chunk.get("micro") == other.chunk.get("micro")
             and self.chunk.get("rc") == other.chunk.get("rc")
+            and self.chunk.get("preview") == other.chunk.get("preview")
+            and self.chunk.get("prerelease") == other.chunk.get("prerelease")
             and self.chunk.get("commitnum") == other.chunk.get("commitnum")
         )
 
@@ -125,6 +155,8 @@ class Version:
                 self.chunk.get("minor"),
                 self.chunk.get("micro"),
                 self.chunk.get("rc"),
+                self.chunk.get("preview"),
+                self.chunk.get("prerelease"),
                 self.chunk.get("commitnum"),
             )
         )

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -427,7 +427,7 @@ class StaticContentHandler:
                 logging.exception("api_v1_last_handler: %s", err)
         return web.json_response(data)
 
-    async def _process_remote_metadata(
+    async def _process_remote_metadata(  # pylint: disable=too-many-locals
         self, request: web.Request, metadata: dict, source: str = "remote"
     ):
         """Common processing for remote metadata submissions"""

--- a/tests/webserver/test_webserver.py
+++ b/tests/webserver/test_webserver.py
@@ -464,7 +464,7 @@ def test_webserver_remote_input_field_whitelisting(getwebserver):  # pylint: dis
         "httpport": 8080,  # Should be filtered out
         "hostname": "testhost",  # Should be filtered out
         "dbid": 12345,  # Should be filtered out
-        "secret": "test_secret",  # Should be filtered out
+        "secret": "test_secret",  # pragma: allowlist secret
     }
 
     req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)

--- a/tests/webserver/test_webserver.py
+++ b/tests/webserver/test_webserver.py
@@ -237,10 +237,12 @@ def test_webserver_remote_input_no_secret(getwebserver):  # pylint: disable=rede
     # Test without secret configured - should accept any request
     test_metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=5)
+    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
     assert req.status_code == 200
     response_data = req.json()
     assert "dbid" in response_data
+    assert "processed_metadata" in response_data
+    assert response_data["processed_metadata"]["artist"] == "Test Artist"
 
 
 @pytest.mark.skipif(
@@ -265,10 +267,13 @@ def test_webserver_remote_input_with_secret(getwebserver):  # pylint: disable=re
     }
 
     # Test with correct secret
-    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=5)
+    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
     assert req.status_code == 200
     response_data = req.json()
     assert "dbid" in response_data
+    assert "processed_metadata" in response_data
+    # Secret should be stripped from processed metadata
+    assert "secret" not in response_data["processed_metadata"]
 
 
 @pytest.mark.skipif(
@@ -293,7 +298,7 @@ def test_webserver_remote_input_invalid_secret(getwebserver):  # pylint: disable
     }
 
     # Test with wrong secret
-    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=5)
+    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
     assert req.status_code == 403
     response_data = req.json()
     assert "error" in response_data
@@ -321,7 +326,7 @@ def test_webserver_remote_input_missing_secret(getwebserver):  # pylint: disable
     }
 
     # Test without secret when required
-    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=5)
+    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
     assert req.status_code == 403
     response_data = req.json()
     assert "error" in response_data
@@ -331,18 +336,21 @@ def test_webserver_remote_input_missing_secret(getwebserver):  # pylint: disable
     sys.platform == "win32",
     reason="Windows SQLite file locking issues with multiprocess webserver",
 )
-def test_webserver_remote_input_wrong_method(getwebserver):  # pylint: disable=redefined-outer-name
-    """test remote input endpoint with wrong HTTP method"""
+def test_webserver_remote_input_get_method(getwebserver):  # pylint: disable=redefined-outer-name
+    """test remote input endpoint with GET method"""
     config, metadb = getwebserver  # pylint: disable=unused-variable
     port = config.cparser.value("weboutput/httpport", type=int)
 
     test_metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    # Test with GET instead of POST
-    req = requests.get(f"http://localhost:{port}/v1/remoteinput", params=test_metadata, timeout=5)
-    assert req.status_code == 405
+    # Test with GET - should now work
+    req = requests.get(f"http://localhost:{port}/v1/remoteinput", params=test_metadata, timeout=30)
+    assert req.status_code == 200
+    response_data = req.json()
+    assert "dbid" in response_data
+    assert "processed_metadata" in response_data
 
-    # Test with PUT instead of POST
+    # Test with PUT - should still return 405
     req = requests.put(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=5)
     assert req.status_code == 405
 
@@ -366,3 +374,96 @@ def test_webserver_remote_input_invalid_json(getwebserver):  # pylint: disable=r
     assert req.status_code == 400
     response_data = req.json()
     assert "error" in response_data
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows SQLite file locking issues with multiprocess webserver",
+)
+def test_webserver_remote_input_null_byte_stripping(getwebserver):  # pylint: disable=redefined-outer-name
+    """test remote input endpoint strips null bytes from string fields"""
+    config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value("weboutput/httpport", type=int)
+
+    # Test data with null bytes (like radiologik sends) - using GET to avoid JSON serialization issues
+    test_metadata = {
+        "artist": "Test Artist",
+        "title": "Test Title",
+        "isrc": "USWB10104747\x00\x00\x00",  # Null bytes at end
+        "filename": "test.mp3",
+    }
+
+    req = requests.get(f"http://localhost:{port}/v1/remoteinput", params=test_metadata, timeout=30)
+    assert req.status_code == 200
+    response_data = req.json()
+    assert "dbid" in response_data
+    assert "processed_metadata" in response_data
+    # Null bytes should be stripped
+    processed_isrc = response_data["processed_metadata"].get("isrc", "")
+    assert "USWB10104747" in processed_isrc
+    assert "\x00" not in processed_isrc
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows SQLite file locking issues with multiprocess webserver",
+)
+def test_webserver_remote_input_field_length_limits(getwebserver):  # pylint: disable=redefined-outer-name
+    """test remote input endpoint enforces field length limits"""
+    config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value("weboutput/httpport", type=int)
+
+    # Test data with oversized field (1000+ characters)
+    very_long_title = "x" * 1500  # Exceeds MAX_FIELD_LENGTH of 1000
+    test_metadata = {
+        "artist": "Test Artist",
+        "title": very_long_title,
+        "filename": "test.mp3",
+    }
+
+    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
+    assert req.status_code == 200
+    response_data = req.json()
+    assert "dbid" in response_data
+    assert "processed_metadata" in response_data
+    # Title should be truncated to 1000 characters
+    assert len(response_data["processed_metadata"]["title"]) == 1000
+    assert response_data["processed_metadata"]["title"] == "x" * 1000
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows SQLite file locking issues with multiprocess webserver",
+)
+def test_webserver_remote_input_field_whitelisting(getwebserver):  # pylint: disable=redefined-outer-name
+    """test remote input endpoint filters out excluded fields"""
+    config, metadb = getwebserver  # pylint: disable=unused-variable
+    port = config.cparser.value("weboutput/httpport", type=int)
+
+    # Test data with fields that should be filtered out
+    test_metadata = {
+        "artist": "Test Artist",
+        "title": "Test Title",
+        "filename": "test.mp3",
+        "httpport": 8080,  # Should be filtered out
+        "hostname": "testhost",  # Should be filtered out
+        "dbid": 12345,  # Should be filtered out
+        "coverimageraw": b"fake_image_data",  # Binary field, should be filtered out
+    }
+
+    req = requests.post(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
+    assert req.status_code == 200
+    response_data = req.json()
+    assert "dbid" in response_data  # Response dbid is different from input dbid
+    assert "processed_metadata" in response_data
+
+    processed = response_data["processed_metadata"]
+    # Allowed fields should be present
+    assert processed["artist"] == "Test Artist"
+    assert processed["title"] == "Test Title"
+
+    # Excluded fields should not be present
+    assert "httpport" not in processed
+    assert "hostname" not in processed
+    assert "coverimageraw" not in processed
+    # Note: input dbid is filtered out, but response has a new dbid from storage

--- a/tests/webserver/test_webserver.py
+++ b/tests/webserver/test_webserver.py
@@ -350,8 +350,15 @@ def test_webserver_remote_input_get_method(getwebserver):  # pylint: disable=red
     assert "dbid" in response_data
     assert "processed_metadata" in response_data
 
+    # Negative test: GET with empty metadata (should still work, just return minimal processed data)
+    req = requests.get(f"http://localhost:{port}/v1/remoteinput", params={}, timeout=30)
+    assert req.status_code == 200
+    response_data = req.json()
+    assert "dbid" in response_data
+    assert "processed_metadata" in response_data
+
     # Test with PUT - should still return 405
-    req = requests.put(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=5)
+    req = requests.put(f"http://localhost:{port}/v1/remoteinput", json=test_metadata, timeout=30)
     assert req.status_code == 405
 
 
@@ -369,11 +376,12 @@ def test_webserver_remote_input_invalid_json(getwebserver):  # pylint: disable=r
         f"http://localhost:{port}/v1/remoteinput",
         data="invalid json",
         headers={"Content-Type": "application/json"},
-        timeout=5,
+        timeout=30,
     )
     assert req.status_code == 400
     response_data = req.json()
     assert "error" in response_data
+    assert response_data["error"] == "Invalid JSON in request body"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary by Sourcery

Improve the remote input API by supporting GET requests, enforcing input validation (length limits, null byte stripping, field whitelisting), returning enriched metadata in responses, and unify processing logic; also enhance path normalization, URL handling, and add comprehensive documentation and tests.

New Features:
- Allow GET requests on the /v1/remoteinput endpoint alongside POST
- Return enriched and filtered processed_metadata in remoteinput responses
- Enforce string field length limits and strip null bytes from remote submissions
- Introduce whitelisting of metadata fields to filter out system and binary data
- Add catch-all 404 handler with logging for unknown endpoints

Enhancements:
- Refactor remote input handling into a common _process_remote_metadata method
- Normalize file paths in songpathsubst using pathlib and apply user-configured quirks
- Make URL normalization in metadata processing resilient to invalid URLs
- Support pathlib.Path objects for tinytag metadata extraction

Documentation:
- Expand remote input API documentation with GET/POST usage, validation rules, and DJ software examples

Tests:
- Add tests for null byte stripping, field length limits, field whitelisting, and GET method support on remoteinput