### PR TITLE
report denon version for agent

### DIFF
--- a/nowplaying/denon/plugin.py
+++ b/nowplaying/denon/plugin.py
@@ -53,6 +53,13 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         # Cannot auto-detect network devices, user must configure manually
         return False
 
+    def get_source_agent_data(self) -> dict:
+        """Return source agent data including device software version from StagelinQ discovery."""
+        data = super().get_source_agent_data()
+        if self.current_device and self.current_device.software_version:
+            data["source_agent_version"] = self.current_device.software_version
+        return data
+
     def defaults(self, qsettings: "QSettings | None"):
         """Set default configuration values"""
         qsettings.setValue("denon/discovery_timeout", 5.0)

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -304,7 +304,6 @@ class Plugin(IcecastPlugin):
                 metadata[key] = [row[key]]
         return metadata
 
-
     #### Data feed methods
 
     async def getplayingtrack(self):

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -483,7 +483,6 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
 
         await self.setup_watcher("virtualdj/history")
 
-
     async def getplayingtrack(self):
         """wrapper to call getplayingtrack"""
         return self.metadata

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -228,7 +228,6 @@ class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instanc
             "Remote mode scrapes Serato Live Playlists from serato.com."
         )
 
-
     async def getplayingtrack(self) -> TrackMetadata | None:
         """Get current track information from local or remote mode"""
         if self.mode == "local":


### PR DESCRIPTION
## Summary by Sourcery

Report Denon device software version through the source agent data and perform minor cleanup in input plugins.

New Features:
- Expose Denon device software version in source agent data for downstream consumers.

Enhancements:
- Remove minor whitespace in Traktor, VirtualDJ, and Serato input plugins.