### PR TITLE
send a version when requesting a charts key

### DIFF
--- a/nowplaying/notifications/charts.py
+++ b/nowplaying/notifications/charts.py
@@ -13,7 +13,7 @@ import aiohttp
 from PySide6.QtCore import QStandardPaths  # pylint: disable=import-error, no-name-in-module
 
 import nowplaying.db
-import nowplaying.version
+import nowplaying.version  # pylint: disable=no-name-in-module,import-error
 from nowplaying.types import TrackMetadata
 
 from . import NotificationPlugin
@@ -53,7 +53,7 @@ def generate_anonymous_key(debug: bool = False) -> str | None:
     )
 
     try:
-        data = json.dumps({"version": nowplaying.version.__VERSION__}).encode("utf-8")
+        data = json.dumps({"version": nowplaying.version.__VERSION__}).encode("utf-8")  # pylint: disable=no-member
         request = urllib.request.Request(url, data=data, method="POST")
         request.add_header("Content-Type", "application/json")
 
@@ -423,7 +423,7 @@ class Plugin(NotificationPlugin):  # pylint: disable=too-many-instance-attribute
 
         try:
             session = await self._get_session()
-            data = {"version": nowplaying.version.__VERSION__}
+            data = {"version": nowplaying.version.__VERSION__}  # pylint: disable=no-member
             async with session.post(
                 url, json=data, headers={"Content-Type": "application/json"}
             ) as response:

--- a/nowplaying/notifications/charts.py
+++ b/nowplaying/notifications/charts.py
@@ -13,6 +13,7 @@ import aiohttp
 from PySide6.QtCore import QStandardPaths  # pylint: disable=import-error, no-name-in-module
 
 import nowplaying.db
+import nowplaying.version
 from nowplaying.types import TrackMetadata
 
 from . import NotificationPlugin
@@ -52,7 +53,8 @@ def generate_anonymous_key(debug: bool = False) -> str | None:
     )
 
     try:
-        request = urllib.request.Request(url, method="POST")
+        data = json.dumps({"version": nowplaying.version.__VERSION__}).encode("utf-8")
+        request = urllib.request.Request(url, data=data, method="POST")
         request.add_header("Content-Type", "application/json")
 
         with urllib.request.urlopen(request, timeout=10) as response:
@@ -421,7 +423,10 @@ class Plugin(NotificationPlugin):  # pylint: disable=too-many-instance-attribute
 
         try:
             session = await self._get_session()
-            async with session.post(url) as response:
+            data = {"version": nowplaying.version.__VERSION__}
+            async with session.post(
+                url, json=data, headers={"Content-Type": "application/json"}
+            ) as response:
                 if response.status == 200:
                     try:
                         result = await response.json()

--- a/tests/test_metadata_multi_artist.py
+++ b/tests/test_metadata_multi_artist.py
@@ -108,11 +108,12 @@ COLLABORATION_CASES = [
     ("A$AP Rocky, Tyler, The Creator", ["A$AP Rocky", "Tyler, The Creator"]),
 ]
 
+
 @pytest.mark.parametrize("artist_string,expected", SPLITTING_TEST_CASES)
 @pytest.mark.asyncio
 async def test_split_artist_string(bootstrap, artist_string, expected):
     """Test artist string splitting with various formats"""
-    await asyncio.sleep(.5)
+    await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
     helper = nowplaying.musicbrainz.helper.MusicBrainzHelper(config=config)
@@ -124,12 +125,13 @@ async def test_split_artist_string(bootstrap, artist_string, expected):
 @pytest.mark.asyncio
 async def test_split_artist_string_edge_cases(bootstrap, artist_string, expected):
     """Test artist string splitting edge cases"""
-    await asyncio.sleep(.5)
+    await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
     helper = nowplaying.musicbrainz.helper.MusicBrainzHelper(config=config)
     result = helper._split_artist_string(artist_string)
     assert result == expected
+
 
 @pytest.mark.asyncio
 async def test_collaboration_delimiters_constant():
@@ -153,11 +155,12 @@ async def test_collaboration_delimiters_constant():
     )
     assert list(COLLABORATION_DELIMITERS_BY_PRIORITY) == all_delimiters
 
+
 @pytest.mark.parametrize("artist_string,expected", DJ_COLLABORATION_CASES)
 @pytest.mark.asyncio
 async def test_dj_collaboration_formats(bootstrap, artist_string, expected):
     """Test common DJ/electronic music collaboration formats"""
-    await asyncio.sleep(.5)
+    await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
     helper = nowplaying.musicbrainz.helper.MusicBrainzHelper(config=config)
@@ -289,7 +292,7 @@ async def test_integration_hierarchical_breakdown(bootstrap):
 @pytest.mark.asyncio
 async def test_integration_single_artists_not_split(bootstrap, artist_name):
     """Test that single artists containing delimiters are not split when found in MusicBrainz"""
-    await asyncio.sleep(.5)
+    await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
     processor = nowplaying.metadata.MetadataProcessors(config=config)
@@ -338,7 +341,7 @@ async def test_integration_single_artists_not_split(bootstrap, artist_name):
 @pytest.mark.asyncio
 async def test_integration_collaborations_split(bootstrap, collaboration, expected_artists):
     """Test that collaborations are properly split when individual artists exist in MusicBrainz"""
-    await asyncio.sleep(.5)
+    await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
     processor = nowplaying.metadata.MetadataProcessors(config=config)


### PR DESCRIPTION
## Summary by Sourcery

Add version information to charts key requests and clean up sleep duration formatting in tests

New Features:
- Include application version in the JSON payload when requesting an anonymous charts key using both synchronous and asynchronous HTTP calls

Enhancements:
- Standardize asyncio.sleep calls in tests to use explicit float notation (0.5)