### PR TITLE
Fix test_upgrade_same to use copytree not copyfile

### DIFF
--- a/tests/test_upgradetemplates.py
+++ b/tests/test_upgradetemplates.py
@@ -149,9 +149,13 @@ def test_upgrade_same(upgrade_bootstrap):  # pylint: disable=redefined-outer-nam
     destdir = os.path.join(testpath, "testsuite", "templates")
     srctemplates = os.listdir(srcdir)
     pathlib.Path(destdir).mkdir(parents=True, exist_ok=True)
-    shutil.copytree(
-        os.path.join(srcdir, srctemplates[1]),
-        os.path.join(destdir, os.path.basename(srctemplates[1])),
+    num = 1
+    if srctemplates[num] == "vendor":
+        num = 2
+    print(srctemplates[num])
+    shutil.copyfile(
+        os.path.join(srcdir, srctemplates[num]),
+        os.path.join(destdir, os.path.basename(srctemplates[num])),
     )
     nowplaying.upgrades.templates.UpgradeTemplates(bundledir=bundledir, testdir=testpath)
     compare_content(srcdir, destdir)

--- a/tests/test_upgradetemplates.py
+++ b/tests/test_upgradetemplates.py
@@ -149,7 +149,7 @@ def test_upgrade_same(upgrade_bootstrap):  # pylint: disable=redefined-outer-nam
     destdir = os.path.join(testpath, "testsuite", "templates")
     srctemplates = os.listdir(srcdir)
     pathlib.Path(destdir).mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(
+    shutil.copytree(
         os.path.join(srcdir, srctemplates[1]),
         os.path.join(destdir, os.path.basename(srctemplates[1])),
     )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change test_upgrade_same to use shutil.copytree instead of shutil.copyfile to copy template directories