### PR TITLE
Enable http2 for wnpmb

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ MPRIS2-compatible players (Linux)
 
 ## Download
 
-[Get the latest release](https://github.com/whatsnowplaying/whats-now-playing/releases) for Windows 10+ or macOS 11+.
+[Get the latest release](https://github.com/whatsnowplaying/whats-now-playing/releases)
+in binary or source forms.
 
 ## Quick Links
 

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -7,7 +7,7 @@ charset-normalizer==3.4.7
 defusedxml==0.7.1
 discord.py==2.7.1
 diskcache==5.6.3
-httpx==0.28.1
+httpx[http2]==0.28.1
 jinja2==3.1.6
 lxml==6.0.3
 netifaces-plus==0.12.5

--- a/vendor.txt
+++ b/vendor.txt
@@ -1,3 +1,3 @@
 git+https://github.com/whatsnowplaying/tinytag@wnp
-git+https://github.com/whatsnowplaying/wnpmb@0.1.4
+git+https://github.com/whatsnowplaying/wnpmb@0.1.5
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update README download section to state that releases are available in both binary and source forms.