### PR TITLE
minor tweak

### DIFF
--- a/nowplaying/hostmeta.py
+++ b/nowplaying/hostmeta.py
@@ -88,9 +88,8 @@ def gethostmeta() -> dict[str, str | None]:
     """resolve hostname/ip of this machine"""
     global TIMESTAMP  # pylint: disable=global-statement
 
-    logging.debug("Attempting to get DNS information")
-
     if not TIMESTAMP or (datetime.datetime.now() - TIMESTAMP > TIMEDELTA) or not HOSTNAME:
+        logging.debug("Attempting to get DNS information")
         trysocket()
         # sourcery skip: hoist-repeated-if-condition
         if not HOSTIP and IFACES:

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -281,7 +281,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         if not self.metadata:
             return None
 
-        if not self.config.cparser.value("musicbrainz/enabled"):
+        if not self.config.cparser.value("musicbrainz/enabled", type=bool):
             logging.debug("Skipping MusicBrainz lookup - disabled")
             return
 
@@ -306,7 +306,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
     async def _mb_fallback(self) -> None:
         """at least see if album can be found"""
 
-        if not self.config.cparser.value("musicbrainz/enabled"):
+        if not self.config.cparser.value("musicbrainz/enabled", type=bool):
             logging.debug("Skipping MusicBrainz fallback lookup - disabled")
             return
 
@@ -345,7 +345,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         if not self.metadata:
             return
 
-        if not self.config.cparser.value("musicbrainz/enabled"):
+        if not self.config.cparser.value("musicbrainz/enabled", type=bool):
             logging.debug("Skipping youtube fallback lookup - disabled")
             return None
 

--- a/nowplaying/metadata.py
+++ b/nowplaying/metadata.py
@@ -281,6 +281,10 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         if not self.metadata:
             return None
 
+        if not self.config.cparser.value("musicbrainz/enabled"):
+            logging.debug("Skipping MusicBrainz lookup - disabled")
+            return
+
         # Check if we already have key MusicBrainz data to avoid unnecessary lookups
         if (
             self.metadata.get("musicbrainzartistid")
@@ -301,6 +305,10 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
 
     async def _mb_fallback(self) -> None:
         """at least see if album can be found"""
+
+        if not self.config.cparser.value("musicbrainz/enabled"):
+            logging.debug("Skipping MusicBrainz fallback lookup - disabled")
+            return
 
         addmeta = {}
         # user does not want fallback support
@@ -336,6 +344,11 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
     ) -> None:
         if not self.metadata:
             return
+
+        if not self.config.cparser.value("musicbrainz/enabled"):
+            logging.debug("Skipping youtube fallback lookup - disabled")
+            return None
+
         addmeta2 = copy.deepcopy(self.metadata)
         artist, title = self.metadata["title"].split(" - ")
         addmeta2["artist"] = artist.strip()

--- a/tests/webserver/test_webserver_consolidated.py
+++ b/tests/webserver/test_webserver_consolidated.py
@@ -256,7 +256,7 @@ async def test_webserver_remote_input_validation(getwebserver):
             "httpport": 8080,  # Should be filtered out
             "hostname": "testhost",  # Should be filtered out
             "dbid": 12345,  # Should be filtered out
-            "secret": "test_secret",   # pragma: allowlist secret
+            "secret": "test_secret",  # pragma: allowlist secret
         }
         async with session.post(
             f"http://localhost:{port}/v1/remoteinput",


### PR DESCRIPTION
## Summary by Sourcery

Add configuration gating to MusicBrainz metadata lookups, refine DNS logging placement, and clean up test formatting

Enhancements:
- Skip MusicBrainz lookups and fallbacks when the 'musicbrainz/enabled' config flag is false
- Move DNS debug logging to only occur during host metadata refresh in gethostmeta

Tests:
- Adjust whitespace in the secret allowlist comment in the remoteinput test