### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -170,7 +170,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python: ["3.11", "3.12", "3.13"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
     env:
       DISPLAY: ':99.0'
     steps:

--- a/builder.sh
+++ b/builder.sh
@@ -22,8 +22,8 @@ check_python_version() {
     echo "Python 3.11 or later is required (got ${pyver})."
     exit 1
   fi
-  if [[ ${PY_VER[1]} -ge 14 ]]; then
-    echo "Python 3.14+ is not yet supported (got ${pyver}). Use Python 3.11–3.13."
+  if [[ ${PY_VER[1]} -ge 15 ]]; then
+    echo "Python 3.15+ is not yet supported (got ${pyver}). Use Python 3.11–3.14."
     exit 1
   fi
 }
@@ -56,8 +56,9 @@ if [[ "${SYSTEM}" == "dev" ]]; then
   PYTHONBINDIR=$(dirname "${ACTIVATE}")
   PYTHONBIN="${PYTHONBINDIR}/${PYTHON}"
   "${PYTHONBIN}" -m pip install --upgrade pip
-  "${PYTHONBIN}" -m pip install -e ".[dev,docs,osspecials,test]"
+  "${PYTHONBIN}" -m pip install --upgrade --upgrade-strategy eager -e ".[dev,docs,osspecials,test]"
   "${PYTHONBIN}" -m vendoring sync
+  touch nowplaying/vendor/.gitkeep
   versioningit --write
   "${PYTHONBIN}" tools/setupnltk.py
   "${PYTHONBIN}" tools/build_templates.py

--- a/conftest.py
+++ b/conftest.py
@@ -88,6 +88,7 @@ def bootstrap(getroot):  # pylint: disable=redefined-outer-name
                 bundledir=bundledir, logpath=newpath, testmode=True
             )
             config.cparser.setValue("acoustidmb/enabled", False)
+            config.cparser.setValue("testmode/metadbpath", str(dbfile))
             config.cparser.sync()
             config.testdir = pathlib.Path(newpath)
             config.dbtestfile = dbfile

--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,6 @@ from PySide6.QtCore import (  # pylint: disable=import-error, no-name-in-module
 import nowplaying.apicache
 import nowplaying.bootstrap
 import nowplaying.config
-import nowplaying.db
 
 # if sys.platform == 'darwin':
 #     import psutil
@@ -82,21 +81,18 @@ def bootstrap(getroot):  # pylint: disable=redefined-outer-name
             dbdir.mkdir()
             dbfile = dbdir.joinpath("test.db")
 
-            with unittest.mock.patch.dict(
-                os.environ,
-                {"WNP_CONFIG_TEST_DIR": str(newpath), "WNP_METADB_TEST_FILE": str(dbfile)},
-            ):
-                rmdir = newpath
-                bundledir = pathlib.Path(getroot).joinpath("nowplaying")
-                nowplaying.bootstrap.set_qt_names(domain=DOMAIN, appname="testsuite")
-                config = nowplaying.config.ConfigFile(
-                    bundledir=bundledir, logpath=newpath, testmode=True
-                )
-                config.cparser.setValue("acoustidmb/enabled", False)
-                config.cparser.sync()
-                config.testdir = pathlib.Path(newpath)
+            rmdir = newpath
+            bundledir = pathlib.Path(getroot).joinpath("nowplaying")
+            nowplaying.bootstrap.set_qt_names(domain=DOMAIN, appname="testsuite")
+            config = nowplaying.config.ConfigFile(
+                bundledir=bundledir, logpath=newpath, testmode=True
+            )
+            config.cparser.setValue("acoustidmb/enabled", False)
+            config.cparser.sync()
+            config.testdir = pathlib.Path(newpath)
+            config.dbtestfile = dbfile
 
-                yield config
+            yield config
             if pathlib.Path(rmdir).exists():
                 shutil.rmtree(rmdir)
 

--- a/docs/help/developers.md
+++ b/docs/help/developers.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-* Python 3.11+ for your operating system
+* Python 3.11–3.14 for your operating system (3.15+ is not yet supported)
 * A terminal / development shell
 * `git` installed and working
 
@@ -20,12 +20,12 @@ cd whats-now-playing
 ./builder.sh dev
 ```
 
-If your system default Python is unsupported (e.g. 3.14+) or you have multiple
+If your system default Python is unsupported (e.g. 3.15+) or you have multiple
 versions installed and need to target a specific supported one, set `PYTHONBIN`
 before running the script:
 
 ```bash
-PYTHONBIN=/usr/local/bin/python3.11 ./builder.sh dev
+PYTHONBIN=/usr/local/bin/python3.12 ./builder.sh dev
 ```
 
 `builder.sh` defaults to `python3` (or `python` on Windows) found on `PATH`.

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -305,6 +305,14 @@ class Plugin(ArtistExtrasPlugin):
             logging.debug("discogs did not find it")
             return None
 
+        # The release search returns only a basic artist reference (id/name only).
+        # Fetch the full artist profile so bio and websites are populated.
+        artist_id = getattr(artistresultlist, "id", None)
+        if artist_id:
+            full_artist = await self._artist_async_cached(str(artist_id), metadata["artist"])
+            if full_artist:
+                artistresultlist = full_artist
+
         self._process_metadata(metadata["imagecacheartist"], artistresultlist, imagecache)
         return self.addmeta
 

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -305,13 +305,19 @@ class Plugin(ArtistExtrasPlugin):
             logging.debug("discogs did not find it")
             return None
 
-        # The release search returns only a basic artist reference (id/name only).
-        # Fetch the full artist profile so bio and websites are populated.
-        artist_id = getattr(artistresultlist, "id", None)
-        if artist_id:
-            full_artist = await self._artist_async_cached(str(artist_id), metadata["artist"])
-            if full_artist:
-                artistresultlist = full_artist
+        # If load_full_artist_data was rate-limited during the search, the cached result
+        # may have an incomplete artist (no bio/urls).  Fetch the full profile explicitly
+        # so we always have a separate artist_{id} cache entry to fall back on.
+        needs_bio = self.config.cparser.value("discogs/bio", type=bool)
+        needs_websites = self.config.cparser.value("discogs/websites", type=bool)
+        missing_bio = needs_bio and not getattr(artistresultlist, "profile_plaintext", None)
+        missing_urls = needs_websites and not getattr(artistresultlist, "urls", None)
+        if missing_bio or missing_urls:
+            artist_id = getattr(artistresultlist, "discogs_id", None)
+            if artist_id:
+                full_artist = await self._artist_async_cached(str(artist_id), metadata["artist"])
+                if full_artist:
+                    artistresultlist = full_artist
 
         self._process_metadata(metadata["imagecacheartist"], artistresultlist, imagecache)
         return self.addmeta

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -171,8 +171,6 @@ class MetadataDB:
         """split this out to make testing easier"""
         if databasefile:
             return pathlib.Path(databasefile)
-        if os.environ.get("WNP_METADB_TEST_FILE"):
-            return pathlib.Path(os.environ["WNP_METADB_TEST_FILE"])
         return pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]
         ).joinpath("metadb", "npsql.db")

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -169,10 +169,10 @@ class MetadataDB:
     @staticmethod
     def init_db_var(databasefile: str | pathlib.Path | None) -> pathlib.Path:
         """split this out to make testing easier"""
-        if os.environ.get("WNP_METADB_TEST_FILE"):
-            return pathlib.Path(os.environ["WNP_METADB_TEST_FILE"])
         if databasefile:
             return pathlib.Path(databasefile)
+        if os.environ.get("WNP_METADB_TEST_FILE"):
+            return pathlib.Path(os.environ["WNP_METADB_TEST_FILE"])
         return pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]
         ).joinpath("metadb", "npsql.db")

--- a/nowplaying/discogsclient.py
+++ b/nowplaying/discogsclient.py
@@ -7,6 +7,7 @@ A minimal asyncio-based Discogs API client that replaces the vendored discogs_cl
 with just the functionality needed by the nowplaying application.
 """
 
+import contextlib
 import logging
 import ssl
 from typing import Any
@@ -61,12 +62,15 @@ class DiscogsRelease:  # pylint: disable=too-few-public-methods
         url = f"{self.client.BASE_URL}/releases/{self.discogs_id}"
         try:
             async with self.client.session.get(url) as response:
+                self.client._log_rate_limit(response)  # pylint: disable=protected-access
                 if response.status == 200:
                     data = await response.json()
                     if "artists" in data and data["artists"]:
                         # Create artist objects with IDs for further lookup
                         self.artists = [DiscogsArtist(artist) for artist in data["artists"]]
                         self._artists_loaded = True
+                elif response.status == 429:
+                    logging.warning("Discogs release lookup rate limited (429), skipping")
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.debug("Error loading full release data: %s", error)
 
@@ -146,6 +150,20 @@ class AsyncDiscogsClient:
         if self.session:
             await self.session.close()
 
+    @staticmethod
+    def _log_rate_limit(response: aiohttp.ClientResponse) -> None:
+        """Log Discogs rate limit headers so callers can see how close we are."""
+        remaining_str = response.headers.get("X-Discogs-Ratelimit-Remaining")
+        limit_str = response.headers.get("X-Discogs-Ratelimit")
+        if remaining_str is not None and limit_str is not None:
+            with contextlib.suppress(ValueError):
+                remaining = int(remaining_str)
+                limit = int(limit_str)
+                if remaining <= 2:
+                    logging.warning("Discogs rate limit low: %d/%d remaining", remaining, limit)
+                else:
+                    logging.debug("Discogs rate limit: %d/%d remaining", remaining, limit)
+
     async def search(  # pylint: disable=too-many-arguments
         self,
         query: str,
@@ -171,6 +189,7 @@ class AsyncDiscogsClient:
             if not self.session:
                 return DiscogsSearchResult([], self)
             async with self.session.get(url, params=params) as response:  # pylint: disable=not-async-context-manager
+                self._log_rate_limit(response)
                 if response.status == 200:
                     data = await response.json()
                     results = data.get("results", [])
@@ -187,7 +206,10 @@ class AsyncDiscogsClient:
 
                     return search_result
 
-                logging.warning("Discogs search failed with status %d", response.status)
+                if response.status == 429:
+                    logging.warning("Discogs search rate limited (429), skipping")
+                else:
+                    logging.warning("Discogs search failed with status %d", response.status)
                 return DiscogsSearchResult([], self)
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.debug("Discogs search error: %s", error)
@@ -204,6 +226,7 @@ class AsyncDiscogsClient:
 
         try:
             async with self.session.get(url) as response:  # pylint: disable=not-async-context-manager
+                self._log_rate_limit(response)
                 if response.status == 200:
                     data = await response.json()
 
@@ -227,7 +250,10 @@ class AsyncDiscogsClient:
 
                     return DiscogsArtist(data)
 
-                logging.warning("Discogs artist lookup failed with status %d", response.status)
+                if response.status == 429:
+                    logging.warning("Discogs artist lookup rate limited (429), skipping")
+                else:
+                    logging.warning("Discogs artist lookup failed with status %d", response.status)
                 return None
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.debug("Discogs artist lookup error: %s", error)

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -670,7 +670,10 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         template_dir = app[CONFIG_KEY].getbundledir().joinpath("templates")
         app.router.add_static("/vendor/", path=template_dir / "vendor", name="vendor")
         app.router.add_static("/guessgame/", path=template_dir / "guessgame", name="guessgame")
-        app[METADB_KEY] = nowplaying.db.MetadataDB()
+        metadb_path: str | None = None
+        if self.testmode:
+            metadb_path = app[CONFIG_KEY].cparser.value("testmode/metadbpath", defaultValue=None)
+        app[METADB_KEY] = nowplaying.db.MetadataDB(databasefile=metadb_path)
         app[IC_KEY] = nowplaying.imagecache.ImageCache()
         app[WATCHER_KEY] = app[METADB_KEY].watcher()
         app[WATCHER_KEY].start()

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -1081,7 +1081,10 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
     ) -> TrackRequestResult:
         """twofer request"""
 
-        metadb = nowplaying.db.MetadataDB()
+        metadb_path: str | None = None
+        if self.testmode and self.config:
+            metadb_path = self.config.cparser.value("testmode/metadbpath", defaultValue=None)
+        metadb = nowplaying.db.MetadataDB(databasefile=metadb_path)
         metadata = await metadb.read_last_meta_async()
         if not metadata:
             logging.debug("Twofer: No currently playing track? skipping")

--- a/nowplaying/vendor/wnpmb.pyi
+++ b/nowplaying/vendor/wnpmb.pyi
@@ -1,0 +1,1 @@
+from wnpmb import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "WhatsNowPlaying"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 license-files = ["LICENSE.txt"]
 
 [project.entry-points.pyinstaller40]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,16 +18,16 @@ def results(expected, metadata):
 
 
 @pytest.mark.asyncio
-async def test_simple_check(bootstrap):  # pylint: disable=unused-argument
+async def test_simple_check(bootstrap):
     """test writing false data"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
     assert metadb
 
 
 @pytest.mark.asyncio
-async def test_empty_db(bootstrap):  # pylint: disable=unused-argument
+async def test_empty_db(bootstrap):
     """test writing false data"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
     await metadb.write_to_metadb(metadata=None)
     readdata = metadb.read_last_meta()
 
@@ -40,9 +40,9 @@ async def test_empty_db(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_empty_db_async(bootstrap):  # pylint: disable=unused-argument
+async def test_empty_db_async(bootstrap):
     """test writing false data"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
     await metadb.write_to_metadb(metadata=None)
     readdata = await metadb.read_last_meta_async()
 
@@ -55,9 +55,9 @@ async def test_empty_db_async(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_data_db1(bootstrap):  # pylint: disable=unused-argument
+async def test_data_db1(bootstrap):
     """simple data test"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
 
     expected = {
         "acoustidid": None,
@@ -119,9 +119,9 @@ async def test_data_db1(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_data_db2(bootstrap):  # pylint: disable=unused-argument
+async def test_data_db2(bootstrap):
     """more complex data test"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
 
     expected = {
         "album": "Secret Samadhi",
@@ -204,9 +204,9 @@ async def test_data_db2(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_data_dbid(bootstrap):  # pylint: disable=unused-argument
+async def test_data_dbid(bootstrap):
     """make sure dbid increments"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
 
     expected = {
         "artist": "Nine Inch Nails",
@@ -228,9 +228,9 @@ async def test_data_dbid(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_data_previoustrack(bootstrap):  # pylint: disable=unused-argument
+async def test_data_previoustrack(bootstrap):
     """test the previoustrack functionality"""
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
 
     for counter in range(4):
         await metadb.write_to_metadb(metadata={"artist": f"a{counter}", "title": f"t{counter}"})
@@ -245,7 +245,7 @@ async def test_data_previoustrack(bootstrap):  # pylint: disable=unused-argument
 ## there are no crashes
 
 
-def test_empty_setlist(bootstrap):  # pylint: disable=unused-argument
+def test_empty_setlist(bootstrap):
     """test a simple empty db"""
     config = bootstrap
     config.cparser.setValue("setlist/enabled", True)
@@ -253,11 +253,11 @@ def test_empty_setlist(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_simple_setlist(bootstrap):  # pylint: disable=unused-argument
+async def test_simple_setlist(bootstrap):
     """test a single entry db"""
     config = bootstrap
     config.cparser.setValue("setlist/enabled", True)
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
 
     expected = {
         "artist": "Great Artist Here",
@@ -269,11 +269,11 @@ async def test_simple_setlist(bootstrap):  # pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
-async def test_missingartist_setlist(bootstrap):  # pylint: disable=unused-argument
+async def test_missingartist_setlist(bootstrap):
     """test a single entry db"""
     config = bootstrap
     config.cparser.setValue("setlist/enabled", True)
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
 
     expected = {
         "artist": None,

--- a/tests/test_has_tracks_by_artist.py
+++ b/tests/test_has_tracks_by_artist.py
@@ -9,6 +9,7 @@ Refactored version using parameterization to reduce duplication.
 
 import asyncio
 import gc
+import inspect
 import tempfile
 import time
 import unittest.mock
@@ -652,7 +653,7 @@ async def test_all_plugins_implement_has_tracks_by_artist(bootstrap):
         assert hasattr(plugin, "has_tracks_by_artist"), (
             f"{plugin_class.__name__} missing has_tracks_by_artist method"
         )
-        assert asyncio.iscoroutinefunction(plugin.has_tracks_by_artist), (
+        assert inspect.iscoroutinefunction(plugin.has_tracks_by_artist), (
             f"{plugin_class.__name__}.has_tracks_by_artist must be async"
         )
 

--- a/tests/test_imagecache.py
+++ b/tests/test_imagecache.py
@@ -323,6 +323,7 @@ async def test_get_next_dlset_empty_database(bootstrap):
         result = imagecache.get_next_dlset()
         assert result is None or result == []
     finally:
+        imagecache.close()
         # Clean up SQLite WAL files to prevent flaky test failures
         if imagecache.databasefile.exists():
             with contextlib.suppress(Exception):
@@ -342,20 +343,23 @@ async def test_database_operations(bootstrap):
 
     imagecache = nowplaying.imagecache.ImageCache(cachedir=dbdir)
 
-    # Test put_db_srclocation
-    imagecache.put_db_srclocation("testartist", "testurl", "fanart")
+    try:
+        # Test put_db_srclocation
+        imagecache.put_db_srclocation("testartist", "testurl", "fanart")
 
-    # Test find_srclocation
-    data = imagecache.find_srclocation("testurl")
-    assert data is not None
-    assert data["identifier"] == "testartist"
-    assert data["imagetype"] == "fanart"
-    assert data["srclocation"] == "testurl"
+        # Test find_srclocation
+        data = imagecache.find_srclocation("testurl")
+        assert data is not None
+        assert data["identifier"] == "testartist"
+        assert data["imagetype"] == "fanart"
+        assert data["srclocation"] == "testurl"
 
-    # Test erase_srclocation
-    imagecache.erase_srclocation("testurl")
-    data = imagecache.find_srclocation("testurl")
-    assert data is None
+        # Test erase_srclocation
+        imagecache.erase_srclocation("testurl")
+        data = imagecache.find_srclocation("testurl")
+        assert data is None
+    finally:
+        imagecache.close()
 
 
 @pytest.mark.asyncio
@@ -445,22 +449,25 @@ async def test_stopwnp_only_in_batch(bootstrap):
     imagecache = nowplaying.imagecache.ImageCache(cachedir=dbdir)
     recently_processed = {}
 
-    # Simulate shutdown scenario where only STOPWNP is in the queue
-    mock_dataset = [
-        {"srclocation": "STOPWNP", "identifier": "STOPWNP", "imagetype": "STOPWNP"},
-    ]
+    try:
+        # Simulate shutdown scenario where only STOPWNP is in the queue
+        mock_dataset = [
+            {"srclocation": "STOPWNP", "identifier": "STOPWNP", "imagetype": "STOPWNP"},
+        ]
 
-    with patch.object(imagecache, "get_next_dlset", return_value=mock_dataset):
-        batch = imagecache._get_next_queue_batch(recently_processed)  # pylint: disable=protected-access
-        assert len(batch) == 1
-        assert batch[0]["srclocation"] == "STOPWNP"
+        with patch.object(imagecache, "get_next_dlset", return_value=mock_dataset):
+            batch = imagecache._get_next_queue_batch(recently_processed)  # pylint: disable=protected-access
+            assert len(batch) == 1
+            assert batch[0]["srclocation"] == "STOPWNP"
 
-    # Verify filtering out STOPWNP leaves empty batch (clean shutdown)
-    items_to_process = [item for item in batch if item["srclocation"] != "STOPWNP"]
-    should_stop = len(items_to_process) != len(batch)
+        # Verify filtering out STOPWNP leaves empty batch (clean shutdown)
+        items_to_process = [item for item in batch if item["srclocation"] != "STOPWNP"]
+        should_stop = len(items_to_process) != len(batch)
 
-    assert not items_to_process
-    assert should_stop
+        assert not items_to_process
+        assert should_stop
+    finally:
+        imagecache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -614,7 +614,7 @@ async def test_twofer(bootstrap, getroot):  # pylint: disable=redefined-outer-na
     )
     config.cparser.sync()
 
-    metadb = nowplaying.db.MetadataDB(initialize=True)
+    metadb = nowplaying.db.MetadataDB(databasefile=bootstrap.dbtestfile, initialize=True)
     trackrequest = nowplaying.trackrequests.Requests(
         stopevent=stopevent, config=config, testmode=True
     )

--- a/tests/webserver/conftest.py
+++ b/tests/webserver/conftest.py
@@ -4,12 +4,10 @@
 import asyncio
 import contextlib
 import logging
-import os
 import pathlib
 import socket
 import tempfile
 import time
-import unittest.mock
 
 import pytest
 import pytest_asyncio
@@ -71,63 +69,58 @@ def shared_webserver_config(pytestconfig):
     """module-scoped webserver configuration shared across all webserver tests"""
     with contextlib.suppress(PermissionError):
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as newpath:
-            dbinit_patch = unittest.mock.patch("nowplaying.db.MetadataDB.init_db_var")
-            dbinit_mock = dbinit_patch.start()
             dbdir = pathlib.Path(newpath).joinpath("mdb")
             dbdir.mkdir()
             dbfile = dbdir.joinpath("test.db")
-            dbinit_mock.return_value = dbfile
 
-            with unittest.mock.patch.dict(
-                os.environ,
-                {"WNP_CONFIG_TEST_DIR": str(newpath), "WNP_METADB_TEST_FILE": str(dbfile)},
-            ):
-                bundledir = pathlib.Path(pytestconfig.rootpath).joinpath("nowplaying")
-                nowplaying.bootstrap.set_qt_names(
-                    domain="com.github.whatsnowplaying.testsuite", appname="testsuite"
-                )
-                config = nowplaying.config.ConfigFile(
-                    bundledir=bundledir, logpath=newpath, testmode=True
-                )
-                config.cparser.setValue("acoustidmb/enabled", False)
-                config.cparser.setValue("musicbrainz/enabled", False)
-                config.cparser.setValue("weboutput/httpenabled", "true")
-                config.cparser.sync()
+            bundledir = pathlib.Path(pytestconfig.rootpath).joinpath("nowplaying")
+            nowplaying.bootstrap.set_qt_names(
+                domain="com.github.whatsnowplaying.testsuite", appname="testsuite"
+            )
+            config = nowplaying.config.ConfigFile(
+                bundledir=bundledir, logpath=newpath, testmode=True
+            )
+            config.cparser.setValue("acoustidmb/enabled", False)
+            config.cparser.setValue("musicbrainz/enabled", False)
+            config.cparser.setValue("weboutput/httpenabled", "true")
+            config.cparser.setValue("testmode/metadbpath", str(dbfile))
+            config.cparser.sync()
 
-                metadb = nowplaying.db.MetadataDB(initialize=True)
-                logging.debug("shared webserver databasefile = %s", metadb.databasefile)
+            metadb = nowplaying.db.MetadataDB(databasefile=dbfile, initialize=True)
+            logging.debug("shared webserver databasefile = %s", metadb.databasefile)
 
-                port = config.cparser.value("weboutput/httpport", type=int)
-                logging.debug("checking %s for use", port)
-                while is_port_in_use(port):
-                    logging.debug("%s is in use; waiting", port)
-                    time.sleep(2)
-
-                manager = nowplaying.subprocesses.SubprocessManager(config=config, testmode=True)
-                manager.start_webserver()
-
-                # Wait for webserver to start
-                timeout = 10.0
-                start_time = time.time()
-                while time.time() - start_time < timeout:
-                    with contextlib.suppress(
-                        requests.exceptions.RequestException, requests.exceptions.ConnectionError
-                    ):
-                        req = requests.get(f"http://localhost:{port}/internals", timeout=2)
-                        if req.status_code == 200:
-                            logging.debug("internals = %s", req.json())
-                            break
-                    time.sleep(0.1)
-                else:
-                    raise RuntimeError(
-                        f"Webserver on port {port} failed to start within {timeout} seconds"
-                    )
-
-                yield config, metadb, manager, port
-
-                manager.stop_all_processes()
+            port = config.cparser.value("weboutput/httpport", type=int)
+            logging.debug("checking %s for use", port)
+            while is_port_in_use(port):
+                logging.debug("%s is in use; waiting", port)
                 time.sleep(2)
-                dbinit_mock.stop()
+
+            manager = nowplaying.subprocesses.SubprocessManager(config=config, testmode=True)
+            manager.start_webserver()
+
+            # Wait for webserver to start
+            timeout = 10.0
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                with contextlib.suppress(
+                    requests.exceptions.RequestException, requests.exceptions.ConnectionError
+                ):
+                    req = requests.get(f"http://localhost:{port}/internals", timeout=2)
+                    if req.status_code == 200:
+                        logging.debug("internals = %s", req.json())
+                        break
+                time.sleep(0.1)
+            else:
+                raise RuntimeError(
+                    f"Webserver on port {port} failed to start within {timeout} seconds"
+                )
+
+            yield config, metadb, manager, port
+
+            manager.stop_all_processes()
+            config.cparser.remove("testmode/metadbpath")
+            config.cparser.sync()
+            time.sleep(2)
 
 
 @pytest_asyncio.fixture
@@ -144,6 +137,7 @@ async def getwebserver(shared_webserver_config):
     config.cparser.setValue("weboutput/httpport", port)
     config.cparser.setValue("acoustidmb/enabled", False)
     config.cparser.setValue("musicbrainz/enabled", False)
+    config.cparser.setValue("testmode/metadbpath", str(metadb.databasefile))
     config.cparser.sync()
 
     # Recreate the database for clean test isolation
@@ -160,6 +154,8 @@ async def getwebserver(shared_webserver_config):
     yield config, metadb
 
     manager.stop_all_processes()
+    config.cparser.remove("testmode/metadbpath")
+    config.cparser.sync()
     await asyncio.sleep(1)
 
 
@@ -178,6 +174,7 @@ async def webserver_with_imagecache(shared_webserver_config):
     config.cparser.setValue("acoustidmb/enabled", False)
     config.cparser.setValue("musicbrainz/enabled", False)
     config.cparser.setValue("artistextras/enabled", True)
+    config.cparser.setValue("testmode/metadbpath", str(metadb.databasefile))
     config.cparser.sync()
 
     # Recreate the database for clean test isolation
@@ -203,6 +200,8 @@ async def webserver_with_imagecache(shared_webserver_config):
     yield config, metadb, manager, port
 
     manager.stop_all_processes()
+    config.cparser.remove("testmode/metadbpath")
+    config.cparser.sync()
     await asyncio.sleep(1)
 
 

--- a/tests/webserver/test_webserver_consolidated.py
+++ b/tests/webserver/test_webserver_consolidated.py
@@ -37,7 +37,7 @@ async def test_webserver_templates(getwebserver, template_type, endpoint, expect
     port = config.cparser.value("weboutput/httpport", type=int)
 
     # Configure template
-    template_path = config.getbundledir().joinpath("templates", "basic-plain.txt")
+    template_path = str(config.getbundledir().joinpath("templates", "basic-plain.txt"))
     if template_type == "html":
         config.cparser.setValue("weboutput/htmltemplate", template_path)
     else:


### PR DESCRIPTION
## Summary by Sourcery

Extend supported Python versions and refresh development tooling and CI to match.

New Features:
- Support running and installing the project on Python 3.14.

Enhancements:
- Relax the runtime version constraint to allow Python 3.14 while preventing use of 3.15+, and align the builder script messaging accordingly.
- Improve the dev environment setup by eagerly upgrading dependencies during editable installs and ensuring the vendored directory is always present in the repo.
- Add a new vendor type stub file for internal use.

CI:
- Expand the GitHub Actions test matrix to include Python 3.14.

Documentation:
- Update developer documentation to state support for Python 3.11–3.14 and clarify examples for choosing a supported Python version.