### PR TITLE
add a /status endpoint for agents

### DIFF
--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -457,6 +457,15 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         return web.json_response(data)
 
     @staticmethod
+    async def status(request: web.Request):
+        """health check endpoint"""
+        data = {
+            "status": "ok",
+            "version": request.app[CONFIG_KEY].version,
+        }
+        return web.json_response(data)
+
+    @staticmethod
     async def _handle_oauth_redirect(request: web.Request, oauth_config: dict) -> web.Response:
         """Generic OAuth2 redirect handler - delegates to base OAuth2 class."""
         # Pass config and jinja2 environment from app context using correct keys
@@ -547,6 +556,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                 web.get("/twitchchatredirect", self.twitchchatredirect_handler),
                 web.get("/request.htm", self.static_handler.requesterlaunch_htm_handler),
                 web.get("/internals", self.internals),
+                web.get("/status", self.status),
                 web.get("/ws", self.websocket_handler),
                 web.get("/wsstream", self.websocket_streamer),
                 web.get("/wsartistfanartstream", self.websocket_artistfanart_streamer),

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -18,10 +18,10 @@ from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
 import nowplaying.inputs
 import nowplaying.utils.sqlite
 from nowplaying.types import TrackMetadata
+
 from .handler import Serato4Handler
 from .reader import Serato4RootReader
 from .remote import SeratoRemoteHandler
-
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -19,7 +19,6 @@ from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
 
 import nowplaying.serato.plugin
-
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
 

--- a/nowplaying/subprocesses.py
+++ b/nowplaying/subprocesses.py
@@ -9,7 +9,10 @@ import socket
 import typing as t
 
 from PySide6.QtCore import Qt  # pylint: disable=import-error,no-name-in-module
-from PySide6.QtWidgets import QApplication, QMessageBox  # pylint: disable=import-error,no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=import-error,no-name-in-module
+    QApplication,
+    QMessageBox,
+)
 
 import nowplaying
 import nowplaying.config

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -6,8 +6,8 @@ import sqlite3
 
 from PySide6.QtCore import (  # pylint: disable=no-name-in-module
     QFileSystemWatcher,
-    QThread,
     Qt,
+    QThread,
     Signal,
 )
 from PySide6.QtGui import QAction, QActionGroup, QIcon  # pylint: disable=no-name-in-module

--- a/nowplaying/upgrades/templates.py
+++ b/nowplaying/upgrades/templates.py
@@ -13,7 +13,7 @@ from PySide6.QtCore import (  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QMessageBox  # pylint: disable=no-name-in-module
 
 # Import unified checksum function and exclusion list
-from nowplaying.utils.checksum import checksum, EXCLUDED_FILES
+from nowplaying.utils.checksum import EXCLUDED_FILES, checksum
 
 
 class UpgradeTemplates:


### PR DESCRIPTION
## Summary by Sourcery

Add a lightweight health check endpoint and register it on the web server while performing minor import cleanups.

New Features:
- Expose a /status HTTP endpoint that returns a simple health status and application version.

Enhancements:
- Tidy up import ordering in Serato plugin and upgrade templates modules.