### PR TITLE
web server fix, serato fix, spec file fix

### DIFF
--- a/NowPlaying.spec
+++ b/NowPlaying.spec
@@ -31,7 +31,7 @@ def collect_all_nowplaying_modules():
             init_file = os.path.join(subdir_path, '__init__.py')
 
             if os.path.isdir(subdir_path) and os.path.exists(init_file):
-                # Skip vendor directory and other non-plugin directories
+                # Skip non-plugin directories
                 if item not in ['vendor', '__pycache__', 'htmlcov']:
                     plugin_packages.append(f'nowplaying.{item}')
 
@@ -146,7 +146,10 @@ for execname, execpy in executables.items():
                  hiddenimports=ALL_PLUGIN_MODULES,
                  hookspath=[('nowplaying/__pyinstaller')],
                  runtime_hooks=[],
-                 excludes=[],
+                 excludes=[
+                     'tkinter', '_tkinter', 'Tkinter',
+                     'tcl', 'tk', '_tcl', '_tk',
+                 ],
                  win_no_prefer_redirects=False,
                  win_private_assemblies=False,
                  cipher=block_cipher,

--- a/nowplaying/serato/handler.py
+++ b/nowplaying/serato/handler.py
@@ -53,7 +53,7 @@ class Serato4Handler:  # pylint: disable=too-many-instance-attributes
         logging.debug("setting up watcher")
         self.event_handler = PatternMatchingEventHandler(
             patterns=["master*"],
-            ignore_patterns=[".DS_Store"],
+            ignore_patterns=[".DS_Store", "*.sqlite-shm"],
             ignore_directories=True,
             case_sensitive=False,
         )

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -127,7 +127,7 @@ class StaticContentHandler:
         template_path = config.templatedir.joinpath(template_name)
 
         if not template_path.exists():
-            logging.debug("Cannot load %s as a template", template_path.absolute)
+            logging.debug("Cannot load %s as a template", template_path.absolute())
             return web.Response(status=404, text="Template not found")
 
         try:

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -124,9 +124,10 @@ class StaticContentHandler:
             return web.Response(status=403, text="Invalid template name")
 
         config = request.app[self.config_key]
-        template_path = config.getbundledir().joinpath("templates", template_name)
+        template_path = config.templatedir.joinpath(template_name)
 
         if not template_path.exists():
+            logging.debug("Cannot load %s as a template", template_path.absolute)
             return web.Response(status=404, text="Template not found")
 
         try:


### PR DESCRIPTION
actually fixes #1331

## Summary by Sourcery

Improve packaging, template handling, and file watching by updating the spec file, webserver static handler, and Serato handler ignore patterns

Bug Fixes:
- Use config.templatedir instead of getbundledir for locating webserver templates
- Add debug logging when a template file is missing
- Ignore SQLite shared-memory files (*.sqlite-shm) in the Serato handler watcher

Enhancements:
- Exclude tkinter and related modules in the PyInstaller spec to streamline packaging

Chores:
- Simplify comment for skipping non-plugin directories in the spec file