### PR TITLE
Update tests to better handle MB rate limiting during CI

### DIFF
--- a/nowplaying/metadata/processors.py
+++ b/nowplaying/metadata/processors.py
@@ -36,9 +36,12 @@ YOUTUBE_MATCH_RE = re.compile("^https?://[www.]*youtube.com/watch.v=")
 class MetadataProcessors:  # pylint: disable=too-few-public-methods
     """Run through a bunch of different metadata processors"""
 
-    def __init__(self, config: nowplaying.config.ConfigFile | None = None):
+    def __init__(
+        self, config: nowplaying.config.ConfigFile | None = None, test_mode: bool = False
+    ):
         self.metadata: TrackMetadata = {}
         self.imagecache: nowplaying.imagecache.ImageCache | None = None
+        self.test_mode = test_mode
         if config:
             self.config: nowplaying.config.ConfigFile = config
         else:
@@ -317,7 +320,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
             return
 
         try:
-            musicbrainz = nowplaying.musicbrainz.MusicBrainzHelper(config=self.config)
+            musicbrainz = nowplaying.musicbrainz.MusicBrainzHelper(
+                config=self.config, test_mode=self.test_mode
+            )
             addmeta = await musicbrainz.recognize(copy.copy(self.metadata))
             self.metadata = recognition_replacement(
                 config=self.config, metadata=self.metadata, addmeta=addmeta
@@ -350,7 +355,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
 
         logging.debug("Attempting musicbrainz fallback")
 
-        musicbrainz = nowplaying.musicbrainz.MusicBrainzHelper(config=self.config)
+        musicbrainz = nowplaying.musicbrainz.MusicBrainzHelper(
+            config=self.config, test_mode=self.test_mode
+        )
         addmeta = await musicbrainz.lastditcheffort(copy.copy(self.metadata))
         self.metadata = recognition_replacement(
             config=self.config, metadata=self.metadata, addmeta=addmeta

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -12,6 +12,7 @@ from typing import Any
 from nowplaying.vendor.wnpmb import (  # pylint: disable=no-name-in-module,import-error
     MusicBrainzClient,
     MusicBrainzError,
+    RateLimitError,
     WNPCacheAdapter,
     extract_artist_urls,
 )
@@ -29,16 +30,46 @@ logger = logging.getLogger(__name__)
 class MusicBrainzHelper:
     """handler for NowPlaying"""
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, test_mode: bool = False):
         if config:
             self.config = config
         else:
             self.config = nowplaying.config.ConfigFile()
 
+        self.test_mode = test_mode
         self.emailaddressset = False
         self.mb_client = MusicBrainzClient(
             retry_settings=RetrySettings(max_retries=2, wait=0.5),
         )
+
+    async def _mb_op_with_retry(self, operation, error_msg: str, default: Any) -> Any:
+        """Run an async MB operation, retrying on RateLimitError only in test_mode.
+
+        In live performance mode (test_mode=False) a rate-limit failure returns
+        the default immediately so the DJ is never blocked waiting for retries.
+        """
+        max_attempts = 3 if self.test_mode else 1
+        for attempt in range(max_attempts):
+            if attempt > 0:
+                sleep_time = 10 * attempt
+                logger.warning(
+                    "Rate limited; sleeping %ds before retry %d/%d",
+                    sleep_time,
+                    attempt,
+                    max_attempts - 1,
+                )
+                await asyncio.sleep(sleep_time)
+            try:
+                return await operation()
+            except RateLimitError:
+                if attempt < max_attempts - 1:
+                    continue
+                logger.warning("Rate limited after %d attempts: %s", max_attempts, error_msg)
+                return default
+            except MusicBrainzError:
+                logger.exception("MusicBrainz error: %s", error_msg)
+                return default
+        return default
 
     def _setemail(self):
         """make sure the musicbrainz fetch has an email address set
@@ -67,17 +98,17 @@ class MusicBrainzHelper:
 
         self._setemail()
         year = nowplaying.utils.metadata.get_best_year(metadata)
-        try:
+
+        async def _find():
             async with self.mb_client:
-                mbid = await self.mb_client.find_recording(
+                return await self.mb_client.find_recording(
                     title=title,
                     artist=artist,
                     album=album,
                     year=year,
                 )
-        except MusicBrainzError:
-            logger.exception("MusicBrainz error during find_recording")
-            return None
+
+        mbid = await self._mb_op_with_retry(_find, "find_recording", None)
         if mbid:
             return await self.recordingid(mbid)
         return None
@@ -154,13 +185,11 @@ class MusicBrainzHelper:
 
         self._setemail()
 
-        try:
+        async def _resolve():
             async with self.mb_client:
-                mbid = await self.mb_client.resolve_recording_by_isrc(isrclist)
-        except MusicBrainzError:
-            logger.exception("MusicBrainz error during ISRC lookup")
-            return None
+                return await self.mb_client.resolve_recording_by_isrc(isrclist)
 
+        mbid = await self._mb_op_with_retry(_resolve, "resolve_recording_by_isrc", None)
         if mbid:
             return await self.recordingid(mbid)
         return None
@@ -192,8 +221,7 @@ class MusicBrainzHelper:
         """uncached version of recordingid lookup"""
         self._setemail()
 
-        newdata: dict[str, Any] = {}
-        try:
+        async def _fetch() -> dict:
             async with self.mb_client:
                 mb_data = await self.mb_client.get_recording_by_id(recordingid)
                 if not mb_data:
@@ -202,7 +230,7 @@ class MusicBrainzHelper:
                 enriched = await self.mb_client.process_recording_data(mb_data, recordingid)
 
                 # Map wnpmb key names to WNP TrackMetadata key names
-                newdata = {
+                newdata: dict[str, Any] = {
                     "musicbrainzrecordingid": enriched["musicbrainz_recording_id"],
                 }
                 for key in ("title", "artist", "album", "date", "label"):
@@ -224,11 +252,9 @@ class MusicBrainzHelper:
                             newdata["coverimageraw"] = await self.mb_client.get_image_front(
                                 rg_id, "release-group"
                             )
-        except MusicBrainzError:
-            logger.exception("MusicBrainz error fetching recording %s", recordingid)
-            return {}
+                return newdata
 
-        return newdata
+        return await self._mb_op_with_retry(_fetch, "get_recording_by_id", {})
 
     async def artistids(self, idlist):
         """add data available via musicbrainz artist ids"""

--- a/tests/test_metadata_multi_artist.py
+++ b/tests/test_metadata_multi_artist.py
@@ -154,7 +154,7 @@ async def test_integration_single_artist_known_to_mb(bootstrap):
     """Test that artists known to MusicBrainz don't get split"""
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     # Test cases: artists that SHOULD be found in MusicBrainz as single entities
     known_single_artists = [
@@ -189,7 +189,7 @@ async def test_integration_collaboration_not_in_mb(bootstrap):
     """Test that collaborations not in MB get resolved to individual artists"""
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     # Test cases: collaborations that probably DON'T exist in MB as combined entities
     collaboration_cases = [
@@ -233,7 +233,7 @@ async def test_integration_hierarchical_breakdown(bootstrap):
     """Test hierarchical breakdown with a case that requires splitting"""
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     # Test case that should require hierarchical breakdown - using a made-up collaboration
     # that definitely won't exist as a full string in MusicBrainz
@@ -276,7 +276,7 @@ async def test_integration_single_artists_not_split(bootstrap, artist_name):
     await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     processor.metadata = {
         "artist": artist_name,
@@ -325,7 +325,7 @@ async def test_integration_collaborations_split(bootstrap, collaboration, expect
     await asyncio.sleep(0.5)
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     processor.metadata = {
         "artist": collaboration,
@@ -368,7 +368,7 @@ async def test_integration_real_collaboration_example(bootstrap):
     """Test our known working example: Disclosure ft. AlunaGeorge"""
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     processor.metadata = {"artist": "Disclosure ft. AlunaGeorge", "title": "White Noise"}
 
@@ -409,7 +409,7 @@ async def test_integration_conservative_splitting(bootstrap):
     """Test that ambiguous cases are handled conservatively"""
     config = bootstrap
     config.cparser.setValue("musicbrainz/enabled", True)
-    processor = nowplaying.metadata.MetadataProcessors(config=config)
+    processor = nowplaying.metadata.MetadataProcessors(config=config, test_mode=True)
 
     # Test ambiguous cases that should NOT split
     conservative_cases = [

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -25,7 +25,7 @@ def getmusicbrainz(bootstrap):
     for site in ["bandcamp", "homepage", "lastfm", "discogs"]:
         config.cparser.setValue(f"musicbrainz/{site}", True)
     config.cparser.setValue("musicbrainz/emailaddress", "aw+wnptest@effectivemachines.com")
-    return nowplaying.musicbrainz.MusicBrainzHelper(config=config)
+    return nowplaying.musicbrainz.MusicBrainzHelper(config=config, test_mode=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable test mode for MusicBrainz integration and centralize rate-limit-aware retry handling to avoid blocking live usage while making CI tests more robust.

Bug Fixes:
- Ensure MusicBrainz operations in tests can tolerate API rate limiting without causing CI flakiness by adding controlled retries in test mode.
- Prevent live DJ usage from being blocked on MusicBrainz rate limiting by avoiding long retries outside of test mode.

Enhancements:
- Centralize MusicBrainz async call error handling and retry logic in a shared helper, simplifying callers and standardizing responses on failures.

Tests:
- Update metadata and MusicBrainz integration tests to construct processors and helpers in test mode so they exercise the new retry behavior during CI.