### PR TITLE
functools lastditchrid

### DIFF
--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -1,4 +1,5 @@
 # 6.5.x's rcc is broken on macos
+aiocache=0.12.3
 aiofiles==24.1.0
 aiohttp==3.12.15
 aiosqlite==0.21.0

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -1,5 +1,5 @@
 # 6.5.x's rcc is broken on macos
-aiocache=0.12.3
+aiocache==0.12.3
 aiofiles==24.1.0
 aiohttp==3.12.15
 aiosqlite==0.21.0


### PR DESCRIPTION
## Summary by Sourcery

Add a cached last-ditch MusicBrainz recording ID lookup and improve metadata cleanup in YouTube fallbacks.

New Features:
- Introduce _lastditchrid and its cached counterpart to perform a fallback lookup for missing MusicBrainz recording IDs

Enhancements:
- Refactor search logic to iterate over artist name variations and consolidate metadata preparation for compatibility with the _pickarecording helper
- Add a 5-minute TTL cache to throttle repeated recording lookups
- Enhance the YouTube fallback to strip extraneous video suffixes from titles using configurable regex rules before performing the lookup