### PR TITLE
document the generic template support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     * Revamped old templates to remove some sizing and background issues with OBS
     * New templates that mirror the boring templates everyone else uses
     * New templates with new special effects
+    * All templates may now be referenced by name (e.g, `/template.htm` -> `/templates/template.htm`)
     * ws-gifwords-fade.htm to show GifWords requests
     * ws-justthecover.htm to cycle through all of the front covers
     * Bundled copies of some common libraries available via the `/vendor` endpoint

--- a/docs/output/webserver.md
+++ b/docs/output/webserver.md
@@ -46,6 +46,10 @@ the OBS source wherever you would like.
 | /index.txt | Same output as the text output in the General settings. |
 | /cover.png | This URL will return the cover image, if available. |
 | /httpstatic/ | Any content in\`Documents/NowPlaying/httpstatic\` will get served under this URL. |
+| /template.htm | Any template.htm file in the templates directory. See below. |
+
+Additionally, referencing `/<templatename>.htm` will also read `template.htm`  from the `templates` directory and
+render it.  This feature allows you to use more than one template at a time for advanced setups.
 
 See also [Artist Extras](../extras/index.md) for other URLs when that
 set of features is enabled.


### PR DESCRIPTION
## Summary by Sourcery

Document generic template support in the webserver output and update the changelog to reflect named template routing

New Features:
- Allow referencing any template in the templates directory via the /<template_name>.htm endpoint

Documentation:
- Add documentation for /<template_name>.htm template routing in the webserver output guide
- Update CHANGELOG to note that templates can now be referenced by name