### PR TITLE
fix doc links for guess game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     * Klipy is preferred when both API keys are configured
   * Add support for autodiscovery using Bonjour/Zeroconf for Remote Output and for
     some upcoming feature support
+  * Add a new guessing game based upon the current track
 
 * Serato
   * Add artist-based library query support for Serato 4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - Discord: output/discord.md
       - Kick Bot: output/kickbot.md
       - Twitch Bot: output/twitchbot.md
+      - Guess Game: output/guessgame.md
   - Requests: requests.md
   - Help:
       - Overview: help/index.md


### PR DESCRIPTION
## Summary by Sourcery

Document the new guessing game feature and link it into the docs navigation.

Documentation:
- Mention the new guessing game feature in the changelog.
- Add the Guess Game page to the documentation navigation.