### PR TITLE
requests error with chardet 6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "WhatsNowPlaying"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 
 [project.entry-points.pyinstaller40]
 hook-dirs = "nowplaying.__pyinstaller:get_hook_dirs"

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -3,6 +3,7 @@ aiocache==0.12.3
 aiofiles==25.1.0
 aiohttp==3.13.3
 aiosqlite==0.22.1
+chardet<6
 defusedxml==0.7.1
 discord.py==2.6.4
 diskcache==5.6.3


### PR DESCRIPTION
## Summary by Sourcery

Expand the declared supported Python versions to include Python 3.14 by updating the project’s requires-python constraint in pyproject.toml.