### PR TITLE
Cleanup Serato 4.x a bit

### DIFF
--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -359,7 +359,8 @@ async def test_ignores_closed_sessions(bootstrap, serato_master_db):  # pylint: 
         with nowplaying.utils.sqlite.sqlite_connection(serato_master_db["db_path"]) as conn:
             # Insert closed session (end_time != -1)
             conn.execute(
-                "INSERT INTO history_session (id, start_time, end_time, file_name) VALUES (2, ?, ?, 'old_session.txt')",
+                "INSERT INTO history_session (id, start_time, end_time, file_name) "
+                "VALUES (2, ?, ?, 'old_session.txt')",
                 (1693125000, 1693125600),  # Closed session (ended 10 min after start)
             )
 

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -370,7 +370,7 @@ async def test_ignores_closed_sessions(bootstrap, serato_master_db):  # pylint: 
                 (id, session_id, file_name, artist, name, album, genre, bpm, key, year,
                  length_sec, start_time, played, deck, file_size,
                  file_sample_rate, file_bit_rate)
-                VALUES (99, 2, '/music/old_track.mp3', 'Old Artist', 'Old Track', 'Old Album', 
+                VALUES (99, 2, '/music/old_track.mp3', 'Old Artist', 'Old Track', 'Old Album',
                         'Rock', 140.0, 'Am', '2020', 200, ?, 1, '1', 6000000, 44100.0, 320.0)
             """,
                 (1693125000 + 60,),  # Track from closed session


### PR DESCRIPTION
## Summary by Sourcery

Clean up Serato 4.x integration by introducing query caching, optimizing SQL for per-deck track selection, removing redundant change-detection methods, and adding a test to ignore closed sessions

New Features:
- Introduce caching mechanism in Serato handler to reduce database queries
- Optimize SQL query in Serato reader using window functions for per-deck track lookup

Bug Fixes:
- Ignore tracks from closed Serato sessions (end_time != -1)

Enhancements:
- Refactor handler logic to remove `_async_check_track_change` and inline refresh logic
- Apply deck skip filtering in-memory instead of at the SQL level

Tests:
- Add test to verify closed sessions are ignored by the plugin