### PR TITLE
Various Fixes:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,10 @@ except Exception as exc:  # pylint: disable=broad-exception-caught
 
 **Custom Test Scripts:**
 
-If you write a custom test script that instantiates `ConfigFile` directly (outside the pytest framework), you **MUST** call the Qt bootstrap code before creating the config. This ensures proper Qt application initialization and prevents configuration errors.
+If you write a custom test script that instantiates `ConfigFile` directly
+(outside the pytest framework), you **MUST** call the Qt bootstrap code
+before creating the config. This ensures proper Qt application
+initialization and prevents configuration errors.
 
 ```python
 # Required bootstrap for custom test scripts using ConfigFile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,22 @@ except Exception as exc:  # pylint: disable=broad-exception-caught
 - Test both happy path and failure scenarios for production reliability
 - Use meaningful test names that clearly indicate what scenario is being tested
 
+**Custom Test Scripts:**
+
+If you write a custom test script that instantiates `ConfigFile` directly (outside the pytest framework), you **MUST** call the Qt bootstrap code before creating the config. This ensures proper Qt application initialization and prevents configuration errors.
+
+```python
+# Required bootstrap for custom test scripts using ConfigFile
+import nowplaying.bootstrap
+nowplaying.bootstrap.set_qt_names()
+
+# Now safe to use ConfigFile
+from nowplaying.config import ConfigFile
+config = ConfigFile()
+```
+
+This is **NOT** needed for regular pytest tests as the `bootstrap` fixture handles Qt initialization automatically.
+
 **Test Coverage Requirements for Artistextras Plugins:**
 
 Each artistextras plugin should have comprehensive test coverage including:

--- a/nowplaying/notifications/textoutput.py
+++ b/nowplaying/notifications/textoutput.py
@@ -159,15 +159,14 @@ class Plugin(NotificationPlugin):
 
     def verify_settingsui(self, qwidget: "QWidget") -> bool:
         """Verify settings"""
-        # Only validate if both file and template are provided (indicating intent to use)
+        # Only validate if user has configured output file (indicating intent to use)
         output_file = qwidget.textoutput_lineedit.text().strip()
         template_file = qwidget.texttemplate_lineedit.text().strip()
 
-        if output_file:
-            if template_file and not pathlib.Path(template_file).exists():
-                raise PluginVerifyError(f"Template file does not exist: {template_file}")
-        elif template_file:
-            raise PluginVerifyError("Output file path is required when using text output")
+        if output_file and (template_file and not pathlib.Path(template_file).exists()):
+            raise PluginVerifyError(f"Template file does not exist: {template_file}")
+        # If no output file configured, don't require anything regardless of template
+        # (template might be set by default but user doesn't want text output)
         return True
 
     def connect_settingsui(self, qwidget: "QWidget", uihelp):

--- a/nowplaying/serato/base.py
+++ b/nowplaying/serato/base.py
@@ -68,6 +68,8 @@ class SeratoRuleMatchingMixin:  # pylint: disable=too-few-public-methods
             # Additional operators found in practice
             9: "contains",
             10: "is",
+            # Smart crate specific operators
+            23: "greater_than_equal",  # Found in 2010.scrate for aft/bef conditions
         }
 
         return operator_map.get(operator_code, "contains")

--- a/nowplaying/serato/database.py
+++ b/nowplaying/serato/database.py
@@ -92,13 +92,16 @@ class SeratoDatabaseV2Reader(SeratoRuleMatchingMixin, SeratoBaseReader):
     def apply_smart_crate_rules(self, rules: list[dict[str, t.Any]]) -> list[str]:
         """Apply smart crate rules to database tracks and return file paths"""
         if not rules:
+            logging.debug("No rules provided to apply_smart_crate_rules")
             return []
 
+        logging.debug("Applying %d rules to %d tracks", len(rules), len(self.tracks))
         matching_tracks = []
         for track in self.tracks:
             if self._track_matches_rules(track, rules) and track.get("filepath"):
                 matching_tracks.append(track["filepath"])
 
+        logging.debug("Rules matched %d tracks", len(matching_tracks))
         return matching_tracks
 
     def _track_matches_rules(self, track: dict[str, t.Any], rules: list[dict[str, t.Any]]) -> bool:

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -414,6 +414,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         smartcrate_path = pathlib.Path(libpath).joinpath("SmartCrates", f"{playlist_name}.scrate")
 
         if not smartcrate_path.exists():
+            logging.warning("Smart crate file not found: %s", smartcrate_path)
             return False
 
         try:

--- a/nowplaying/serato/smart_crate.py
+++ b/nowplaying/serato/smart_crate.py
@@ -26,6 +26,16 @@ class SeratoSmartCrateReader(SeratoRuleMatchingMixin, SeratoBaseReader):
             {
                 "trft": self._decode_struct,  # Filter conditions
                 "osrt": self._decode_struct,  # Sort conditions
+                "rurt": self._noop,  # Rule data - keep as raw bytes for manual parsing
+            }
+        )
+
+        # Add handlers for null-byte prefixed data (UTF-16 strings in smart crates)
+        self.decode_func_first.update(
+            {
+                "\x00": lambda x: x.decode("utf-16-be", errors="replace").rstrip(
+                    "\x00"
+                ),  # UTF-16 string, strip null terminator
             }
         )
 
@@ -45,10 +55,171 @@ class SeratoSmartCrateReader(SeratoRuleMatchingMixin, SeratoBaseReader):
             return
 
         self.rules = []
+        unsupported_rules = []
+        logging.debug("Parsing smart crate data with %d entries", len(self.smart_crate))
         for tag, value in self.smart_crate:
-            if tag == "trft":  # Filter condition
+            logging.debug("Processing smart crate tag: %s", tag)
+            if tag == "rurt":  # Rule data - contains trft inside
+                if rule := self._parse_rule_from_rurt(value):
+                    if self._is_rule_supported(rule):
+                        self.rules.append(rule)
+                    else:
+                        unsupported_rules.append(rule)
+                        logging.info(
+                            "Skipping unsupported smart crate rule: "
+                            "%s (field '%s' not available in Serato database)",
+                            rule,
+                            rule.get("field"),
+                        )
+            elif tag == "trft":  # Direct filter condition (backup)
                 if rule := self._parse_filter_condition(value):
-                    self.rules.append(rule)
+                    if self._is_rule_supported(rule):
+                        self.rules.append(rule)
+                    else:
+                        unsupported_rules.append(rule)
+                        logging.info(
+                            "Skipping unsupported smart crate rule: "
+                            "%s (field '%s' not available in Serato database)",
+                            rule,
+                            rule.get("field"),
+                        )
+
+        logging.debug(
+            "Total rules parsed: %d supported, %d unsupported",
+            len(self.rules),
+            len(unsupported_rules),
+        )
+        if unsupported_rules:
+            supported_fields = list(self._get_supported_fields())
+            logging.info(
+                "Note: What's Now Playing smart crates support only these fields: %s",
+                ", ".join(supported_fields),
+            )
+
+    @staticmethod
+    def _get_supported_fields() -> set[str]:
+        """Get the set of fields supported by What's Now Playing smart crates
+
+        Based on fields available in Serato database V2 format:
+        ['filepath', 'filename', 'title', 'artist', 'album', 'bpm', 'composer', 'key']
+        """
+        return {
+            # Text fields that can be searched
+            "filename",
+            "title",
+            "artist",
+            "album",
+            "composer",
+            "key",
+            # Numeric fields (though most smart crates use text-style searches)
+            "bpm",
+            # Note: 'filepath' excluded as it's internal path format
+        }
+
+    @staticmethod
+    def _is_rule_supported(rule: dict[str, t.Any]) -> bool:
+        """Check if a smart crate rule can be supported with available database fields"""
+        field = rule.get("field")
+        if not field:
+            return False
+
+        # Map Serato smart crate field names to our database field names
+        field_mapping = {
+            "filename": "filename",
+            "song": "title",  # Serato calls it 'song', we have 'title'
+            "title": "title",
+            "artist": "artist",
+            "album": "album",
+            "bpm": "bpm",
+            "composer": "composer",
+            "key": "key",
+            # Unsupported fields that Serato smart crates might reference:
+            # 'year', 'genre', 'length', 'bitrate', 'comment', 'grouping',
+            # 'label', 'remixer', 'plays', 'added', 'last_played'
+        }
+
+        if mapped_field := field_mapping.get(field):
+            # Update the rule to use our database field name
+            rule["field"] = mapped_field
+            return True
+
+        return False
+
+    def _parse_rule_from_rurt(  # pylint: disable=too-many-branches
+        self, rurt_data: bytes
+    ) -> dict[str, t.Any] | None:
+        """Parse rule from rurt binary data that contains embedded trft"""
+        try:
+            logging.debug("Parsing rurt data: %d bytes", len(rurt_data))
+
+            # Manual parsing of the rurt structure based on hex analysis
+            rule = {"field": None, "operator": None, "value": None, "field_type": None}
+            condition_type = None
+
+            i = 0
+            while i < len(rurt_data):
+                if i + 8 > len(rurt_data):
+                    break
+
+                tag = rurt_data[i : i + 4].decode("ascii", errors="replace")
+                length = int.from_bytes(rurt_data[i + 4 : i + 8], "big")
+                data = rurt_data[i + 8 : i + 8 + length]
+
+                if tag == "trft":
+                    # This should be a UTF-16 string describing the condition type
+                    condition_type = data.decode("utf-16-be", errors="replace").rstrip("\x00")
+
+                    # Map condition types to field names (but don't set operator yet)
+                    if "con_str" in condition_type:
+                        rule["field"] = "filename"  # Contains string in filename
+                        rule["field_type"] = "text"
+                    elif "aft_str" in condition_type:
+                        rule["field"] = "year"
+                        rule["field_type"] = "numeric"
+                    elif "bef_str" in condition_type:
+                        rule["field"] = "year"
+                        rule["field_type"] = "numeric"
+
+                elif tag == "urkt":
+                    # Operator code
+                    if len(data) >= 4:
+                        operator_code = int.from_bytes(data[:4], "big")
+                        # Use existing operator mapping
+                        rule["operator"] = self._get_operator_name(operator_code)
+
+                elif tag == "trpt":
+                    # Value - could be UTF-16 string or numeric
+                    if len(data) > 0:
+                        try:
+                            # Try as UTF-16 first
+                            value = data.decode("utf-16-be", errors="replace").rstrip("\x00")
+                            rule["value"] = value
+                        except (UnicodeDecodeError, UnicodeError):
+                            # If that fails, try as raw bytes
+                            rule["value"] = data.decode("ascii", errors="replace")
+
+                i += 8 + length
+
+            # Override operator based on condition type for date/numeric fields
+            if rule["field"] == "year" and rule["field_type"] == "numeric":
+                if condition_type and "aft_str" in condition_type:
+                    rule["operator"] = "greater_than_equal"
+                elif condition_type and "bef_str" in condition_type:
+                    rule["operator"] = "less_than_equal"
+
+            # Validate rule has all required fields
+            if rule["field"] and rule["value"] and rule["operator"]:
+                return rule
+            missing = [k for k in ("field", "value", "operator") if not rule[k]]
+            logging.warning(
+                "Ignoring malformed smart crate rule due to missing: %s", ", ".join(missing)
+            )
+            return None
+
+        except (struct.error, UnicodeDecodeError, IndexError, ValueError) as err:
+            logging.warning("Failed to parse rule from rurt data: %s", err)
+            logging.debug("Exception details:", exc_info=True)
+            return None
 
     def _parse_filter_condition(
         self, condition_data: list[tuple[str, t.Any]]
@@ -99,3 +270,46 @@ class SeratoSmartCrateReader(SeratoRuleMatchingMixin, SeratoBaseReader):
                 err,
             )
             return None
+
+    async def getfilenames_from_multiple_paths(self, all_libpaths: list[str]) -> list[str] | None:
+        """Get filenames by executing smart crate rules against multiple Serato databases"""
+        if not self.smart_crate:
+            logging.error("smart crate has not been loaded")
+            return None
+
+        if not all_libpaths:
+            return await self.getfilenames()  # Fallback to single path
+
+        all_matching_files = []
+
+        # Process each database path separately to keep memory usage low
+        for libpath in all_libpaths:
+            try:
+                logging.debug("Checking smart crate rules against database: %s", libpath)
+                db_reader = SeratoDatabaseV2Reader(libpath)
+                await db_reader.loaddatabase()
+
+                if db_reader.tracks:
+                    logging.debug(
+                        "Database %s loaded with %d tracks", libpath, len(db_reader.tracks)
+                    )
+                    if matches := db_reader.apply_smart_crate_rules(self.rules):
+                        logging.debug("Found %d matches in database %s", len(matches), libpath)
+                        all_matching_files.extend(matches)
+                    else:
+                        logging.debug("No matches found in database %s", libpath)
+                else:
+                    logging.warning("No tracks found in database %s", libpath)
+
+                # Clear db_reader to free memory before next iteration
+                del db_reader
+
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                logging.error("Failed to load Serato database %s: %s", libpath, err)
+                continue
+
+        logging.debug(
+            "Smart crate found total %d matching files across all databases",
+            len(all_matching_files),
+        )
+        return all_matching_files if all_matching_files else None

--- a/nowplaying/serato/smart_crate.py
+++ b/nowplaying/serato/smart_crate.py
@@ -312,7 +312,8 @@ class SeratoSmartCrateReader(SeratoRuleMatchingMixin, SeratoBaseReader):
         if all_matching_files:
             deduped_files = list(dict.fromkeys(all_matching_files))
             logging.debug(
-                "Smart crate found %d total files (%d unique after deduplication) across all databases",
+                "Smart crate found %d total files"
+                " (%d unique after deduplication) across all databases",
                 len(all_matching_files),
                 len(deduped_files),
             )

--- a/nowplaying/templates/setlist-table.txt
+++ b/nowplaying/templates/setlist-table.txt
@@ -1,1 +1,1 @@
-| {{ artist | truncate(30) | ljust(30) }} | {{ title | truncate(40) | ljust(40) }} |
+| {{ "{:<30}".format((artist | truncate(30)) or "") }} | {{ "{:<40}".format((title | truncate(40)) or "") }} |

--- a/nowplaying/utils/__init__.py
+++ b/nowplaying/utils/__init__.py
@@ -221,8 +221,6 @@ def image2avif(rawdata: bytes | None) -> bytes | None:
     return imgbuffer.getvalue()
 
 
-
-
 def songpathsubst(config: "nowplaying.config.ConfigFile", filename: str) -> str:
     """if needed, change the pathing of a file"""
 
@@ -259,6 +257,7 @@ def songpathsubst(config: "nowplaying.config.ConfigFile", filename: str) -> str:
 
     logging.debug("filename substitution: %s -> %s", origfilename, newname)
     return newname
+
 
 def normalize_text(text: str | None) -> str | None:
     """take a string and genercize it"""

--- a/tests/notifications/test_notifications_textoutput.py
+++ b/tests/notifications/test_notifications_textoutput.py
@@ -232,7 +232,7 @@ def test_textoutput_plugin_save_settingsui():
 
 
 def test_textoutput_plugin_verify_settingsui_missing_file():
-    """test verify_settingsui with missing output file"""
+    """test verify_settingsui with missing output file should now be allowed"""
     config = nowplaying.config.ConfigFile(testmode=True)
     plugin = nowplaying.notifications.textoutput.Plugin(config=config)
 
@@ -243,10 +243,28 @@ def test_textoutput_plugin_verify_settingsui_missing_file():
     mock_widget.texttemplate_lineedit = unittest.mock.Mock()
     mock_widget.texttemplate_lineedit.text.return_value = "/path/to/template.txt"
 
-    with pytest.raises(
-        nowplaying.exceptions.PluginVerifyError, match="Output file path is required"
-    ):
-        plugin.verify_settingsui(mock_widget)
+    # Should not raise an error - template without output file is allowed
+    # (user may have default template but not want text output)
+    result = plugin.verify_settingsui(mock_widget)
+    assert result is True
+
+
+def test_textoutput_plugin_verify_settingsui_new_install_scenario():
+    """test verify_settingsui with typical new install scenario
+    (default template, no output file)"""
+    config = nowplaying.config.ConfigFile(testmode=True)
+    plugin = nowplaying.notifications.textoutput.Plugin(config=config)
+
+    # Mock UI widget simulating new install: default template set, no output file
+    mock_widget = unittest.mock.Mock()
+    mock_widget.textoutput_lineedit = unittest.mock.Mock()
+    mock_widget.textoutput_lineedit.text.return_value = ""  # No output file
+    mock_widget.texttemplate_lineedit = unittest.mock.Mock()
+    mock_widget.texttemplate_lineedit.text.return_value = "basic-plain.txt"  # Default template
+
+    # Should not require output file just because default template exists
+    result = plugin.verify_settingsui(mock_widget)
+    assert result is True
 
 
 def test_textoutput_plugin_verify_settingsui_nonexistent_template():

--- a/tests/notifications/test_notifications_textoutput.py
+++ b/tests/notifications/test_notifications_textoutput.py
@@ -249,6 +249,23 @@ def test_textoutput_plugin_verify_settingsui_missing_file():
     assert result is True
 
 
+def test_textoutput_plugin_verify_settingsui_both_missing():
+    """test verify_settingsui with both output file and template missing"""
+    config = nowplaying.config.ConfigFile(testmode=True)
+    plugin = nowplaying.notifications.textoutput.Plugin(config=config)
+
+    # Mock UI widget with neither output file nor template
+    mock_widget = unittest.mock.Mock()
+    mock_widget.textoutput_lineedit = unittest.mock.Mock()
+    mock_widget.textoutput_lineedit.text.return_value = ""
+    mock_widget.texttemplate_lineedit = unittest.mock.Mock()
+    mock_widget.texttemplate_lineedit.text.return_value = ""
+
+    # Should not raise an error - both missing is allowed (plugin disabled)
+    result = plugin.verify_settingsui(mock_widget)
+    assert result is True
+
+
 def test_textoutput_plugin_verify_settingsui_new_install_scenario():
     """test verify_settingsui with typical new install scenario
     (default template, no output file)"""

--- a/tests/test_serato_hasartist.py
+++ b/tests/test_serato_hasartist.py
@@ -188,17 +188,16 @@ async def test_selected_playlists_scope_multiple_databases(mock_config, temp_ser
 
     # Mock the playlist search across databases
     with unittest.mock.patch.object(plugin, "_has_tracks_in_selected_playlists") as mock_search:
-        mock_search.side_effect = [False, True, False]  # Found in second database
+        mock_search.return_value = True  # Found artist in playlists
 
         result = await plugin.has_tracks_by_artist("Test Artist")
 
         assert result is True
-        assert mock_search.call_count == 2  # Should stop after finding match
+        assert mock_search.call_count == 1  # Called once, handles all databases internally
 
-        # Verify the paths that were searched
-        call_args = [call[0] for call in mock_search.call_args_list]
-        assert call_args[0] == ("Test Artist", temp_serato_dirs["primary"])
-        assert call_args[1] == ("Test Artist", temp_serato_dirs["external"])
+        # Verify the method was called with just the artist name
+        call_args = mock_search.call_args_list[0][0]
+        assert call_args == ("Test Artist",)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* Serato crate/smart crate fixes for hasartist
* Bad Jinja2 template
* notification plugins not getting started
* text output false verification
* tests

## Summary by Sourcery

Enhance Serato smart crate parsing with full rule support and multi-path processing, refactor playlist lookup to unify regular and smart crate checks, ensure notification plugins are started at track poll startup, guard template loading in real-time setlist, relax textoutput settings validation, and update tests and documentation to cover these changes

New Features:
- Support binary ‘rurt’ rule data in smart crates and map Serato fields to internal fields
- Add getfilenames_from_multiple_paths to execute smart crate rules across multiple database paths
- Refactor Serato plugin playlist lookup with helper methods for regular and smart crates across all libraries
- Start notification plugins at track poll startup via new _start_notification_plugins method

Bug Fixes:
- Handle Jinja2 or I/O errors when loading real-time setlist templates and disable plugin on failure
- Relax textoutput plugin verification to allow default templates without requiring an output file

Enhancements:
- Log detailed debug info during smart crate parsing and rule application
- Add support for smart-crate-specific operator code in the Serato operator map
- Improve error handling and logging when starting and notifying notification plugins

Documentation:
- Document Qt bootstrap requirement in CLAUDE.md for custom test scripts using ConfigFile

Tests:
- Add tests for textoutput.verify_settingsui covering missing output file and new-install scenarios