### PR TITLE
join location path with asset and history for full filename

### DIFF
--- a/nowplaying/resources/inputs_serato_library_ui.ui
+++ b/nowplaying/resources/inputs_serato_library_ui.ui
@@ -111,55 +111,29 @@
      <x>10</x>
      <y>110</y>
      <width>621</width>
-     <height>120</height>
+     <height>100</height>
     </rect>
    </property>
    <property name="title">
-    <string>Additional Library Paths</string>
+    <string>Library Paths (Auto-Discovered)</string>
    </property>
-   <widget class="QTextEdit" name="additional_libs_textedit">
+   <widget class="QLabel" name="autodiscovery_status_label">
     <property name="geometry">
      <rect>
       <x>10</x>
       <y>25</y>
-      <width>501</width>
-      <height>60</height>
-     </rect>
-    </property>
-    <property name="toolTip">
-     <string>Additional Serato library paths (one per line). Used for external drives and multiple music collections.</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="add_additional_lib_button">
-    <property name="geometry">
-     <rect>
-      <x>520</x>
-      <y>25</y>
-      <width>90</width>
-      <height>30</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Add Path...</string>
-    </property>
-    <property name="toolTip">
-     <string>Browse for additional Serato library directory</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="additional_libs_help_label">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>90</y>
       <width>600</width>
-      <height>25</height>
+      <height>70</height>
      </rect>
     </property>
     <property name="text">
-     <string>Enter additional _Serato_ folder paths (one per line) for external drives or multiple libraries.</string>
+     <string>Library paths are automatically discovered from Serato's database. All external drives and music collections that Serato knows about will be used for artist queries automatically - no manual configuration needed!</string>
+    </property>
+    <property name="wordWrap">
+     <bool>true</bool>
     </property>
     <property name="styleSheet">
-     <string>color: #666;</string>
+     <string>color: #333; padding: 10px; background-color: #f0f0f0; border-radius: 5px;</string>
     </property>
    </widget>
   </widget>

--- a/nowplaying/serato/reader.py
+++ b/nowplaying/serato/reader.py
@@ -15,11 +15,109 @@ import aiosqlite
 import nowplaying.utils.sqlite
 
 
-class Serato4SQLiteReader:  # pylint: disable=too-few-public-methods
+class Serato4SQLiteReader:
     """SQLite database reader for Serato 4+ master.sqlite files"""
 
     def __init__(self, db_path: str | pathlib.Path):
         self.db_path = pathlib.Path(db_path)
+
+    async def get_location_mappings(self) -> dict[int, pathlib.Path]:
+        """Get mapping of location_id to base file path
+
+        Returns a dictionary mapping location_id to the base path for that location.
+        For external libraries, extracts the parent of _Serato_.
+        For the local library, returns root path.
+        """
+        if not self.db_path.exists():
+            logging.error("Serato master.sqlite not found at %s", self.db_path)
+            return {}
+
+        async def _query_locations() -> dict[int, pathlib.Path]:
+            async with aiosqlite.connect(self.db_path) as connection:
+                connection.row_factory = aiosqlite.Row
+
+                # Query location_connections view to get database paths for each location
+                query = """
+                    SELECT location_id, database_uri
+                    FROM location_connections
+                    WHERE database_uri IS NOT NULL
+                """
+
+                cursor = await connection.execute(query)
+                rows = await cursor.fetchall()
+
+                location_map = {}
+                for row in rows:
+                    location_id = row["location_id"]
+                    database_uri = row["database_uri"]
+
+                    # For external libraries: database_uri is like
+                    # "/Volumes/Music/_Serato_/Library/location.sqlite"
+                    # Base path is parent of "_Serato_": "/Volumes/Music/"
+                    #
+                    # For local library: database_uri is like
+                    # "/Users/aw/Library/Application Support/Serato/Library/root.sqlite"
+                    # Base path is root "/"
+                    db_path = pathlib.Path(database_uri)
+
+                    if "_Serato_" in db_path.parts:
+                        # External library - find parent of _Serato_
+                        parts = list(db_path.parts)
+                        serato_idx = parts.index("_Serato_")
+                        base_path = pathlib.Path(*parts[:serato_idx])
+                    else:
+                        # Local library - portable_id is absolute path without leading /
+                        base_path = pathlib.Path("/")
+
+                    location_map[location_id] = base_path
+
+                return location_map
+
+        try:
+            return await nowplaying.utils.sqlite.retry_sqlite_operation_async(_query_locations)
+        except sqlite3.Error as exc:
+            logging.error("Failed to query location mappings: %s", exc)
+            return {}
+
+    async def get_library_database_paths(self) -> list[pathlib.Path]:
+        """Get all library database paths for artist filtering
+
+        Returns list of paths to root.sqlite or location.sqlite files
+        that can be used for querying the full library/crates.
+        """
+        if not self.db_path.exists():
+            logging.error("Serato master.sqlite not found at %s", self.db_path)
+            return []
+
+        async def _query_db_paths() -> list[pathlib.Path]:
+            async with aiosqlite.connect(self.db_path) as connection:
+                connection.row_factory = aiosqlite.Row
+
+                # Query location_connections view to get all database paths
+                query = """
+                    SELECT database_uri
+                    FROM location_connections
+                    WHERE database_uri IS NOT NULL
+                """
+
+                cursor = await connection.execute(query)
+                rows = await cursor.fetchall()
+
+                db_paths = []
+                for row in rows:
+                    db_path = pathlib.Path(row["database_uri"])
+                    if db_path.exists():
+                        db_paths.append(db_path)
+                    else:
+                        logging.debug("Library database not found: %s", db_path)
+
+                return db_paths
+
+        try:
+            return await nowplaying.utils.sqlite.retry_sqlite_operation_async(_query_db_paths)
+        except sqlite3.Error as exc:
+            logging.error("Failed to query library database paths: %s", exc)
+            return []
 
     async def get_latest_tracks_per_deck(self) -> list[dict[str, t.Any]]:
         """Get the most recent track loaded on each deck from current session
@@ -38,6 +136,7 @@ class Serato4SQLiteReader:  # pylint: disable=too-few-public-methods
 
                 # Get the latest track loaded on each deck from current session
                 # Optimized query using window functions instead of correlated subqueries
+                # Use portable_id which contains the full relative path
                 query = """
                     WITH current_session AS (
                         SELECT id FROM history_session
@@ -48,6 +147,8 @@ class Serato4SQLiteReader:  # pylint: disable=too-few-public-methods
                     ranked_tracks AS (
                         SELECT
                             file_name,
+                            portable_id,
+                            location_id,
                             artist,
                             name as title,
                             album,
@@ -72,6 +173,8 @@ class Serato4SQLiteReader:  # pylint: disable=too-few-public-methods
                     )
                     SELECT
                         file_name,
+                        portable_id,
+                        location_id,
                         artist,
                         title,
                         album,


### PR DESCRIPTION
attempt to fix #1415

## Summary by Sourcery

Resolve Serato 4 track filename resolution and simplify library discovery and configuration.

New Features:
- Derive full track filenames by combining Serato location mappings with portable IDs from history data.
- Auto-discover all Serato library database files via location_connections rather than manual path configuration.

Bug Fixes:
- Fix incorrect or partial filenames for Serato 4 tracks by using location_id and portable_id-based path resolution for local tracks.

Enhancements:
- Add reusable helpers in the Serato SQLite reader to fetch location mappings and library database paths, with caching in the handler for efficiency.
- Refine artist lookup to operate directly on discovered database files instead of scanning configured directories.
- Clean up and deprecate manual additional library path configuration in the Serato settings UI.

Tests:
- Extend Serato test database schema and fixtures to cover portable_id, location_id, and location_connections-based path resolution.