### PR TITLE
add macOS 26 cross-build workflow and fix macOS quickstart docs

### DIFF
--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -37,7 +37,7 @@ jobs:
           # so we replicate the formula's build directly where our flags are respected.
           # We install into the existing Homebrew Cellar path so PyICU and PyInstaller
           # find ICU at the expected locations without any path changes.
-          brew install icu4c
+          brew install icu4c@78
           ICU_VERSION=$(brew list --versions icu4c@78 | awk '{print $2}')
           ICU_PREFIX=$(brew --cellar icu4c@78)/${ICU_VERSION}
           echo "Building ICU ${ICU_VERSION} targeting macOS ${MACOSX_DEPLOYMENT_TARGET}"
@@ -57,14 +57,19 @@ jobs:
             --with-library-bits=64
           make -j"$(sysctl -n hw.ncpu)"
           make install
+          ICU_VERSION_FULL=$(ls "${ICU_PREFIX}/lib/libicuuc."*.dylib 2>/dev/null \
+            | sed -E 's/.*libicuuc\.([0-9.]+)\.dylib/\1/' \
+            | head -n 1)
+          ICU_SOVERSION="${ICU_VERSION_FULL%%.*}"
           echo "=== Fixing ICU dylib install names to absolute paths ==="
+          echo "ICU_VERSION_FULL=${ICU_VERSION_FULL}, ICU_SOVERSION=${ICU_SOVERSION}"
           for lib in libicudata libicuuc libicui18n libicuio; do
-            dylib="${ICU_PREFIX}/lib/${lib}.78.3.dylib"
-            [[ -f "$dylib" ]] || continue
-            install_name_tool -id "${ICU_PREFIX}/lib/${lib}.78.dylib" "$dylib"
+            dylib="${ICU_PREFIX}/lib/${lib}.${ICU_VERSION_FULL}.dylib"
+            [[ -n "${ICU_VERSION_FULL}" && -n "${ICU_SOVERSION}" && -f "$dylib" ]] || continue
+            install_name_tool -id "${ICU_PREFIX}/lib/${lib}.${ICU_SOVERSION}.dylib" "$dylib"
             for dep in libicudata libicuuc libicui18n; do
               install_name_tool \
-                -change "${dep}.78.dylib" "${ICU_PREFIX}/lib/${dep}.78.dylib" \
+                -change "${dep}.${ICU_SOVERSION}.dylib" "${ICU_PREFIX}/lib/${dep}.${ICU_SOVERSION}.dylib" \
                 "$dylib" 2>/dev/null || true
             done
           done

--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -1,0 +1,98 @@
+# Reusable workflow for building macOS 15-compatible PyInstaller binaries
+# on macOS 26 runners. Builds ICU from source with explicit deployment
+# target flags since Homebrew overrides MACOSX_DEPLOYMENT_TARGET in its
+# own build subprocess.
+
+# yamllint disable rule:line-length
+---
+
+name: macos26-build
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:  # yamllint disable-line rule:truthy
+    inputs:
+      runs-on:
+        required: true
+        type: string
+      artifact-name:
+        required: true
+        type: string
+      macos-deployment-target:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+    steps:
+      - name: icu
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-deployment-target }}
+        run: |
+          brew update --preinstall || true
+          brew install pkg-config
+          # Homebrew overrides MACOSX_DEPLOYMENT_TARGET in its own build subprocess,
+          # so we replicate the formula's build directly where our flags are respected.
+          # We install into the existing Homebrew Cellar path so PyICU and PyInstaller
+          # find ICU at the expected locations without any path changes.
+          brew install icu4c
+          ICU_VERSION=$(brew list --versions icu4c@78 | awk '{print $2}')
+          ICU_PREFIX=$(brew --cellar icu4c@78)/${ICU_VERSION}
+          echo "Building ICU ${ICU_VERSION} targeting macOS ${MACOSX_DEPLOYMENT_TARGET}"
+          curl -fL \
+            "https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION}/icu4c-${ICU_VERSION}-sources.tgz" \
+            -o /tmp/icu4c-src.tgz
+          tar xzf /tmp/icu4c-src.tgz -C /tmp
+          cd /tmp/icu/source
+          CFLAGS="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+          CXXFLAGS="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
+          LDFLAGS="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -Wl,-headerpad_max_install_names" \
+          ./configure \
+            --prefix="${ICU_PREFIX}" \
+            --disable-samples \
+            --disable-tests \
+            --enable-static \
+            --with-library-bits=64
+          make -j"$(sysctl -n hw.ncpu)"
+          make install
+          echo "=== Fixing ICU dylib install names to absolute paths ==="
+          for lib in libicudata libicuuc libicui18n libicuio; do
+            dylib="${ICU_PREFIX}/lib/${lib}.78.3.dylib"
+            [[ -f "$dylib" ]] || continue
+            install_name_tool -id "${ICU_PREFIX}/lib/${lib}.78.dylib" "$dylib"
+            for dep in libicudata libicuuc libicui18n; do
+              install_name_tool \
+                -change "${dep}.78.dylib" "${ICU_PREFIX}/lib/${dep}.78.dylib" \
+                "$dylib" 2>/dev/null || true
+            done
+          done
+          echo "=== ICU deployment target after custom build ==="
+          vtool -show-build "${ICU_PREFIX}/lib/libicuuc.dylib"
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: update tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: run builder
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-deployment-target }}
+        run: |
+          export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
+          export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"
+          ./builder.sh
+      - name: smoke test binary
+        run: |
+          BINARY=$(find WhatsNowPlaying-* -path "*/Contents/MacOS/WhatsNowPlaying" -type f | head -1)
+          "${BINARY}" --smoke-test
+      - name: artifact dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: "*.zip"

--- a/.github/workflows/macos26-pyinstaller.yml
+++ b/.github/workflows/macos26-pyinstaller.yml
@@ -1,0 +1,22 @@
+# Manually-triggered workflow to build macOS 15-compatible binaries
+# on macOS 26 runners. Run this periodically to verify the cross-build
+# still works as GitHub updates their runner images, so we are ready
+# when macos-15 runners are retired.
+
+# yamllint disable rule:line-length
+---
+
+name: macos26-pyinstaller
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:  # yamllint disable-line rule:truthy
+
+jobs:
+  pyinstaller-macos26-arm:
+    uses: ./.github/workflows/macos26-build.yml
+    permissions:
+      contents: read
+    with:
+      runs-on: macos-26
+      artifact-name: macos15-arm-dist-from-macos26
+      macos-deployment-target: '15.0'

--- a/WhatsNowPlaying.spec
+++ b/WhatsNowPlaying.spec
@@ -120,7 +120,7 @@ def osxcopyright():
 def osxminimumversion():
     ''' Prevent running binaries on incompatible
         versions '''
-    return platform.mac_ver()[0]
+    return os.environ.get('MACOSX_DEPLOYMENT_TARGET') or platform.mac_ver()[0]
 
 
 def windows_version_file():

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,12 +77,15 @@ instructions on adding a Browser Source by hand.
 
 ### macOS
 
-Due to security measures in macOS, unsigned apps may require extra steps to open.
+Due to security measures in macOS, unsigned apps require extra steps to open.
 
 * Do not unzip the downloaded package directly to the folder you will run it from.
   Unzip in `Downloads` first, then move `WhatsNowPlaying.app` to `Applications`.
-* If the app fails to open, hold **Control** and double-click to open.
-* If that does not work, open Terminal and run:
+* On first launch, macOS will show a warning that it cannot verify the app is free of malware.
+  This is expected for unsigned apps.
+* Open **System Settings → Privacy & Security**, scroll down to the **Security** section,
+  and click **Open Anyway** next to the WhatsNowPlaying entry.
+* If no **Open Anyway** button appears, open Terminal and run:
   `sudo xattr -r -d com.apple.quarantine /path/to/WhatsNowPlaying.app`
 
 ### Windows


### PR DESCRIPTION
Add macos26-build.yml reusable workflow that builds macOS 15-compatible PyInstaller binaries on macOS 26 runners. Builds ICU from source with explicit deployment target flags and install_name_tool fixups since Homebrew ignores MACOSX_DEPLOYMENT_TARGET in its build subprocess.

Add macos26-pyinstaller.yml as a manual-only (workflow_dispatch) trigger so the cross-build can be tested periodically without affecting normal CI.

Fix WhatsNowPlaying.spec osxminimumversion() to use MACOSX_DEPLOYMENT_TARGET env var when set, so LSMinimumSystemVersion reflects the intended target OS rather than the build machine OS.

Update docs/quickstart.md macOS instructions for the Sequoia Gatekeeper flow where Open Anyway moved to System Settings > Privacy & Security.

## Summary by Sourcery

Add a reusable macOS 26 cross-build workflow for producing macOS 15-compatible PyInstaller binaries and adjust macOS packaging metadata and documentation to match the intended deployment target and current Gatekeeper behavior.

New Features:
- Introduce a reusable macOS 26 GitHub Actions workflow to build macOS 15-targeted PyInstaller artifacts.
- Add a manually triggered workflow to exercise the macOS 26 cross-build pipeline without affecting regular CI runs.

Enhancements:
- Respect the MACOSX_DEPLOYMENT_TARGET environment variable when setting the macOS minimum version in the app's spec file so built binaries advertise the intended compatibility range.

CI:
- Set up a macOS 26 build job that compiles ICU from source with an explicit deployment target and publishes test artifacts for smoke testing.

Documentation:
- Update macOS quickstart instructions to describe the current Gatekeeper flow using System Settings → Privacy & Security and the Open Anyway option for unsigned apps.