### PR TITLE
fix MIXXX MPRIS2 stupidity

### DIFF
--- a/nowplaying/inputs/mpris2.py
+++ b/nowplaying/inputs/mpris2.py
@@ -32,6 +32,10 @@ from nowplaying.inputs import InputPlugin
 
 MPRIS2_BASE = "org.mpris.MediaPlayer2"
 
+# Mixxx reports these artist strings when no real track is loaded.
+# Title is "Mixxx" (the app name) in all cases.
+MIXXX_IDLE_ARTISTS = frozenset({"AutoDJ is ready!", "No track playing"})
+
 
 class MPRIS2Handler:
     """Read metadata from MPRIS2"""
@@ -74,7 +78,7 @@ class MPRIS2Handler:
         self.meta = None
         self.metadata = {}
 
-    async def getplayingtrack(self):  # pylint: disable=too-many-branches
+    async def getplayingtrack(self):  # pylint: disable=too-many-branches,too-many-statements
         """get the currently playing song"""
 
         # start with a blank slate to prevent
@@ -147,6 +151,14 @@ class MPRIS2Handler:
         if title == filename or title and pathlib.Path(title).exists():
             builddata["title"] = None
             title = None
+
+        # Mixxx reports title="Mixxx" with a system message as the artist when
+        # no real track is loaded (e.g. AutoDJ idle, empty deck). Discard these.
+        artist = builddata.get("artist")
+        if title == "Mixxx" and artist in MIXXX_IDLE_ARTISTS:
+            logging.debug("Ignoring Mixxx idle state: artist=%s", artist)
+            builddata["title"] = None
+            builddata["artist"] = None
 
         # it looks like there is a race condition in mixxx
         # probably should make this an option in the MPRIS2

--- a/tests/test_mpris2.py
+++ b/tests/test_mpris2.py
@@ -169,6 +169,42 @@ async def test_getplayingtrack_with_vlc_metadata(getroot):
 
 @pytest.mark.skipif(not DBUS_FAST_AVAILABLE, reason="dbus-fast not available")
 @pytest.mark.asyncio
+@pytest.mark.parametrize("idle_artist", ["AutoDJ is ready!", "No track playing"])
+async def test_getplayingtrack_mixxx_idle_states(idle_artist):
+    """Test that Mixxx idle/system states are filtered out and not treated as real tracks"""
+    with patch("nowplaying.inputs.mpris2.DBUS_STATUS", True):
+        handler = nowplaying.inputs.mpris2.MPRIS2Handler(service="mixxx")  # pylint: disable=no-member
+
+        mock_bus = MagicMock()
+        mock_props_obj = MagicMock()
+        mock_properties = MagicMock()
+
+        handler.bus = mock_bus
+        handler.introspection = MagicMock()
+
+        mock_bus.get_proxy_object.return_value = mock_props_obj
+        mock_props_obj.get_interface.return_value = mock_properties
+
+        response = {
+            "Metadata": Variant(
+                "a{sv}",
+                {
+                    "xesam:title": Variant("s", "Mixxx"),
+                    "xesam:artist": Variant("as", [idle_artist]),
+                },
+            )
+        }
+
+        mock_properties.call_get_all = AsyncMock(return_value=response)
+
+        result = await handler.getplayingtrack()
+
+        assert result["title"] is None
+        assert result["artist"] is None
+
+
+@pytest.mark.skipif(not DBUS_FAST_AVAILABLE, reason="dbus-fast not available")
+@pytest.mark.asyncio
 async def test_getplayingtrack_multiple_artists():
     """Test getplayingtrack with multiple artists"""
     with patch("nowplaying.inputs.mpris2.DBUS_STATUS", True):


### PR DESCRIPTION
## Summary by Sourcery

Handle Mixxx MPRIS2 idle states as non-tracks and keep smoke-test CLI consistent.

Bug Fixes:
- Ignore Mixxx MPRIS2 idle/system artist states so they are not treated as real playing tracks.

Tests:
- Add coverage ensuring Mixxx idle/system MPRIS2 states are filtered out and return empty track metadata.

Chores:
- Normalize smoke-test CLI argument quoting in the wnppyi entry point.