### PR TITLE
fix vdj playlists

### DIFF
--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import sqlite3
 import time
-import xml.etree.ElementTree as ET
 import xml.sax
 from typing import TYPE_CHECKING
 
@@ -62,6 +61,26 @@ class VirtualDJSAXHandler(xml.sax.ContentHandler):
                 datatuple = tuple(self.current_entry.values())
                 self.sqlcursor.execute(sql, datatuple)
             delattr(self, "current_entry")
+
+
+class VirtualDJFolderSAXHandler(xml.sax.ContentHandler):
+    """SAX handler for streaming VirtualDJ .vdjfolder XML parsing"""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.content = []
+
+    def startElement(self, name: str, attrs: dict[str, str]) -> None:
+        if name == "song":
+            song_path = attrs.get("path")
+            artist = attrs.get("artist")
+            title = attrs.get("title")
+
+            if song_path and artist and title:
+                # Apply song path substitution like M3U processing
+                song_path = nowplaying.utils.songpathsubst(self.config, song_path)
+                self.content.append({"filename": song_path, "artist": artist, "title": title})
 
 
 class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
@@ -306,7 +325,8 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
                 datatuple = (playlist, entry, None, None)
             sqlcursor.execute(sql, datatuple)
 
-    def _ensure_playlist_schema(self, cursor):
+    @staticmethod
+    def _ensure_playlist_schema(cursor):
         """Ensure playlist database has the current schema with artist/title columns"""
         try:
             # Check if artist/title columns exist
@@ -318,27 +338,16 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
             cursor.execute("ALTER TABLE playlists ADD COLUMN title TEXT")
 
     def _read_vdjfolder_file(self, filepath):
-        """read VirtualDJ .vdjfolder XML file and extract song metadata"""
-        content = []
+        """read VirtualDJ .vdjfolder XML file and extract song metadata using SAX parser"""
         try:
-            tree = ET.parse(filepath)
-            root = tree.getroot()
+            handler = VirtualDJFolderSAXHandler(self.config)
+            with open(filepath, "r", encoding="utf-8") as xml_file:
+                xml.sax.parse(xml_file, handler)
+            return handler.content
 
-            # Extract song metadata from <song path="..." artist="..." title="..." /> elements
-            for song_element in root.findall("song"):
-                song_path = song_element.get("path")
-                artist = song_element.get("artist")
-                title = song_element.get("title")
-
-                if song_path and artist and title:
-                    # Apply song path substitution like M3U processing
-                    song_path = nowplaying.utils.songpathsubst(self.config, song_path)
-                    content.append({"filename": song_path, "artist": artist, "title": title})
-
-        except (ET.ParseError, OSError) as err:
+        except (xml.sax.SAXException, OSError, UnicodeDecodeError) as err:
             logging.error("Error parsing vdjfolder file %s: %s", filepath, err)
-
-        return content
+            return []
 
     def rewrite_db(self, playlistdir=None):
         """erase and update the old db"""
@@ -384,7 +393,7 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
 
             connection.commit()
 
-    def install(self):
+    def install(self) -> bool:
         """locate Virtual DJ"""
         # Check multiple possible VirtualDJ locations
         possible_locations = [
@@ -479,114 +488,145 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
             )
 
             if scope == "selected_playlists":
-                # Query specific playlists
-                selected_playlists = self.config.cparser.value(
-                    "virtualdj/selected_playlists", defaultValue=""
-                )
-                if not selected_playlists.strip():
-                    return False
+                return await self._has_tracks_in_selected_playlists(artist_name)
 
-                playlist_names = [
-                    name.strip() for name in selected_playlists.split(",") if name.strip()
-                ]
-                if not playlist_names:
-                    return False
-
-                async with aiosqlite.connect(self.playlists_databasefile) as connection:
-                    connection.row_factory = sqlite3.Row
-                    cursor = await connection.cursor()
-
-                    # Use safe parameterized query with fixed number of placeholders
-                    # Limit to reasonable number of playlists to prevent abuse
-                    if len(playlist_names) > 50:
-                        playlist_names = playlist_names[:50]
-
-                    placeholders = ",".join("?" * len(playlist_names))
-
-                    # Check if playlists have artist metadata (vdjfolder entries)
-                    metadata_sql = (
-                        f"SELECT COUNT(*) as count FROM playlists "
-                        f"WHERE name IN ({placeholders}) AND artist IS NOT NULL"
-                    )
-                    await cursor.execute(metadata_sql, playlist_names)
-                    metadata_row = await cursor.fetchone()
-                    has_metadata = metadata_row and metadata_row["count"] > 0
-
-                    logging.debug(
-                        "VDJ hasartist: playlists have metadata=%s, checking artist %s",
-                        has_metadata,
-                        artist_name,
-                    )
-
-                    if has_metadata:
-                        # Fast path: Direct artist query for modern vdjfolder playlists
-                        artist_sql = f"""
-                            SELECT COUNT(*) as count FROM playlists
-                            WHERE name IN ({placeholders}) AND LOWER(artist) = LOWER(?)
-                        """
-                        params = playlist_names + [artist_name]
-                        await cursor.execute(artist_sql, params)
-                        row = await cursor.fetchone()
-
-                        if row and row["count"] > 0:
-                            logging.debug(
-                                "VDJ hasartist: fast path found %d artist matches in playlists",
-                                row["count"],
-                            )
-                            # Trust playlist metadata for modern vdjfolder files
-                            return True
-
-                        logging.debug("VDJ hasartist: fast path found no matches, returning False")
-                        return False
-                    # Legacy path: Filename matching for M3U playlists
-                    logging.debug("VDJ hasartist: using legacy filename matching")
-                    filename_sql = (
-                        f"SELECT DISTINCT filename FROM playlists WHERE name IN ({placeholders})"
-                    )
-                    await cursor.execute(filename_sql, playlist_names)
-                    rows = await cursor.fetchall()
-                    playlist_filenames = {row["filename"] for row in rows if row["filename"]}
-
-                    if not playlist_filenames:
-                        return False
-
-                    # Check songs database for filename matches
-                    async with aiosqlite.connect(self.songs_databasefile) as songs_conn:
-                        songs_conn.row_factory = sqlite3.Row
-                        songs_cursor = await songs_conn.cursor()
-
-                        filename_placeholders = ",".join("?" * len(playlist_filenames))
-                        songs_sql = f"""
-                            SELECT COUNT(*) as count FROM songs
-                            WHERE LOWER(artist) = LOWER(?) AND filename IN ({filename_placeholders})
-                        """
-                        params = [artist_name] + list(playlist_filenames)
-                        await songs_cursor.execute(songs_sql, params)
-                        row = await songs_cursor.fetchone()
-
-                        result = row and row["count"] > 0
-                        logging.debug(
-                            "VDJ hasartist: legacy path found %d matches, returning %s",
-                            row["count"] if row else 0,
-                            result,
-                        )
-                        return result
-            else:
-                # Query entire library
-                async with aiosqlite.connect(self.songs_databasefile) as connection:
-                    connection.row_factory = sqlite3.Row
-                    cursor = await connection.cursor()
-
-                    await cursor.execute(
-                        "SELECT COUNT(*) as count FROM songs WHERE LOWER(artist) = LOWER(?)",
-                        (artist_name,),
-                    )
-                    row = await cursor.fetchone()
-                    return row["count"] > 0 if row else False
+            return await self._has_tracks_in_entire_library(artist_name)
 
         except sqlite3.OperationalError as err:
             logging.error("Failed to query VirtualDJ database for artist %s: %s", artist_name, err)
             return False
+
+    async def _has_tracks_in_entire_library(self, artist_name: str) -> bool:
+        """Check if artist has tracks in the entire library"""
+        async with aiosqlite.connect(self.songs_databasefile) as connection:
+            connection.row_factory = sqlite3.Row
+            cursor = await connection.cursor()
+
+            await cursor.execute(
+                "SELECT COUNT(*) as count FROM songs WHERE LOWER(artist) = LOWER(?)",
+                (artist_name,),
+            )
+            row = await cursor.fetchone()
+            return row["count"] > 0 if row else False
+
+    async def _has_tracks_in_selected_playlists(self, artist_name: str) -> bool:
+        """Check if artist has tracks in selected playlists"""
+        playlist_names = self._get_selected_playlist_names()
+        if not playlist_names:
+            return False
+
+        async with aiosqlite.connect(self.playlists_databasefile) as connection:
+            connection.row_factory = sqlite3.Row
+            cursor = await connection.cursor()
+
+            # Limit to reasonable number of playlists to prevent abuse
+            if len(playlist_names) > 50:
+                playlist_names = playlist_names[:50]
+
+            placeholders = ",".join("?" * len(playlist_names))
+
+            # Check if playlists have artist metadata (vdjfolder entries)
+            has_metadata = await self._playlists_have_metadata(
+                cursor, playlist_names, placeholders
+            )
+
+            logging.debug(
+                "VDJ hasartist: playlists have metadata=%s, checking artist %s",
+                has_metadata,
+                artist_name,
+            )
+
+            if has_metadata:
+                return await self._check_artist_in_playlist_metadata(
+                    cursor, artist_name, playlist_names, placeholders
+                )
+
+            return await self._check_artist_via_filename_matching(
+                cursor, artist_name, playlist_names, placeholders
+            )
+
+    def _get_selected_playlist_names(self) -> list[str]:
+        """Get the list of selected playlist names from configuration"""
+        selected_playlists = self.config.cparser.value(
+            "virtualdj/selected_playlists", defaultValue=""
+        )
+        if not selected_playlists.strip():
+            return []
+
+        playlist_names = [name.strip() for name in selected_playlists.split(",") if name.strip()]
+        return playlist_names
+
+    @staticmethod
+    async def _playlists_have_metadata(
+        cursor, playlist_names: list[str], placeholders: str
+    ) -> bool:
+        """Check if playlists have artist metadata (vdjfolder entries)"""
+        metadata_sql = (
+            f"SELECT COUNT(*) as count FROM playlists "
+            f"WHERE name IN ({placeholders}) AND artist IS NOT NULL"
+        )
+        await cursor.execute(metadata_sql, playlist_names)
+        metadata_row = await cursor.fetchone()
+        return metadata_row and metadata_row["count"] > 0
+
+    @staticmethod
+    async def _check_artist_in_playlist_metadata(
+        cursor, artist_name: str, playlist_names: list[str], placeholders: str
+    ) -> bool:
+        """Fast path: Direct artist query for modern vdjfolder playlists"""
+        artist_sql = f"""
+            SELECT COUNT(*) as count FROM playlists
+            WHERE name IN ({placeholders}) AND LOWER(artist) = LOWER(?)
+        """
+        params = playlist_names + [artist_name]
+        await cursor.execute(artist_sql, params)
+        row = await cursor.fetchone()
+
+        if row and row["count"] > 0:
+            logging.debug(
+                "VDJ hasartist: fast path found %d artist matches in playlists",
+                row["count"],
+            )
+            return True
+
+        logging.debug("VDJ hasartist: fast path found no matches, returning False")
+        return False
+
+    async def _check_artist_via_filename_matching(
+        self, cursor, artist_name: str, playlist_names: list[str], placeholders: str
+    ) -> bool:
+        """Legacy path: Filename matching for M3U playlists"""
+        logging.debug("VDJ hasartist: using legacy filename matching")
+        # Get playlist filenames
+        filename_sql = f"SELECT DISTINCT filename FROM playlists WHERE name IN ({placeholders})"
+        await cursor.execute(filename_sql, playlist_names)
+        rows = await cursor.fetchall()
+        playlist_filenames = {row["filename"] for row in rows if row["filename"]}
+
+        if not playlist_filenames:
+            return False
+
+        # Check songs database for filename matches
+        async with aiosqlite.connect(self.songs_databasefile) as songs_conn:
+            songs_conn.row_factory = sqlite3.Row
+            songs_cursor = await songs_conn.cursor()
+
+            filename_placeholders = ",".join("?" * len(playlist_filenames))
+            songs_sql = f"""
+                SELECT COUNT(*) as count FROM songs
+                WHERE LOWER(artist) = LOWER(?) AND filename IN ({filename_placeholders})
+            """
+            params = [artist_name] + list(playlist_filenames)
+            await songs_cursor.execute(songs_sql, params)
+            row = await songs_cursor.fetchone()
+
+            result = row and row["count"] > 0
+            logging.debug(
+                "VDJ hasartist: legacy path found %d matches, returning %s",
+                row["count"] if row else 0,
+                result,
+            )
+            return result
 
     def defaults(self, qsettings):
         """(re-)set the default configuration values for this plugin"""

--- a/tests/test_has_tracks_by_artist.py
+++ b/tests/test_has_tracks_by_artist.py
@@ -42,6 +42,15 @@ TEST_PLAYLISTS = [
     ("Electronic", "/music/bjork1.flac"),
 ]
 
+# Extended playlist data with artist/title metadata (for modern .vdjfolder format)
+TEST_PLAYLISTS_WITH_METADATA = [
+    ("House", "/music/nin1.flac", "Nine Inch Nails", "Head Like a Hole"),
+    ("House", "/music/beatles1.flac", "The Beatles", "Hey Jude"),
+    ("Techno", "/music/nin2.flac", "Nine Inch Nails", "Closer"),
+    ("Electronic", "/music/uziq1.flac", "µ-Ziq", "Hasty Boom Alert"),
+    ("Electronic", "/music/bjork1.flac", "Björk", "Human Behaviour"),
+]
+
 
 @pytest.fixture
 def traktor_database():
@@ -212,14 +221,17 @@ def virtualdj_databases():
                 CREATE TABLE playlists (
                     id INTEGER PRIMARY KEY,
                     name TEXT,
-                    filename TEXT
+                    filename TEXT,
+                    artist TEXT,
+                    title TEXT
                 )
             """)
 
-            for playlist_name, filename in TEST_PLAYLISTS:
+            # Insert modern vdjfolder-style playlists with metadata
+            for playlist_name, filename, artist, title in TEST_PLAYLISTS_WITH_METADATA:
                 connection.execute(
-                    "INSERT INTO playlists (name, filename) VALUES (?, ?)",
-                    (playlist_name, filename),
+                    "INSERT INTO playlists (name, filename, artist, title) VALUES (?, ?, ?, ?)",
+                    (playlist_name, filename, artist, title),
                 )
             connection.commit()
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for VirtualDJ .vdjfolder playlists by extracting and storing artist/title metadata, upgrading the playlist schema, and refactoring ingestion and lookup logic to leverage this metadata with a legacy fallback

New Features:
- Introduce VirtualDJFolderSAXHandler to parse .vdjfolder XML files and extract filename, artist, and title

Enhancements:
- Extend the playlists database schema with artist and title columns and migrate existing data
- Process both .m3u and .vdjfolder files when building or rewriting playlists, inserting metadata when available
- Refactor has_tracks_by_artist into helper methods to use metadata for fast artist lookups and fall back to legacy filename matching

Tests:
- Update has_tracks_by_artist tests to include and validate playlist entries with artist/title metadata