### PR TITLE
fix kick key expiry on refresh timeout

### DIFF
--- a/nowplaying/kick/oauth2.py
+++ b/nowplaying/kick/oauth2.py
@@ -11,6 +11,7 @@ import requests
 import nowplaying.config
 import nowplaying.kick.constants
 import nowplaying.oauth2
+import nowplaying.utils
 
 
 class KickOAuth2(nowplaying.oauth2.OAuth2Client):
@@ -31,9 +32,10 @@ class KickOAuth2(nowplaying.oauth2.OAuth2Client):
         url = nowplaying.kick.constants.TOKEN_INTROSPECT_ENDPOINT
         headers = {"Authorization": f"Bearer {token}"}
 
-        async with aiohttp.ClientSession() as session:
+        connector = nowplaying.utils.create_http_connector()
+        async with aiohttp.ClientSession(connector=connector) as session:
             async with session.post(
-                url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=15)
             ) as response:
                 if response.status == 200:
                     validation_response = await response.json()
@@ -121,7 +123,8 @@ class KickOAuth2(nowplaying.oauth2.OAuth2Client):
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-        async with aiohttp.ClientSession() as session:
+        connector = nowplaying.utils.create_http_connector()
+        async with aiohttp.ClientSession(connector=connector) as session:
             async with session.post(
                 revoke_url, params=params, headers=headers, timeout=aiohttp.ClientTimeout(total=30)
             ) as response:

--- a/nowplaying/kick/utils.py
+++ b/nowplaying/kick/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """kick utils"""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -60,6 +61,10 @@ async def attempt_token_refresh(config: nowplaying.config.ConfigFile) -> bool:
                 raise
         logging.debug("No refresh_token available")
 
+    except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError) as error:
+        # Network timeout - assume token is still valid, just couldn't verify
+        logging.warning("Token validation timed out, assuming token is still valid: %s", error)
+        return True
     except Exception as error:  # pylint: disable=broad-except
         logging.exception("Token refresh failed: %s", error)
 


### PR DESCRIPTION
## Summary by Sourcery

Improve HTTP request handling in KickOAuth2 by introducing a reusable connector, extending timeout for token introspection, and gracefully handling timeout errors during token refresh

Bug Fixes:
- Handle network timeouts and cancellations during token refresh by treating the token as still valid to prevent premature expiry

Enhancements:
- Use a custom HTTP connector for KickOAuth2 token validation and revocation requests
- Increase token introspection timeout from 10 to 15 seconds