### PR TITLE
fix syntax error in typingeffects

### DIFF
--- a/template-src/components/js/typed_effects.js
+++ b/template-src/components/js/typed_effects.js
@@ -225,7 +225,7 @@ class TypingEffects {
 }
 
 // Global instance for use with metadata-streaming component
-const typingEffects;
+let typingEffects;
 
 // Initialize when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correctly declare the global typingEffects instance to resolve a JavaScript syntax error.