### PR TITLE
Fix djay pro missing artist to filename match and wrong filenames on windows

### DIFF
--- a/nowplaying/inputs/djaypro.py
+++ b/nowplaying/inputs/djaypro.py
@@ -362,14 +362,15 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 i += 1
         return decoded
 
-    def _parse_blob(self, blob_data: bytes) -> dict[str, str | int | None]:  # pylint: disable=too-many-branches
+    @staticmethod
+    def _parse_blob(blob_data: bytes) -> dict[str, str | int | None]:  # pylint: disable=too-many-branches
         """Parse binary blob data to extract track metadata
 
         Returns a dict with string values for most fields, int for duration,
         and None for missing fields.
         """
         try:  # pylint: disable=too-many-nested-blocks
-            decoded = self._extract_strings(blob_data)
+            decoded = Plugin._extract_strings(blob_data)
 
             title = None
             artist = None

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -192,8 +192,7 @@ def test_parse_blob_ignores_short_file_url():
     assert result["filename"] == "/Users/aw/Music/test.flac"
 
 
-@pytest.mark.asyncio
-async def test_check_for_new_track_no_db(bootstrap):
+def test_check_for_new_track_no_db(bootstrap):
     """test checking for new track when database doesn't exist"""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
@@ -209,8 +208,7 @@ async def test_check_for_new_track_no_db(bootstrap):
         assert plugin.metadata["title"] is None
 
 
-@pytest.mark.asyncio
-async def test_check_for_new_track_empty_db(bootstrap):
+def test_check_for_new_track_empty_db(bootstrap):
     """test checking for new track with empty database"""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
@@ -234,8 +232,7 @@ async def test_check_for_new_track_empty_db(bootstrap):
         assert plugin.metadata["artist"] is None
 
 
-@pytest.mark.asyncio
-async def test_check_for_new_track_with_data(bootstrap):
+def test_check_for_new_track_with_data(bootstrap):
     """test checking for new track with actual data"""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
@@ -267,8 +264,7 @@ async def test_check_for_new_track_with_data(bootstrap):
         assert plugin.metadata["title"] == "Test Song"
 
 
-@pytest.mark.asyncio
-async def test_check_for_new_track_duplicate(bootstrap):
+def test_check_for_new_track_duplicate(bootstrap):
     """test that duplicate tracks don't update metadata unnecessarily"""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)


### PR DESCRIPTION
…windows

## Summary by Sourcery

Fix track filename resolution from djay Pro metadata, including platform-specific handling of file URLs.

Bug Fixes:
- Avoid matching tracks with empty artist or title when resolving filenames from djay Pro metadata.
- Correctly convert file:/// URLs to filesystem paths on Windows and Unix so resolved filenames are accurate.