### PR TITLE
Upgrade wnpmb to 0.1.10; unvendor; fix remote agent handling

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -58,7 +58,7 @@ if [[ "${SYSTEM}" == "dev" ]]; then
   "${PYTHONBIN}" -m pip install --upgrade pip
   "${PYTHONBIN}" -m pip install --upgrade --upgrade-strategy eager -e ".[dev,docs,osspecials,test]"
   "${PYTHONBIN}" -m vendoring sync
-  touch nowplaying/vendor/.gitkeep
+  git checkout nowplaying/vendor/.gitkeep
   versioningit --write
   "${PYTHONBIN}" tools/setupnltk.py
   "${PYTHONBIN}" tools/build_templates.py

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,13 +41,23 @@ If you need to change the port or other settings, go to **Output & Display → W
 
 ## Step 4: Set Up OBS
 
-The easiest way to get your overlays into OBS is to use the built-in export:
+**What's Now Playing** can generate a ready-to-import OBS scene collection with all your
+browser sources pre-configured — no manual URL copying or source sizing required.
+
+> NOTE: This requires OBS Studio 28 or later.
 
 1. **Quit OBS Studio** if it is running
 2. In **What's Now Playing**, click the system tray icon and choose **Export for OBS...**
-3. Review the sources and templates, then click **Export**
-4. Relaunch OBS Studio — the new **WhatsNowPlaying** scene collection will appear
+3. Review the list of sources. For each one you can choose the template, set the
+   width/height, and pick a canvas position. Click **Preview** on any row to see
+   how a template looks before committing.
+4. Click **Export**
+5. Relaunch OBS Studio — the new **WhatsNowPlaying** scene collection will appear
    under **Scene Collection** in the menu bar
+
+The exported collection contains pre-built scenes for your overlays and the Guess Game
+(including WebGL-enhanced versions). Copy the individual browser sources into your
+own scenes as needed.
 
 See [Export for OBS](output/obs-export.md) for full details.
 

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -224,7 +224,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
 
     def _defaults_output(self, settings: QSettings) -> None:
         """default values for output settings"""
-        settings.setValue("textoutput/file", None)
+        settings.setValue("textoutput/file", str(self.basedir.joinpath("now-playing.txt")))
         settings.setValue("textoutput/txttemplate", self.txttemplate)
         settings.setValue("textoutput/clearonstartup", True)
         settings.setValue("textoutput/fileappend", False)
@@ -237,7 +237,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         settings.setValue("obsws/template", str(self.templatedir.joinpath("basic-plain.txt")))
 
         settings.setValue(
-            "weboutput/htmltemplate", str(self.templatedir.joinpath("basic-web.htm"))
+            "weboutput/htmltemplate", str(self.templatedir.joinpath("ws-frosted-glass.htm"))
         )
         settings.setValue(
             "weboutput/artistbannertemplate",

--- a/nowplaying/musicbrainz/client.py
+++ b/nowplaying/musicbrainz/client.py
@@ -3,14 +3,14 @@
 MusicBrainz client for nowplaying — thin re-export of wnpmb.
 """
 
-from nowplaying.vendor.wnpmb import (  # pylint: disable=no-name-in-module,import-error
+from wnpmb import (
     MusicBrainzClient,
     MusicBrainzError,
     NetworkError,
     RateLimitError,
     ResponseError,
 )
-from nowplaying.vendor.wnpmb.client._base import RetrySettings  # pylint: disable=no-name-in-module,import-error
+from wnpmb.client._base import RetrySettings
 
 __all__ = [
     "MusicBrainzClient",

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -9,15 +9,15 @@ import os
 import sys
 from typing import Any
 
-from nowplaying.vendor.wnpmb import (  # pylint: disable=no-name-in-module,import-error
+from wnpmb import (
     MusicBrainzClient,
     MusicBrainzError,
     RateLimitError,
     WNPCacheAdapter,
     extract_artist_urls,
 )
-from nowplaying.vendor.wnpmb.client._base import RetrySettings  # pylint: disable=no-name-in-module,import-error
-from nowplaying.vendor.wnpmb.normalization import normalize  # pylint: disable=no-name-in-module,import-error
+from wnpmb.client._base import RetrySettings
+from wnpmb.normalization import normalize
 
 import nowplaying.apicache
 import nowplaying.bootstrap
@@ -39,7 +39,8 @@ class MusicBrainzHelper:
         self.test_mode = test_mode
         self.emailaddressset = False
         self.mb_client = MusicBrainzClient(
-            retry_settings=RetrySettings(max_retries=2, wait=0.5),
+            timeout=5.0,
+            retry_settings=RetrySettings(max_retries=2, wait=0.5, timeout_retries=1),
         )
 
     async def _mb_op_with_retry(self, operation, error_msg: str, default: Any) -> Any:
@@ -79,7 +80,7 @@ class MusicBrainzHelper:
                 self.config.cparser.value("musicbrainz/emailaddress")
                 or "aw+wnp@effectivemachines.com"
             )
-            self.mb_client.set_useragent("whats-now-playing", self.config.version, emailaddress)
+            self.mb_client.set_useragent(emailaddress)
             self.mb_client.cache_service = WNPCacheAdapter(nowplaying.apicache.get_cache())
             self.emailaddressset = True
 

--- a/nowplaying/upgrades/config.py
+++ b/nowplaying/upgrades/config.py
@@ -509,10 +509,20 @@ class UpgradeConfig:
 
     @staticmethod
     def _upgrade_to_5_2_0(config: QSettings) -> None:
-        """Upgrade to 5.2.0 - Remove Tenor API key (Tenor support removed)"""
+        """Upgrade to 5.2.0 - Remove Tenor API key; fix missing basic-web.htm template"""
         if config.value("gifwords/tenorkey") is not None:
             logging.info("Upgrade to 5.2.0: removing gifwords/tenorkey (Tenor support removed)")
             config.remove("gifwords/tenorkey")
+
+        htmltemplate = config.value("weboutput/htmltemplate")
+        if htmltemplate and isinstance(htmltemplate, str):
+            tmpl_path = pathlib.Path(htmltemplate)
+            if tmpl_path.name == "basic-web.htm" and not tmpl_path.exists():
+                new_path = tmpl_path.parent / "ws-frosted-glass.htm"
+                logging.info(
+                    "Upgrade to 5.2.0: replacing missing basic-web.htm with ws-frosted-glass.htm"
+                )
+                config.setValue("weboutput/htmltemplate", str(new_path))
 
     def _cleanup_old_backup_files(self) -> None:
         """Clean up old .bak backup files from pre-5.0.0-preview5"""

--- a/nowplaying/utils/__init__.py
+++ b/nowplaying/utils/__init__.py
@@ -6,7 +6,6 @@ import base64
 import io
 import logging
 import os
-import re
 import ssl
 import sys
 import time
@@ -16,9 +15,17 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 import jinja2
 import nltk
-import normality
 import PIL.Image
 import pillow_avif  # pylint: disable=unused-import
+
+from wnpmb import (
+    ARTIST_VARIATIONS_RE,
+    CUSTOM_TRANSLATE,
+    generate_artist_variations,
+    normalize,
+    normalize_text,
+    unsmartquotes,
+)
 
 if TYPE_CHECKING:
     import nowplaying.config
@@ -31,18 +38,6 @@ TRANSPARENT_PNG = (
 )
 
 TRANSPARENT_PNG_BIN = base64.b64decode(TRANSPARENT_PNG)
-
-ARTIST_VARIATIONS_RE = [
-    re.compile("(?i)^the (.*)"),
-    re.compile(r"(?i)^(.*?)( feat.* .*)$"),
-]
-
-MISSED_TRANSLITERAL = "ΛΔӨЯ†"
-REPLACED_CHARACTERS = "AAORT"
-CUSTOM_TRANSLATE = str.maketrans(
-    MISSED_TRANSLITERAL + MISSED_TRANSLITERAL.lower(),
-    REPLACED_CHARACTERS + REPLACED_CHARACTERS.lower(),
-)
 
 
 def safe_stopevent_check(stopevent: asyncio.Event | None) -> bool:
@@ -250,40 +245,11 @@ def songpathsubst(config: "nowplaying.config.ConfigFile", filename: str) -> str:
     return newname
 
 
-def normalize_text(text: str | None) -> str | None:
-    """take a string and genercize it"""
-    if not text:
-        return None
-    transtext = unsmartquotes(text.translate(CUSTOM_TRANSLATE))
-    if normal := normality.normalize(transtext):
-        return normal
-    return transtext
+# normalize, normalize_text, unsmartquotes, generate_artist_variations,
+# ARTIST_VARIATIONS_RE, CUSTOM_TRANSLATE imported from wnpmb above.
 
-
-def unsmartquotes(text: str) -> str:
-    """swap smart quotes"""
-    return (
-        text.replace("\u2018", "'")
-        .replace("\u2019", "'")
-        .replace("\u201c", '"')
-        .replace("\u201d", '"')
-    )
-
-
-def normalize(text: str | None, sizecheck: int = 0, nospaces: bool = False) -> str | None:
-    """genericize string, optionally strip spaces, do a size check"""
-    if not text:
-        return None
-    if len(text) < sizecheck:
-        return "TEXT IS TOO SMALL IGNORE"
-    normaltext = normalize_text(text) or text
-    if nospaces:
-        return normaltext.replace(" ", "")
-    return normaltext
-
-
-# Title stripping functions moved to nowplaying.utils.filters.titlestripper()
-# Use that function instead of these deprecated ones
+# Backward-compatible alias — callers that use artist_name_variations() keep working.
+artist_name_variations = generate_artist_variations
 
 
 def humanize_time(seconds: float | int | str | None) -> str:
@@ -300,24 +266,6 @@ def humanize_time(seconds: float | int | str | None) -> str:
     if convseconds > 60:
         return time.strftime("%M:%S", time.gmtime(convseconds))
     return time.strftime("%S", time.gmtime(convseconds))
-
-
-def artist_name_variations(artistname: str) -> list[str]:
-    """turn an artistname into various computed variations"""
-    lowername = unsmartquotes(artistname.lower())
-    names = [lowername, lowername.translate(CUSTOM_TRANSLATE)]
-    if normalized := normality.normalize(lowername):
-        names.append(normalized)
-        names.append(normalized.translate(CUSTOM_TRANSLATE))
-    for recheck in ARTIST_VARIATIONS_RE:
-        if matched := recheck.match(lowername):
-            matchstr = matched.group(1)
-            names.append(matchstr)
-            names.append(matchstr.translate(CUSTOM_TRANSLATE))
-            if normalized := normality.normalize(matchstr):
-                names.append(normalized)
-                names.append(normalized.translate(CUSTOM_TRANSLATE))
-    return list(dict.fromkeys(names))
 
 
 def create_http_connector(

--- a/nowplaying/vendor/wnpmb.pyi
+++ b/nowplaying/vendor/wnpmb.pyi
@@ -1,1 +1,0 @@
-from wnpmb import *

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -479,20 +479,29 @@ class StaticContentHandler:
         return None
 
     @staticmethod
+    def _normalize_version(version: str) -> str:
+        """Pad a short version string to major.minor.micro so Version() can parse it."""
+        parts = version.split(".")
+        while len(parts) < 3:
+            parts.append("0")
+        return ".".join(parts[:3])
+
+    @staticmethod
     def _check_agent_version(metadata: dict) -> "web.Response | None":
         """Return a 426 response if a known agent is below its minimum version, else None."""
         agent_lower = (metadata.get("source_agent_name") or "").lower()
-        agent_version = metadata.get("source_agent_version") or "0"
+        raw_version = metadata.get("source_agent_version") or "0"
+        agent_version = StaticContentHandler._normalize_version(raw_version)
         for prefix, min_version in REMOTE_AGENT_MIN_VERSIONS.items():
             if agent_lower.startswith(prefix):
                 try:
                     if nowplaying.upgrades.Version(agent_version) < nowplaying.upgrades.Version(
-                        min_version
+                        StaticContentHandler._normalize_version(min_version)
                     ):
                         logging.warning(
                             "Agent %s version %s is below minimum %s",
                             metadata.get("source_agent_name"),
-                            agent_version,
+                            raw_version,
                             min_version,
                         )
                         return web.json_response(
@@ -502,7 +511,7 @@ class StaticContentHandler:
                 except ValueError:
                     logging.warning(
                         "Unparsable agent version %s from %s",
-                        agent_version,
+                        raw_version,
                         metadata.get("source_agent_name"),
                     )
                 break
@@ -564,12 +573,20 @@ class StaticContentHandler:
         # Store metadata in remote database
         try:
             # Processing timeout to prevent hanging on network calls
-            processed_metadata = await asyncio.wait_for(
-                request.app[self.metadata_key].getmoremetadata(
-                    metadata=clean_metadata, imagecache=request.app[self.ic_key]
-                ),
-                timeout=30.0,
-            )
+            try:
+                processed_metadata = await asyncio.wait_for(
+                    request.app[self.metadata_key].getmoremetadata(
+                        metadata=clean_metadata, imagecache=request.app[self.ic_key]
+                    ),
+                    timeout=30.0,
+                )
+            except TimeoutError:
+                logging.warning(
+                    "Metadata enrichment timed out for request from %s; storing basic metadata",
+                    request.remote,
+                )
+                processed_metadata = clean_metadata
+
             await request.app[self.remotedb_key].write_to_metadb(metadata=processed_metadata)
             # Re-read to get the dbid
             last_meta = await request.app[self.remotedb_key].read_last_meta_async()
@@ -578,17 +595,12 @@ class StaticContentHandler:
             # Filter out excluded fields from response to ensure JSON serialization works
             response_metadata = self._filter_excluded_fields(processed_metadata)
 
-            # Let aiohttp handle JSON serialization automatically
-
             # Build response with optional warnings
             response = {"dbid": dbid, "processed_metadata": response_metadata}
             if validation_warnings:
                 response["warnings"] = validation_warnings
 
             return web.json_response(response)
-        except TimeoutError:
-            logging.error("Metadata processing timeout for request from %s", request.remote)
-            return web.json_response({"error": "Processing timeout"}, status=408)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logging.error("Failed to store metadata in remote database: %s", exc)
             return web.json_response({"error": "Failed to store metadata"}, status=500)

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -580,7 +580,7 @@ class StaticContentHandler:
                     ),
                     timeout=30.0,
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 logging.warning(
                     "Metadata enrichment timed out for request from %s; storing basic metadata",
                     request.remote,

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -7,7 +7,6 @@ charset-normalizer==3.4.7
 defusedxml==0.7.1
 discord.py==2.7.1
 diskcache==5.6.3
-httpx[http2]==0.28.1
 jinja2==3.1.6
 lxml==6.0.4
 netifaces-plus==0.12.5
@@ -29,6 +28,7 @@ truststore==0.10.4
 twitchAPI==4.5.0
 url_normalize==2.2.1
 watchdog==6.0.0
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.1.10/wnpmb-0.1.10-py3-none-any.whl
 zeroconf==0.148.0
 
 #

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -367,14 +367,13 @@ async def test_fallback_davidbowie(getmusicbrainz):  # pylint: disable=redefined
 
 @pytest.mark.asyncio
 async def test_fallback_complex_and_with_feature(getmusicbrainz):  # pylint: disable=redefined-outer-name
-    """a very complex one. get the wrong recording id which is correctly rejected though"""
+    """MB returns a mismatched title (reference track), so recording id is rejected"""
     mbhelper = getmusicbrainz
-    metadata = {"artist": "Troye Sivan & Kacey Musgraves feat Mark Ronson", "title": "Easy"}
+    metadata = {"artist": "Kendrick Lamar feat SZA", "title": "All the Stars"}
     newdata = await mbhelper.lastditcheffort(metadata)
     assert newdata.get("musicbrainzartistid") == [
-        "e5712ceb-c37a-4c49-a11c-ccf4e21852d4",
-        "d1393ecb-431b-4fde-a6ea-d769f2f040cb",
-        "c3c82bdc-d9e7-4836-9746-c24ead47ca19",
+        "381086ea-f511-4aba-bdf9-71c753dc5077",
+        "272989c8-5535-492d-a25c-9f58803e027f",
     ]
     assert not newdata.get("musicbrainzrecordingid")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,7 +132,7 @@ def test_image_conversion_parameterized(getroot, conversion_func, expected_heade
             "Grimes feat Janelle Monáe",
             ["grimes feat janelle monáe", "grimes feat janelle monae", "grimes"],
         ),
-        ("G feat J and featuring U", ["g feat j and featuring u", "g"]),
+        ("G feat J and featuring U", ["g feat j and featuring u", "g feat j", "g"]),
         (
             "MӨЯIS BLΛK feat. grabyourface",
             [

--- a/tests/upgrade/test_520.py
+++ b/tests/upgrade/test_520.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""test 5.2.0 config upgrade"""
+
+import os
+import sys
+import tempfile
+
+from PySide6.QtCore import (  # pylint: disable=no-name-in-module
+    QCoreApplication,
+    QSettings,
+)
+from upgradetools import reboot_macosx_prefs  # pylint: disable=import-error
+
+import nowplaying.bootstrap  # pylint: disable=import-error
+import nowplaying.upgrades.config  # pylint: disable=import-error
+
+
+def _make_config(version: str, extra_keys: dict | None = None) -> str:
+    """Create a QSettings config at the given version with optional extra keys."""
+    if sys.platform == "win32":
+        qsettingsformat = QSettings.IniFormat
+    else:
+        qsettingsformat = QSettings.NativeFormat
+
+    nowplaying.bootstrap.set_qt_names(appname="testsuite")
+
+    settings = QSettings(
+        qsettingsformat,
+        QSettings.UserScope,
+        QCoreApplication.organizationName(),
+        QCoreApplication.applicationName(),
+    )
+    settings.clear()
+    reboot_macosx_prefs()
+    settings.setValue("settings/configversion", version)
+    if extra_keys:
+        for key, value in extra_keys.items():
+            settings.setValue(key, value)
+    settings.sync()
+    filename = settings.fileName()
+    del settings
+    reboot_macosx_prefs()
+    assert os.path.exists(filename)
+    return filename
+
+
+def test_upgrade_520_removes_tenorkey():
+    """upgrade to 5.2.0 strips the gifwords/tenorkey setting"""
+    with tempfile.TemporaryDirectory() as newpath:
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+
+        _oldfilename = _make_config(
+            "5.1.0",
+            {"gifwords/tenorkey": "some-tenor-api-key", "settings/delay": "2.5"},
+        )
+
+        reboot_macosx_prefs()
+        nowplaying.bootstrap.set_qt_names(appname="testsuite")
+        _upgrade = nowplaying.upgrades.config.UpgradeConfig(testdir=newpath)  # pylint: disable=unused-variable
+
+        config = QSettings(
+            qsettingsformat,
+            QSettings.UserScope,
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+        newfilename = config.fileName()
+        config.sync()
+
+        assert config.value("gifwords/tenorkey") is None
+        assert config.value("settings/delay") == "2.5"
+
+        config.clear()
+        del config
+        if os.path.exists(newfilename):
+            os.unlink(newfilename)
+        reboot_macosx_prefs()
+
+
+def test_upgrade_520_fixes_missing_basic_web_htm(tmp_path):
+    """upgrade to 5.2.0 replaces basic-web.htm with ws-frosted-glass.htm when file is absent"""
+    with tempfile.TemporaryDirectory() as newpath:
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        old_template = str(templates_dir / "basic-web.htm")
+        expected_template = str(templates_dir / "ws-frosted-glass.htm")
+
+        _oldfilename = _make_config(
+            "5.1.0",
+            {"weboutput/htmltemplate": old_template},
+        )
+
+        reboot_macosx_prefs()
+        nowplaying.bootstrap.set_qt_names(appname="testsuite")
+        _upgrade = nowplaying.upgrades.config.UpgradeConfig(testdir=newpath)  # pylint: disable=unused-variable
+
+        config = QSettings(
+            qsettingsformat,
+            QSettings.UserScope,
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+        newfilename = config.fileName()
+        config.sync()
+
+        assert config.value("weboutput/htmltemplate") == expected_template
+
+        config.clear()
+        del config
+        if os.path.exists(newfilename):
+            os.unlink(newfilename)
+        reboot_macosx_prefs()
+
+
+def test_upgrade_520_preserves_basic_web_htm_if_file_exists(tmp_path):
+    """upgrade to 5.2.0 must not replace basic-web.htm if the file still exists on disk"""
+    with tempfile.TemporaryDirectory() as newpath:
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        old_template_path = templates_dir / "basic-web.htm"
+        old_template_path.write_text("<!-- existing template -->")
+        old_template = str(old_template_path)
+
+        _oldfilename = _make_config(
+            "5.1.0",
+            {"weboutput/htmltemplate": old_template},
+        )
+
+        reboot_macosx_prefs()
+        nowplaying.bootstrap.set_qt_names(appname="testsuite")
+        _upgrade = nowplaying.upgrades.config.UpgradeConfig(testdir=newpath)  # pylint: disable=unused-variable
+
+        config = QSettings(
+            qsettingsformat,
+            QSettings.UserScope,
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+        newfilename = config.fileName()
+        config.sync()
+
+        assert config.value("weboutput/htmltemplate") == old_template
+
+        config.clear()
+        del config
+        if os.path.exists(newfilename):
+            os.unlink(newfilename)
+        reboot_macosx_prefs()
+
+
+def test_upgrade_520_preserves_other_template():
+    """upgrade to 5.2.0 does not modify htmltemplate when it is not basic-web.htm"""
+    with tempfile.TemporaryDirectory() as newpath:
+        if sys.platform == "win32":
+            qsettingsformat = QSettings.IniFormat
+        else:
+            qsettingsformat = QSettings.NativeFormat
+
+        existing_template = "/Users/dj/Documents/WhatsNowPlaying/templates/my-custom.htm"
+
+        _oldfilename = _make_config(
+            "5.1.0",
+            {"weboutput/htmltemplate": existing_template},
+        )
+
+        reboot_macosx_prefs()
+        nowplaying.bootstrap.set_qt_names(appname="testsuite")
+        _upgrade = nowplaying.upgrades.config.UpgradeConfig(testdir=newpath)  # pylint: disable=unused-variable
+
+        config = QSettings(
+            qsettingsformat,
+            QSettings.UserScope,
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+        newfilename = config.fileName()
+        config.sync()
+
+        assert config.value("weboutput/htmltemplate") == existing_template
+
+        config.clear()
+        del config
+        if os.path.exists(newfilename):
+            os.unlink(newfilename)
+        reboot_macosx_prefs()

--- a/vendor.txt
+++ b/vendor.txt
@@ -1,3 +1,2 @@
 git+https://github.com/whatsnowplaying/tinytag@wnp
-git+https://github.com/whatsnowplaying/wnpmb@0.1.6
 


### PR DESCRIPTION
* Replace vendored wnpmb with installed wheel (0.1.10) from GitHub releases; remove nowplaying/vendor/wnpmb.pyi and vendor.txt entry
* Remove httpx from requirements-run.txt (transitive dep via wnpmb)
* Replace local normalize/normalize_text/unsmartquotes/ artist_name_variations/ARTIST_VARIATIONS_RE/CUSTOM_TRANSLATE in nowplaying/utils/__init__.py with re-exports from wnpmb
* Update musicbrainz/client.py and helper.py to import from wnpmb directly; fix set_useragent() call for new single-arg API; set explicit timeout=5.0 and RetrySettings(timeout_retries=1)
* Fix remote agent version parsing to accept two-part versions like "0.1" by padding to major.minor.micro before comparison
* Fix 30s enrichment timeout to store basic metadata instead of dropping the track with a 408 response
* Quickstart doc and OBS export steps updated
* config.py: set better default templates for new installs
* upgrades/config.py: migrate basic-web.htm → ws-frosted-glass.htm

## Summary by Sourcery

Upgrade metadata normalization and MusicBrainz integration while improving remote agent handling, defaults, and upgrade behavior.

New Features:
- Use the external wnpmb package for string normalization, artist variations, and MusicBrainz client functionality instead of vendored code.
- Provide a ready-to-import OBS scene collection export workflow with clearer quickstart guidance for overlays.

Bug Fixes:
- Relax remote agent version parsing to handle two-part version strings by normalizing them before comparison.
- Ensure remote metadata enrichment timeouts fall back to storing basic metadata instead of returning a 408 error.
- Correct MusicBrainz client configuration for the updated API, including user agent setup and request timeout behavior.
- Fix configuration upgrades to replace missing basic-web.htm templates with ws-frosted-glass.htm only when the original file is absent.

Enhancements:
- Set more helpful default output paths and templates for new installs, including a default now-playing text file and ws-frosted-glass.htm HTML template.
- Adjust artist name variation handling to include additional computed variations via the updated normalization utilities.

Build:
- Remove direct httpx runtime dependency now that it is provided transitively via wnpmb.

Documentation:
- Expand OBS setup instructions in the quickstart guide to document the export flow and contents of the generated scene collection.

Tests:
- Add upgrade tests for the 5.2.0 config migration, covering removal of the Tenor key and template path fixes.
- Update artist name variation tests to reflect the expanded variation set produced by the new normalization logic.

Chores:
- Remove the vendored wnpmb stub file and associated vendor metadata now that the project depends on the published wheel.