### PR TITLE
acoustid incorrect albumid

### DIFF
--- a/nowplaying/notifications/charts.py
+++ b/nowplaying/notifications/charts.py
@@ -98,7 +98,7 @@ class Plugin(NotificationPlugin):  # pylint: disable=too-many-instance-attribute
         config: "nowplaying.config.ConfigFile | None" = None,
         qsettings: "QWidget | None" = None,
     ):
-        self.debug = False  # Initialize before super() since defaults() needs it
+        self.debug = True  # Initialize before super() since defaults() needs it
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Charts"
         self.enabled = True  # Default enabled

--- a/nowplaying/notifications/charts.py
+++ b/nowplaying/notifications/charts.py
@@ -98,7 +98,7 @@ class Plugin(NotificationPlugin):  # pylint: disable=too-many-instance-attribute
         config: "nowplaying.config.ConfigFile | None" = None,
         qsettings: "QWidget | None" = None,
     ):
-        self.debug = True  # Initialize before super() since defaults() needs it
+        self.debug = False  # Initialize before super() since defaults() needs it
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Charts"
         self.enabled = True  # Default enabled

--- a/nowplaying/recognition/acoustid.py
+++ b/nowplaying/recognition/acoustid.py
@@ -242,7 +242,7 @@ class Plugin(RecognitionPlugin):
                         if artistidlist:
                             newdata["musicbrainzartistid"] = artistidlist
                         if release.get("id"):
-                            newdata["musicbrainzalbumid"] = [release["id"]]
+                            newdata["musicbrainzalbumid"] = release["id"]
                         lastscore = score
 
         for key, value in newdata.items():

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -295,7 +295,7 @@ async def test_update_ipc_with_musicbrainz_cover_art(discord_support):
     metadata = {
         "title": "Test Song",
         "artist": "Test Artist",
-        "musicbrainzalbumid": ["12345678-1234-1234-1234-123456789abc"],
+        "musicbrainzalbumid": "12345678-1234-1234-1234-123456789abc",
     }
 
     await discord_support._update_ipc("test message", metadata)


### PR DESCRIPTION
## Summary by Sourcery

Enable debug mode for Charts, correct the musicbrainz album ID format in AcoustID integration to be a string, and update tests to match the new format

Bug Fixes:
- Fix musicbrainz album ID assignment in AcoustID results to use a string instead of a list

Enhancements:
- Enable debug mode by default for the Charts notification plugin

Tests:
- Update Discord IPC tests to expect musicbrainzalbumid as a string rather than a list