### PR TITLE
Add EarShot mentions across docs for vinyl/CDJ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ MPRIS2-compatible players (Linux)
 
 **File-based:** M3U playlists
 
+**Via EarShot:** Vinyl decks, standalone CDJs, Rekordbox, and analog mixers —
+using Shazam-based audio identification on macOS, iOS, and watchOS
+
 ## Download
 
 [Get the latest release](https://github.com/whatsnowplaying/whats-now-playing/releases)

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,6 +39,14 @@ updates required.
 * **MPRIS2** (Linux) — reads from VLC, Rhythmbox, Spotify, and any
   MPRIS2-compatible player
 
+### [Vinyl, CDJs & Analog Mixers](https://whatsnowplaying.com/earshot)
+
+* **[EarShot](https://whatsnowplaying.com/earshot)** — companion app for macOS, iOS, and
+  watchOS that uses Shazam-based audio identification to detect tracks playing on
+  vinyl decks, standalone CDJs, Rekordbox, and analog mixers, then sends them to
+  WNP automatically over the local network. No software integration with the
+  hardware required. Requires WNP 5.2.0 or later.
+
 ### [Remote WNP Instance](input/remote.md)
 
 * One WNP instance can receive track data from another WNP instance over the

--- a/docs/input/index.md
+++ b/docs/input/index.md
@@ -34,3 +34,12 @@ Network streaming and file-based sources:
 - **[Icecast](icecast.md)** - Icecast streaming server metadata
 - **[M3U](m3u.md)** - M3U playlist file monitoring
 - **[Remote](remote.md)** - Remote input via REST API from other applications
+
+## Vinyl, CDJs & Analog Mixers
+
+For hardware not directly supported by WNP:
+
+- **[EarShot](https://whatsnowplaying.com/earshot)** - companion app for macOS, iOS, and
+  watchOS that uses Shazam-based audio identification to detect tracks from vinyl decks,
+  standalone CDJs, Rekordbox, and analog mixers, then sends them to WNP over the local
+  network. Requires WNP 5.2.0 or later.

--- a/docs/input/remote.md
+++ b/docs/input/remote.md
@@ -85,4 +85,5 @@ http://localhost:8899/v1/remoteinput?title=<t>&artist=<a>&album=<l>&isrc=<i>&com
 
 ## Advanced API Usage
 
-For detailed API documentation including request/response formats, authentication, and validation details, see the [API Reference](../reference/api.md#getpost-v1remoteinput).
+For detailed API documentation including request/response formats, authentication, and validation details,
+see the [API Reference](../reference/api.md#getpost-v1remoteinput).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -3,10 +3,13 @@
 > Free, open-source application for Windows, macOS, and Linux that reads live
 > track data from DJ software and makes it available to stream overlays, chat
 > bots, text files, and APIs. Supports Serato DJ, Traktor, Virtual DJ, Denon DJ,
-> djay Pro, DJUCED, and more. Outputs to OBS, Twitch, Kick, Discord, and custom
-> HTML overlays via a built-in web server with Jinja2 templating. Includes OBS
-> scene export to generate ready-to-import OBS 28+ scene collection JSON files
-> with pre-configured browser sources.
+> djay Pro, DJUCED, and more. Vinyl decks, standalone CDJs, Rekordbox, and analog
+> mixers are supported via EarShot, a companion app using Shazam-based audio
+> identification.
+> Outputs to OBS, Twitch, Kick, Discord, and custom HTML overlays via a built-in
+> web server with Jinja2 templating. Includes OBS scene export to generate
+> ready-to-import OBS 28+ scene collection JSON files with pre-configured browser
+> sources.
 
 ## Key Pages
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,6 +22,9 @@ On first launch, **What's Now Playing** attempts to auto-detect your DJ software
 * Hardware-based sources (Denon StageLinQ) require the device to be connected and
   actively broadcasting on the network
 * The first detected source wins. If multiple are found, you can change it afterwards.
+* For **vinyl decks, standalone CDJs, Rekordbox, and analog mixers**, use
+  [EarShot](https://whatsnowplaying.com/earshot) — a companion app that identifies
+  tracks via Shazam and sends them to WNP automatically
 
 Before launching, make sure your DJ software has been run at least once. For Traktor, first
 launch also includes building a file index, which may take a few minutes for large libraries.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -112,7 +112,8 @@ The API includes automatic validation and processing:
 1. **Field Length Limits**: String fields are truncated to 1000 characters
 2. **Null Byte Stripping**: Removes null bytes (`\x00`) from string values
 3. **Security Filtering**: Blocks system fields and binary data
-4. **Full Metadata Processing**: Runs complete enrichment including MusicBrainz lookups, artist extras, and recognition services
+4. **Full Metadata Processing**: Runs complete enrichment including MusicBrainz lookups, artist extras,
+   and recognition services
 
 ### GET /v1/status
 

--- a/docs/settings/filter.md
+++ b/docs/settings/filter.md
@@ -1,8 +1,25 @@
 # Filter
 
-Some DJ Pools add extra identifiers to track titles. **What's Now Playing** has
-the ability to remove extra text from the title of a track using two types of
-filters: **Simple** phrase-based filters and **Complex** regex patterns.
+Track titles often contain extra text that clutters stream overlays and chat
+announcements — DJ Pool tags, YouTube-style suffixes, remix labels, video quality
+flags, and more. **What's Now Playing** can automatically strip this extra text
+from track titles before sending it anywhere.
+
+> **Note:** Filters apply to the **track title only**. Artist, album, and other
+> metadata fields are not affected.
+
+## Why You Might Need Filters
+
+Here are common examples of title clutter that filters can remove:
+
+* DJ Pool tags: `Song Title - HD`, `Song Title (Clean)`, `Song Title [Explicit]`
+* Video suffixes: `Song Title (Official Music Video)`, `Song Title [Lyric Video]`
+* Version labels: `Song Title (Radio Edit)`, `Song Title - Extended Mix`
+* Remaster notes: `Song Title (Remastered)`, `Song Title - 2024 Remaster`
+* BPM/key annotations added by some tools: `Song Title (128 BPM)`, `Song Title [Am]`
+
+Without filtering, these tags appear in your overlays, chat announcements,
+Guess Game, and set lists exactly as stored in the file.
 
 ## Filter Types
 
@@ -16,10 +33,11 @@ The Simple tab provides an easy-to-use interface for filtering common
 unwanted phrases from track titles. These filters work by matching
 specific phrases in different formats (all case-insensitive):
 
-* **- phrase**: Matches " - phrase" at the end of titles
-* **(phrase)**: Matches " (phrase)" anywhere in titles
-* **[phrase]**: Matches " [phrase]" anywhere in titles
-* **plain**: Matches "phrase" anywhere in titles
+* **- phrase**: Matches `"- phrase"` at the end of titles (with a leading space)
+* **(phrase)**: Matches `"(phrase)"` anywhere in titles (with a leading space)
+* **[phrase]**: Matches `"[phrase]"` anywhere in titles (with a leading space)
+* **plain**: Matches `phrase` anywhere in titles (use with care — plain
+  matching strips the phrase wherever it appears in the title)
 
 #### Default Phrases
 
@@ -31,11 +49,22 @@ By default, these phrases are enabled for dash/paren/bracket filtering:
   official music video, official trailer, official video
 * Audio processing: remaster, remastered
 
+#### Additional Phrases (Off by Default)
+
+These phrases are available but not enabled by default — turn them on if
+they appear in your library:
+
+* Version types: acoustic, acoustic version, club mix, demo, demo version,
+  extended mix, extended version, instrumental, live, live version,
+  radio edit, radio version, remix, studio version, unreleased
+* Release types: anniversary edition, bonus track, deluxe edition, special edition
+
 #### Managing Custom Phrases
 
 * **Add custom phrases**: Enter text in the input field and click "Add"
 * **Remove custom phrases**: Select a custom phrase row and click "Remove"
-* **Configure formats**: Use checkboxes to enable/disable different matching formats for each phrase
+* **Configure formats**: Use checkboxes to enable/disable different matching
+  formats for each phrase
 
 ### Complex Filters
 
@@ -43,7 +72,11 @@ By default, these phrases are enabled for dash/paren/bracket filtering:
 
 The Complex tab allows advanced users to create custom
 [Python-style regular expressions](https://docs.python.org/3/howto/regex.html)
-for more sophisticated pattern matching.
+for more sophisticated pattern matching. This is useful for:
+
+* Stripping BPM or key annotations like `(128 BPM)` or `[Am]`
+* Removing `feat.` / `ft.` artist credits from titles
+* Handling source-specific tagging conventions not covered by simple phrases
 
 #### Adding Complex Rules
 
@@ -56,7 +89,7 @@ for more sophisticated pattern matching.
 * **Delete entry**: Select entry and click "Delete Entry"
 * **Reorder rules**: Drag entries to change application order
 * **Add number patterns**: Click "Add Numbers" to add patterns that
-  match numbers in parentheses/brackets like " (123)" and " [456]"
+  match numbers in parentheses/brackets like `"(123)"` and `"[456]"`
 
 ## Reset to Defaults
 
@@ -71,13 +104,16 @@ This provides a clean starting point if filters become misconfigured.
 ## Testing Your Filters
 
 The test section at the bottom works with **both** simple and
-complex filters together, showing exactly what will happen to track titles in real usage:
+complex filters together, showing exactly what will happen to track titles
+in real usage:
 
 1. Enter test text in the input field
 2. Click "Test" button
-3. The result shows what the title becomes after applying **all active filters** (both simple and complex)
+3. The result shows what the title becomes after applying **all active filters**
+   (both simple and complex)
 
-This unified testing ensures you see the complete filtering behavior that will be applied to your tracks.
+Paste a few real titles from your library to verify the output looks right
+before going live.
 
 ## How Filters Are Applied
 
@@ -87,3 +123,5 @@ During playback, **What's Now Playing** applies filters in this order:
 2. **Complex regex patterns** (in the order shown in the Complex tab)
 
 Both types of filters work together to provide comprehensive title cleaning.
+The cleaned title is used everywhere — overlays, chat announcements, text
+output, the Guess Game, and set lists.


### PR DESCRIPTION
Update README, features, input index, quickstart, and llms.txt to reference EarShot as the path for vinyl decks, standalone CDJs, and analog mixers not directly supported by WNP.

## Summary by Sourcery

Document EarShot as the recommended solution for using WNP with vinyl decks, standalone CDJs, and analog mixers across the main README and input-related docs.

Documentation:
- Add an EarShot section to the input sources index describing Shazam-based identification for vinyl, CDJs, and analog mixers and its WNP version requirement.
- Highlight EarShot as a vinyl/CDJ/analog mixer workflow in the features documentation with a dedicated subsection and link.
- Mention EarShot as the path for using vinyl decks, standalone CDJs, and analog mixers in the README input sources list.
- Update the quickstart guide to direct users of vinyl decks, standalone CDJs, and analog mixers to EarShot as the companion app.