### PR TITLE
Better support for trackhunter

### DIFF
--- a/nowplaying/metadata/processors.py
+++ b/nowplaying/metadata/processors.py
@@ -81,20 +81,23 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         if "artistfanarturls" not in self.metadata:
             self.metadata["artistfanarturls"] = []
 
-        if (
-            self.metadata.get("coverimageraw")
-            and self.imagecache
-            and self.metadata.get("album")
-            and self.metadata.get("artist")
-        ):
+        if self.imagecache and self.metadata.get("artist") and self.metadata.get("album"):
             identifier = f"{self.metadata['artist']}_{self.metadata['album']}"
-            logging.debug("Placing provided front cover")
-            _ = self.imagecache.put_db_cachekey(
-                identifier=identifier,
-                srclocation=f"{identifier}_provided_0",
-                imagetype="front_cover",
-                content=self.metadata["coverimageraw"],
-            )
+            if self.metadata.get("coverimageraw"):
+                logging.debug("Placing provided front cover")
+                _ = self.imagecache.put_db_cachekey(
+                    identifier=identifier,
+                    srclocation=f"{identifier}_provided_0",
+                    imagetype="front_cover",
+                    content=self.metadata["coverimageraw"],
+                )
+            else:
+                cached = self.imagecache.random_image_fetch(
+                    identifier=identifier, imagetype="front_cover"
+                )
+                if cached:
+                    logging.debug("Restoring coverimageraw from imagecache for %s", identifier)
+                    self.metadata["coverimageraw"] = cached
 
         try:
             for processor in "hostmeta", "tinytag", "image2png":

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -167,15 +167,25 @@ class MusicBrainzHelper:
         if metadata.get("musicbrainzrecordingid"):
             logger.debug("Preprocessing with musicbrainz recordingid")
             addmeta = await self.recordingid(metadata["musicbrainzrecordingid"])
-        elif metadata.get("isrc"):
+            if addmeta:
+                return addmeta
+
+        if metadata.get("isrc"):
             logger.debug("Preprocessing with musicbrainz isrc")
             addmeta = await self.isrc(metadata["isrc"])
-        elif metadata.get("musicbrainzartistid"):
+            if addmeta:
+                return addmeta
+
+        if metadata.get("musicbrainzartistid"):
             logger.debug("Preprocessing with musicbrainz artistid")
             addmeta = await self.artistids(metadata["musicbrainzartistid"])
-        elif metadata.get("artist") and metadata.get("title"):
+            if addmeta:
+                return addmeta
+
+        if metadata.get("artist") and metadata.get("title"):
             logger.debug("Attempting lastditcheffort lookup")
             addmeta = await self.lastditcheffort(metadata)
+
         return addmeta
 
     async def isrc(self, isrclist):

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -73,6 +73,7 @@ IC_KEY = web.AppKey("imagecache", nowplaying.imagecache.ImageCache)
 WATCHER_KEY = web.AppKey("watcher", nowplaying.db.DBWatcher)
 JINJA2_KEY = web.AppKey("jinja2_env", jinja2.Environment)
 METADATA_KEY = web.AppKey("metadata", nowplaying.metadata.MetadataProcessors)
+HTTP_SESSION_KEY = web.AppKey("http_session", aiohttp.ClientSession)
 
 
 _MDNS_LABEL_ALLOWED = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
@@ -134,6 +135,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             metadb_key=METADB_KEY,
             remotedb_key=REMOTEDB_KEY,
             metadata_key=METADATA_KEY,
+            http_session_key=HTTP_SESSION_KEY,
         )
 
         while not enabled and not nowplaying.utils.safe_stopevent_check(self.stopevent):
@@ -685,6 +687,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             ).joinpath("remotedb", "remote.db")
         app[REMOTEDB_KEY] = nowplaying.db.MetadataDB(databasefile=remotedb)
         app[METADATA_KEY] = nowplaying.metadata.MetadataProcessors(config=app[CONFIG_KEY])
+        app[HTTP_SESSION_KEY] = aiohttp.ClientSession()
         app["statedb"] = await aiosqlite.connect(self.databasefile)
         app["statedb"].row_factory = aiosqlite.Row
         cursor = await app["statedb"].cursor()
@@ -714,6 +717,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         await self._unregister_mdns_service()
 
         await app["statedb"].close()
+        await app[HTTP_SESSION_KEY].close()
         app[WATCHER_KEY].stop()
         app[IC_KEY].close()
 

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -478,6 +478,36 @@ class StaticContentHandler:
             logging.warning("Failed to fetch cover URL: %s", url, exc_info=True)
         return None
 
+    @staticmethod
+    def _check_agent_version(metadata: dict) -> "web.Response | None":
+        """Return a 426 response if a known agent is below its minimum version, else None."""
+        agent_lower = (metadata.get("source_agent_name") or "").lower()
+        agent_version = metadata.get("source_agent_version") or "0"
+        for prefix, min_version in REMOTE_AGENT_MIN_VERSIONS.items():
+            if agent_lower.startswith(prefix):
+                try:
+                    if nowplaying.upgrades.Version(agent_version) < nowplaying.upgrades.Version(
+                        min_version
+                    ):
+                        logging.warning(
+                            "Agent %s version %s is below minimum %s",
+                            metadata.get("source_agent_name"),
+                            agent_version,
+                            min_version,
+                        )
+                        return web.json_response(
+                            {"error": f"Client upgrade required: {prefix} >= {min_version}"},
+                            status=426,
+                        )
+                except ValueError:
+                    logging.warning(
+                        "Unparsable agent version %s from %s",
+                        agent_version,
+                        metadata.get("source_agent_name"),
+                    )
+                break
+        return None
+
     async def _process_remote_metadata(  # pylint: disable=too-many-locals
         self, request: web.Request, metadata: dict, source: str = "remote"
     ):
@@ -501,32 +531,8 @@ class StaticContentHandler:
                 )
                 return web.json_response({"error": "Invalid secret"}, status=403)
 
-        # Check minimum version for known remote agents (case-insensitive prefix match)
-        agent_lower = (metadata.get("source_agent_name") or "").lower()
-        agent_version = metadata.get("source_agent_version") or "0"
-        for prefix, min_version in REMOTE_AGENT_MIN_VERSIONS.items():
-            if agent_lower.startswith(prefix):
-                try:
-                    if nowplaying.upgrades.Version(agent_version) < nowplaying.upgrades.Version(
-                        min_version
-                    ):
-                        logging.warning(
-                            "Agent %s version %s is below minimum %s",
-                            metadata.get("source_agent_name"),
-                            agent_version,
-                            min_version,
-                        )
-                        return web.json_response(
-                            {"error": f"Client upgrade required: {prefix} >= {min_version}"},
-                            status=426,
-                        )
-                except ValueError:
-                    logging.warning(
-                        "Unparseable agent version %s from %s",
-                        agent_version,
-                        metadata.get("source_agent_name"),
-                    )
-                break
+        if upgrade_response := self._check_agent_version(metadata):
+            return upgrade_response
 
         logging.info("Got %s raw metadata from %s: %s ", source, request.host, metadata)
 

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -9,13 +9,22 @@ import secrets
 import uuid
 from typing import TYPE_CHECKING
 
+import aiohttp
 from aiohttp import web
 
 import nowplaying.db
 import nowplaying.hostmeta
 import nowplaying.preview.sampledata
+import nowplaying.upgrades
 import nowplaying.utils
 from nowplaying.types import TrackMetadata
+
+# Minimum required versions for known remote agents.
+# Set to "0" to allow all versions; bump when breaking changes require a client upgrade.
+REMOTE_AGENT_MIN_VERSIONS: dict[str, str] = {
+    "wnptrackhunter": "0",
+    "wnpearshot": "0",
+}
 
 if TYPE_CHECKING:
     import nowplaying.config
@@ -413,6 +422,19 @@ class StaticContentHandler:
                 logging.exception("api_v1_last_handler: %s", err)
         return web.json_response(data)
 
+    @staticmethod
+    async def _fetch_cover_url(url: str) -> bytes | None:
+        """Fetch a cover image from a URL using aiohttp (non-blocking)."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                    if resp.status == 200:
+                        return await resp.read()
+                    logging.warning("cover URL returned HTTP %s: %s", resp.status, url)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.warning("Failed to fetch cover URL: %s", url, exc_info=True)
+        return None
+
     async def _process_remote_metadata(  # pylint: disable=too-many-locals
         self, request: web.Request, metadata: dict, source: str = "remote"
     ):
@@ -436,6 +458,33 @@ class StaticContentHandler:
                 )
                 return web.json_response({"error": "Invalid secret"}, status=403)
 
+        # Check minimum version for known remote agents (case-insensitive prefix match)
+        agent_lower = (metadata.get("source_agent_name") or "").lower()
+        agent_version = metadata.get("source_agent_version") or "0"
+        for prefix, min_version in REMOTE_AGENT_MIN_VERSIONS.items():
+            if agent_lower.startswith(prefix):
+                try:
+                    if nowplaying.upgrades.Version(agent_version) < nowplaying.upgrades.Version(
+                        min_version
+                    ):
+                        logging.warning(
+                            "Agent %s version %s is below minimum %s",
+                            metadata.get("source_agent_name"),
+                            agent_version,
+                            min_version,
+                        )
+                        return web.json_response(
+                            {"error": f"Client upgrade required: {prefix} >= {min_version}"},
+                            status=426,
+                        )
+                except ValueError:
+                    logging.warning(
+                        "Unparseable agent version %s from %s",
+                        agent_version,
+                        metadata.get("source_agent_name"),
+                    )
+                break
+
         logging.info("Got %s raw metadata from %s: %s ", source, request.host, metadata)
 
         # Start with a copy of the metadata
@@ -448,6 +497,14 @@ class StaticContentHandler:
 
         # Field whitelist - based on what remote.py actually sends
         clean_metadata = self._filter_excluded_fields(clean_metadata)
+
+        # If coverurl is an HTTP URL, fetch the image (coverurl in METADATALIST passes filtering)
+        # processors.py will overwrite coverurl with "cover.png" once coverimageraw is set
+        cover_url = clean_metadata.get("coverurl", "")
+        if isinstance(cover_url, str) and cover_url.startswith("http"):
+            cover_bytes = await self._fetch_cover_url(cover_url)
+            if cover_bytes:
+                clean_metadata["coverimageraw"] = cover_bytes
 
         # Strip null bytes from all string fields (radiologik and other sources may send them)
         for key, value in clean_metadata.items():

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -3,9 +3,12 @@
 
 import asyncio
 import base64
+import ipaddress
 import logging
 import os
 import secrets
+import socket
+import urllib.parse
 import uuid
 from typing import TYPE_CHECKING
 
@@ -84,12 +87,14 @@ class StaticContentHandler:
         metadb_key: web.AppKey[nowplaying.db.MetadataDB],
         remotedb_key: web.AppKey[nowplaying.db.MetadataDB],
         metadata_key: web.AppKey["nowplaying.metadata.MetadataProcessors"],
+        http_session_key: web.AppKey[aiohttp.ClientSession],
     ):
         self.config_key = config_key
         self.ic_key = ic_key
         self.metadb_key = metadb_key
         self.remotedb_key = remotedb_key
         self.metadata_key = metadata_key
+        self.http_session_key = http_session_key
 
     async def index_htm_handler(self, request: web.Request):
         """handle web output"""
@@ -422,15 +427,53 @@ class StaticContentHandler:
                 logging.exception("api_v1_last_handler: %s", err)
         return web.json_response(data)
 
+    MAX_COVER_BYTES = 10 * 1024 * 1024  # 10 MB
+
     @staticmethod
-    async def _fetch_cover_url(url: str) -> bytes | None:
-        """Fetch a cover image from a URL using aiohttp (non-blocking)."""
+    def _is_safe_cover_url(url: str) -> bool:
+        """Return True only if the URL is http/https and resolves to a public IP (SSRF guard)."""
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
-                    if resp.status == 200:
-                        return await resp.read()
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme not in ("http", "https"):
+                return False
+            hostname = parsed.hostname
+            if not hostname:
+                return False
+            for _family, _type, _proto, _canonname, sockaddr in socket.getaddrinfo(
+                hostname, None, proto=socket.IPPROTO_TCP
+            ):
+                ip = ipaddress.ip_address(sockaddr[0])
+                if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                    logging.warning("Rejected non-public IP %s for cover URL %s", ip, url)
+                    return False
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.warning("Could not validate cover URL: %s", url, exc_info=True)
+            return False
+        return True
+
+    async def _fetch_cover_url(self, request: web.Request, url: str) -> bytes | None:
+        """Fetch a cover image from a URL using the shared aiohttp session (non-blocking)."""
+        if not self._is_safe_cover_url(url):
+            logging.warning("Blocked unsafe cover URL: %s", url)
+            return None
+        try:
+            session: aiohttp.ClientSession = request.app[self.http_session_key]
+            async with session.get(
+                url,
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=True,
+                max_line_size=8190,
+            ) as resp:
+                if resp.status != 200:
                     logging.warning("cover URL returned HTTP %s: %s", resp.status, url)
+                    return None
+                content_length = resp.content_length
+                if content_length is not None and content_length > self.MAX_COVER_BYTES:
+                    logging.warning(
+                        "cover URL Content-Length %d exceeds limit: %s", content_length, url
+                    )
+                    return None
+                return await resp.content.read(self.MAX_COVER_BYTES)
         except Exception:  # pylint: disable=broad-exception-caught
             logging.warning("Failed to fetch cover URL: %s", url, exc_info=True)
         return None
@@ -502,7 +545,7 @@ class StaticContentHandler:
         # processors.py will overwrite coverurl with "cover.png" once coverimageraw is set
         cover_url = clean_metadata.get("coverurl", "")
         if isinstance(cover_url, str) and cover_url.startswith("http"):
-            cover_bytes = await self._fetch_cover_url(cover_url)
+            cover_bytes = await self._fetch_cover_url(request, cover_url)
             if cover_bytes:
                 clean_metadata["coverimageraw"] = cover_bytes
 


### PR DESCRIPTION
## Summary by Sourcery

Improve handling of remote metadata and cover art, and refine MusicBrainz lookup behavior for better interoperability with external agents.

New Features:
- Support fetching and embedding cover images from remote HTTP URLs provided in incoming metadata.
- Introduce configurable minimum version checks for known remote agents, returning an explicit upgrade-required response when outdated.

Enhancements:
- Preserve or restore album cover art from the image cache when explicit cover image data is not provided but artist and album are known.
- Short-circuit MusicBrainz recognition steps as soon as a successful match is found to avoid unnecessary lookups.