### PR TITLE
Add macOS code signing, notarization, and stapling

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -16,10 +16,15 @@ on:  # yamllint disable-line rule:truthy
       artifact-name:
         required: true
         type: string
+      environment:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
     steps:
@@ -37,7 +42,26 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - name: import signing certificate
+        if: ${{ secrets.MACOS_CERTIFICATE != '' }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          echo "$MACOS_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import /tmp/certificate.p12 -k build.keychain \
+            -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          rm -f /tmp/certificate.p12
       - name: run builder
+        env:
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"

--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -20,10 +20,15 @@ on:  # yamllint disable-line rule:truthy
       macos-deployment-target:
         required: true
         type: string
+      environment:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
     steps:
@@ -85,9 +90,27 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - name: import signing certificate
+        if: ${{ secrets.MACOS_CERTIFICATE != '' }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          echo "$MACOS_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import /tmp/certificate.p12 -k build.keychain \
+            -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          rm -f /tmp/certificate.p12
       - name: run builder
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-deployment-target }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"

--- a/.github/workflows/macos26-pyinstaller.yml
+++ b/.github/workflows/macos26-pyinstaller.yml
@@ -14,9 +14,11 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pyinstaller-macos26-arm:
     uses: ./.github/workflows/macos26-build.yml
+    secrets: inherit
     permissions:
       contents: read
     with:
       runs-on: macos-26
       artifact-name: macos15-arm-dist-from-macos26
       macos-deployment-target: '15.0'
+      environment: macos-signing

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -14,19 +14,23 @@ on: [push]  # yamllint disable-line rule:truthy
 jobs:
   pyinstaller-macos-arm:
     uses: ./.github/workflows/macos-build.yml
+    secrets: inherit
     permissions:
       contents: read
     with:
       runs-on: macos-15
       artifact-name: macos15-arm-dist
+      environment: macos-signing
 
   pyinstaller-macos-intel:
     uses: ./.github/workflows/macos-build.yml
+    secrets: inherit
     permissions:
       contents: read
     with:
       runs-on: macos-15-intel
       artifact-name: macos15-intel-dist
+      environment: macos-signing
 
 
   pyinstaller-linux:

--- a/WhatsNowPlaying.spec
+++ b/WhatsNowPlaying.spec
@@ -212,7 +212,7 @@ for execname, execpy in executables.items():
             coll,
             name=f'{execname}.app',
             icon=geticon(),
-            bundle_identifier=None,
+            bundle_identifier='com.whatsnowplaying.app',
             info_plist={
                 'CFBundleDisplayName': "What's Now Playing",
                 'CFBundleName': 'WhatsNowPlaying',

--- a/bincomponents/entitlements.plist
+++ b/bincomponents/entitlements.plist
@@ -2,13 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <!--
-    These are required for binaries built by PyInstaller.
-    For more info, see:
+    Required for binaries built by PyInstaller with hardened runtime.
+    See:
       https://developer.apple.com/documentation/security/hardened_runtime
       https://github.com/pyinstaller/pyinstaller/issues/4629
   -->
   <dict>
+    <!-- Python requires writable+executable memory pages -->
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- PyInstaller bundles third-party dylibs that may not carry a matching team ID -->
+    <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
   </dict>
 </plist>

--- a/bincomponents/osxcodesign.sh
+++ b/bincomponents/osxcodesign.sh
@@ -1,15 +1,74 @@
 #!/usr/bin/env bash
+# Sign, notarize, and staple a macOS app bundle.
+#
+# Required env var:
+#   MACOS_SIGN_IDENTITY  "Developer ID Application: Name (TEAMID)"
+#
+# Optional env vars (all three required for notarization):
+#   APPLE_ID             Apple ID email
+#   APPLE_ID_PASSWORD    App-specific password (from appleid.apple.com)
+#   APPLE_TEAM_ID        10-character team ID
 
-CERTIFICATE=$1
+set -euo pipefail
 
-if [[ -z "${CERTIFICATE}" ]]; then
-  echo "ERROR: Must provide name of certificate in keychain."
+APP="${1:?Usage: osxcodesign.sh <path/to/App.app>}"
+
+if [[ -z "${MACOS_SIGN_IDENTITY:-}" ]]; then
+  echo "ERROR: MACOS_SIGN_IDENTITY must be set."
   exit 1
 fi
 
-codesign \
-	-v \
-	-s "${CERTIFICATE}" \
-	--entitlements bincomponents/entitlements.plist \
-	--deep \
-	dist/NowPlaying.app/
+echo "=== Signing ${APP} ==="
+
+# Sign all dylibs and Python extension modules from the inside out.
+# This must happen before signing the outer bundle.
+find "${APP}" \( -name "*.dylib" -o -name "*.so" \) | while read -r f; do
+  codesign --force --sign "${MACOS_SIGN_IDENTITY}" \
+    --options runtime \
+    --entitlements bincomponents/entitlements.plist \
+    --timestamp \
+    "${f}"
+done
+
+# Sign any nested executables other than the main binary
+find "${APP}/Contents/MacOS" -type f ! -name "WhatsNowPlaying" | while read -r f; do
+  codesign --force --sign "${MACOS_SIGN_IDENTITY}" \
+    --options runtime \
+    --entitlements bincomponents/entitlements.plist \
+    --timestamp \
+    "${f}"
+done
+
+# Sign the app bundle itself
+codesign --force --sign "${MACOS_SIGN_IDENTITY}" \
+  --options runtime \
+  --entitlements bincomponents/entitlements.plist \
+  --timestamp \
+  "${APP}"
+
+echo "=== Verifying signature ==="
+codesign --verify --deep --strict --verbose=2 "${APP}"
+spctl --assess --type execute --verbose "${APP}"
+
+# Notarize only if all three Apple credentials are present
+if [[ -n "${APPLE_ID:-}" && -n "${APPLE_ID_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
+  echo "=== Notarizing ==="
+  NOTARIZE_ZIP="${APP%.app}-notarize.zip"
+  ditto -c -k --keepParent "${APP}" "${NOTARIZE_ZIP}"
+
+  xcrun notarytool submit "${NOTARIZE_ZIP}" \
+    --apple-id "${APPLE_ID}" \
+    --password "${APPLE_ID_PASSWORD}" \
+    --team-id "${APPLE_TEAM_ID}" \
+    --wait
+
+  rm -f "${NOTARIZE_ZIP}"
+
+  echo "=== Stapling ==="
+  xcrun stapler staple "${APP}"
+
+  echo "=== Verifying notarization ==="
+  spctl --assess --type execute --verbose "${APP}"
+else
+  echo "=== Skipping notarization (APPLE_ID/APPLE_ID_PASSWORD/APPLE_TEAM_ID not set) ==="
+fi

--- a/builder.sh
+++ b/builder.sh
@@ -223,6 +223,14 @@ else
   pyinstaller WhatsNowPlaying.spec
 fi
 
+if [[ "${SYSTEM}" == "macosx" && -n "${MACOS_SIGN_IDENTITY:-}" ]]; then
+  echo "*****"
+  echo "* Signing and notarizing"
+  echo "****"
+  chmod +x bincomponents/osxcodesign.sh
+  bincomponents/osxcodesign.sh dist/WhatsNowPlaying.app
+fi
+
 echo "*****"
 echo "* Cleanup "
 echo "****"


### PR DESCRIPTION
Sign the app bundle with hardened runtime after every PyInstaller build. Triggered by MACOS_SIGN_IDENTITY env var — unsigned builds are unchanged. Notarizes and staples when Apple credentials are also present.

Signing secrets are scoped to a 'macos-signing' GitHub Environment restricted to main, version tags, and the macos-signing branch, so arbitrary branch pushes cannot access the credentials.

- osxcodesign.sh: rewrite to sign dylibs/extensions inside-out, sign the app bundle with hardened runtime + timestamp, verify with spctl, then notarize+staple if APPLE_ID/APPLE_ID_PASSWORD/APPLE_TEAM_ID set
- entitlements.plist: add disable-library-validation for PyInstaller bundled third-party dylibs
- WhatsNowPlaying.spec: set bundle_identifier to com.whatsnowplaying.app
- macos-build.yml, macos26-build.yml: import certificate into a temporary keychain (skipped if MACOS_CERTIFICATE absent), pass signing env vars to builder, add optional 'environment' input
- pyinstaller.yaml, macos26-pyinstaller.yml: pass environment: macos-signing and secrets: inherit to the reusable build workflows

Required GitHub secrets (in the macos-signing environment):
  MACOS_CERTIFICATE      base64-encoded Developer ID Application .p12
  MACOS_CERTIFICATE_PWD  .p12 password
  MACOS_SIGN_IDENTITY    Developer ID Application: Name (TEAMID)
  APPLE_ID               Apple ID email
  APPLE_ID_PASSWORD      app-specific password
  APPLE_TEAM_ID          10-character team ID

## Summary by Sourcery

Add macOS code signing, notarization, and stapling to PyInstaller-built app bundles, wiring it into the build scripts and GitHub Actions workflows while keeping unsigned builds working as before.

Enhancements:
- Replace the macOS signing script to sign inner binaries first, apply hardened runtime entitlements, verify signatures, and optionally notarize and staple the app when Apple credentials are provided.
- Update PyInstaller entitlements to allow unsigned executable memory and disable library validation for bundled third-party dylibs.
- Set a stable macOS bundle identifier (com.whatsnowplaying.app) for the application bundle.

Build:
- Modify the build script to run the macOS signing/notarization pipeline after PyInstaller when a signing identity is provided.

CI:
- Extend reusable macOS build workflows to optionally target a GitHub environment, import a signing certificate into a temporary keychain, and expose signing/notarization environment variables to the builder.
- Update PyInstaller GitHub workflows to inherit secrets and run in the restricted macos-signing environment so only protected branches can produce signed/notarized macOS builds.