### PR TITLE
disable diskcache pickling (CVE-2025-69872)

### DIFF
--- a/nowplaying/utils/xml.py
+++ b/nowplaying/utils/xml.py
@@ -16,8 +16,6 @@ import defusedxml.sax
 import nowplaying.utils.sqlite
 
 
-
-
 # pylint: disable=missing-function-docstring,invalid-name
 class XMLHandler(Protocol):
     """Protocol for XML SAX handlers"""


### PR DESCRIPTION
## Summary by Sourcery

Prevent insecure pickle-based deserialization in the image cache by enforcing a secure disk backend and validating its behavior.

Bug Fixes:
- Block use of diskcache's pickle mode by introducing a SecureDisk wrapper that raises on MODE_PICKLE fetch attempts while preserving other modes.

Tests:
- Add tests verifying that SecureDisk is used by the image cache and that pickle mode is rejected but raw mode continues to function.