### PR TITLE
Wrong exception for Denon workaround

### DIFF
--- a/nowplaying/denon/connection.py
+++ b/nowplaying/denon/connection.py
@@ -71,7 +71,7 @@ class ConnectionManager:
                 local_addr=("0.0.0.0", DISCOVERY_PORT),
                 reuse_port=True,
             )
-        except OSError:
+        except (OSError, ValueError):
             # Fallback binding approaches
             try:
                 transport, _protocol = await loop.create_datagram_endpoint(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Handle ValueError alongside OSError when creating the Denon discovery datagram endpoint to avoid crashes on certain environments.