### PR TITLE
Add macOS code signing, notarization, and stapling

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: import signing certificate
-        if: ${{ env.MACOS_CERTIFICATE != '' }}
+        if: ${{ secrets.MACOS_CERTIFICATE != '' }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -16,10 +16,15 @@ on:  # yamllint disable-line rule:truthy
       artifact-name:
         required: true
         type: string
+      environment:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
     steps:
@@ -37,7 +42,28 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - name: import signing certificate
+        if: ${{ env.MACOS_CERTIFICATE != '' }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          echo "$MACOS_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          KEYCHAIN_PWD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PWD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PWD" build.keychain
+          security list-keychains -d user -s build.keychain $(security list-keychains -d user | tr -d '"')
+          security import /tmp/certificate.p12 -k build.keychain \
+            -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PWD" build.keychain
+          rm -f /tmp/certificate.p12
       - name: run builder
+        env:
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"

--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -20,10 +20,15 @@ on:  # yamllint disable-line rule:truthy
       macos-deployment-target:
         required: true
         type: string
+      environment:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
     steps:
@@ -85,9 +90,29 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - name: import signing certificate
+        if: ${{ env.MACOS_CERTIFICATE != '' }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          echo "$MACOS_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          KEYCHAIN_PWD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PWD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PWD" build.keychain
+          security list-keychains -d user -s build.keychain $(security list-keychains -d user | tr -d '"')
+          security import /tmp/certificate.p12 -k build.keychain \
+            -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PWD" build.keychain
+          rm -f /tmp/certificate.p12
       - name: run builder
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ inputs.macos-deployment-target }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"

--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: import signing certificate
-        if: ${{ env.MACOS_CERTIFICATE != '' }}
+        if: ${{ secrets.MACOS_CERTIFICATE != '' }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}

--- a/.github/workflows/macos26-pyinstaller.yml
+++ b/.github/workflows/macos26-pyinstaller.yml
@@ -14,9 +14,11 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pyinstaller-macos26-arm:
     uses: ./.github/workflows/macos26-build.yml
+    secrets: inherit  # pragma: allowlist secret
     permissions:
       contents: read
     with:
       runs-on: macos-26
       artifact-name: macos15-arm-dist-from-macos26
       macos-deployment-target: '15.0'
+      environment: macos-signing

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -14,19 +14,23 @@ on: [push]  # yamllint disable-line rule:truthy
 jobs:
   pyinstaller-macos-arm:
     uses: ./.github/workflows/macos-build.yml
+    secrets: inherit  # pragma: allowlist secret
     permissions:
       contents: read
     with:
       runs-on: macos-15
       artifact-name: macos15-arm-dist
+      environment: macos-signing
 
   pyinstaller-macos-intel:
     uses: ./.github/workflows/macos-build.yml
+    secrets: inherit  # pragma: allowlist secret
     permissions:
       contents: read
     with:
       runs-on: macos-15-intel
       artifact-name: macos15-intel-dist
+      environment: macos-signing
 
 
   pyinstaller-linux:

--- a/WhatsNowPlaying.spec
+++ b/WhatsNowPlaying.spec
@@ -198,7 +198,9 @@ for execname, execpy in executables.items():
             strip=False,
             upx=False,
             #console=False,
-            icon=geticon())
+            icon=geticon(),
+            codesign_identity=os.environ.get('MACOS_SIGN_IDENTITY'),
+            entitlements_file='bincomponents/entitlements.plist')
         coll = COLLECT(  # pylint: disable=undefined-variable
             exe,
             a.binaries,
@@ -212,7 +214,7 @@ for execname, execpy in executables.items():
             coll,
             name=f'{execname}.app',
             icon=geticon(),
-            bundle_identifier=None,
+            bundle_identifier='com.whatsnowplaying.app',
             info_plist={
                 'CFBundleDisplayName': "What's Now Playing",
                 'CFBundleName': 'WhatsNowPlaying',

--- a/bincomponents/entitlements.plist
+++ b/bincomponents/entitlements.plist
@@ -2,13 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <!--
-    These are required for binaries built by PyInstaller.
-    For more info, see:
+    Required for binaries built by PyInstaller with hardened runtime.
+    See:
       https://developer.apple.com/documentation/security/hardened_runtime
       https://github.com/pyinstaller/pyinstaller/issues/4629
   -->
   <dict>
+    <!-- Python requires writable+executable memory pages -->
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- PyInstaller bundles third-party dylibs that may not carry a matching team ID -->
+    <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
   </dict>
 </plist>

--- a/bincomponents/osxcodesign.sh
+++ b/bincomponents/osxcodesign.sh
@@ -1,15 +1,57 @@
 #!/usr/bin/env bash
+# Notarize and staple a macOS app bundle.
+# Signing is handled by PyInstaller via codesign_identity on EXE.
+#
+# Required env var:
+#   MACOS_SIGN_IDENTITY  "Developer ID Application: Name (TEAMID)"
+#
+# Optional env vars (all three required for notarization):
+#   APPLE_ID             Apple ID email
+#   APPLE_ID_PASSWORD    App-specific password (from appleid.apple.com)
+#   APPLE_TEAM_ID        10-character team ID
 
-CERTIFICATE=$1
+APP="${1:?Usage: osxcodesign.sh <path/to/App.app>}"
 
-if [[ -z "${CERTIFICATE}" ]]; then
-  echo "ERROR: Must provide name of certificate in keychain."
+if [[ -z "${MACOS_SIGN_IDENTITY:-}" ]]; then
+  echo "ERROR: MACOS_SIGN_IDENTITY must be set."
   exit 1
 fi
 
-codesign \
-	-v \
-	-s "${CERTIFICATE}" \
-	--entitlements bincomponents/entitlements.plist \
-	--deep \
-	dist/NowPlaying.app/
+echo "=== Verifying signature ==="
+codesign --verify --deep --strict --verbose=2 "${APP}"
+
+# Notarize only if all three Apple credentials are present
+if [[ -n "${APPLE_ID:-}" && -n "${APPLE_ID_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
+  echo "=== Notarizing ==="
+  NOTARIZE_ZIP="${APP%.app}-notarize.zip"
+  ditto -c -k --keepParent "${APP}" "${NOTARIZE_ZIP}"
+
+  NOTARIZE_RESULT=$(xcrun notarytool submit "${NOTARIZE_ZIP}" \
+    --apple-id "${APPLE_ID}" \
+    --password "${APPLE_ID_PASSWORD}" \
+    --team-id "${APPLE_TEAM_ID}" \
+    --wait --output-format json)
+  NOTARIZE_ID=$(echo "${NOTARIZE_RESULT}" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  NOTARIZE_STATUS=$(echo "${NOTARIZE_RESULT}" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
+  echo "Notarization status: ${NOTARIZE_STATUS} (id: ${NOTARIZE_ID})"
+
+  if [[ "${NOTARIZE_STATUS}" != "Accepted" ]]; then
+    echo "=== Notarization log ==="
+    xcrun notarytool log "${NOTARIZE_ID}" \
+      --apple-id "${APPLE_ID}" \
+      --password "${APPLE_ID_PASSWORD}" \
+      --team-id "${APPLE_TEAM_ID}"
+    echo "ERROR: Notarization failed with status: ${NOTARIZE_STATUS}"
+    exit 1
+  fi
+
+  rm -f "${NOTARIZE_ZIP}"
+
+  echo "=== Stapling ==="
+  xcrun stapler staple "${APP}"
+
+  echo "=== Verifying notarization ==="
+  spctl --assess --type execute --verbose "${APP}"
+else
+  echo "=== Skipping notarization (APPLE_ID/APPLE_ID_PASSWORD/APPLE_TEAM_ID not set) ==="
+fi

--- a/bincomponents/osxcodesign.sh
+++ b/bincomponents/osxcodesign.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Notarize and staple a macOS app bundle.
 # Signing is handled by PyInstaller via codesign_identity on EXE.
 #
@@ -30,7 +31,11 @@ if [[ -n "${APPLE_ID:-}" && -n "${APPLE_ID_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-
     --apple-id "${APPLE_ID}" \
     --password "${APPLE_ID_PASSWORD}" \
     --team-id "${APPLE_TEAM_ID}" \
-    --wait --output-format json)
+    --wait --output-format json) || {
+    echo "ERROR: notarytool submit failed (exit $?)"
+    echo "${NOTARIZE_RESULT}"
+    exit 1
+  }
   NOTARIZE_ID=$(echo "${NOTARIZE_RESULT}" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
   NOTARIZE_STATUS=$(echo "${NOTARIZE_RESULT}" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
   echo "Notarization status: ${NOTARIZE_STATUS} (id: ${NOTARIZE_ID})"

--- a/builder.sh
+++ b/builder.sh
@@ -223,6 +223,14 @@ else
   pyinstaller WhatsNowPlaying.spec
 fi
 
+if [[ "${SYSTEM}" == "macosx" && -n "${MACOS_SIGN_IDENTITY:-}" ]]; then
+  echo "*****"
+  echo "* Signing and notarizing"
+  echo "****"
+  chmod +x bincomponents/osxcodesign.sh
+  bincomponents/osxcodesign.sh dist/WhatsNowPlaying.app
+fi
+
 echo "*****"
 echo "* Cleanup "
 echo "****"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -90,16 +90,12 @@ instructions on adding a Browser Source by hand.
 
 ### macOS
 
-Due to security measures in macOS, unsigned apps require extra steps to open.
+The app is signed and notarized. macOS should open it without any security warnings.
 
 * Do not unzip the downloaded package directly to the folder you will run it from.
   Unzip in `Downloads` first, then move `WhatsNowPlaying.app` to `Applications`.
-* On first launch, macOS will show a warning that it cannot verify the app is free of malware.
-  This is expected for unsigned apps.
-* Open **System Settings → Privacy & Security**, scroll down to the **Security** section,
-  and click **Open Anyway** next to the WhatsNowPlaying entry.
-* If no **Open Anyway** button appears, open Terminal and run:
-  `sudo xattr -r -d com.apple.quarantine /path/to/WhatsNowPlaying.app`
+* If macOS still shows a security warning, open **System Settings → Privacy & Security**,
+  scroll down to the **Security** section, and click **Open Anyway**.
 
 ### Windows
 


### PR DESCRIPTION
PyInstaller signs all binaries during the build via codesign_identity and entitlements_file on EXE. After the build, osxcodesign.sh verifies the signature, notarizes via notarytool, and staples the ticket. Triggered by MACOS_SIGN_IDENTITY env var — unsigned builds unchanged.

Signing secrets are scoped to a 'macos-signing' GitHub Environment restricted to main, version tags, and the macos-signing branch, so arbitrary branch pushes cannot access the credentials.

- WhatsNowPlaying.spec: set bundle_identifier to com.whatsnowplaying.app; add codesign_identity and entitlements_file to EXE
- entitlements.plist: add disable-library-validation for PyInstaller bundled third-party dylibs
- osxcodesign.sh: rewrite as verify + notarize + staple; fetches and prints Apple's notarization log on failure
- builder.sh: call osxcodesign.sh after PyInstaller when MACOS_SIGN_IDENTITY is set
- macos-build.yml, macos26-build.yml: import certificate into a temporary keychain (skipped if MACOS_CERTIFICATE absent), pass signing env vars to builder, add optional 'environment' input
- pyinstaller.yaml, macos26-pyinstaller.yml: pass environment: macos-signing and secrets: inherit to the reusable build workflows

Required GitHub secrets (in the macos-signing environment):
  MACOS_CERTIFICATE      base64-encoded Developer ID Application .p12
  MACOS_CERTIFICATE_PWD  .p12 password
  MACOS_SIGN_IDENTITY    Developer ID Application: Name (TEAMID)
  APPLE_ID               Apple ID email
  APPLE_ID_PASSWORD      app-specific password
  APPLE_TEAM_ID          10-character team ID

## Summary by Sourcery

Add macOS code signing, notarization, and stapling to the build, wired through PyInstaller, the builder script, and macOS GitHub workflows, and update docs to reflect the new signed/notarized distribution.

New Features:
- Enable PyInstaller-built macOS app bundles to be signed using a configurable Developer ID identity and entitlements plist.
- Add optional notarization and stapling of the macOS app when Apple developer credentials are provided in the environment.

Enhancements:
- Define a stable macOS bundle identifier for the app to support signing and notarization.
- Extend the macOS GitHub build workflows to import a signing certificate into a temporary keychain and expose signing-related secrets via an environment-scoped configuration.

Documentation:
- Update macOS quickstart instructions to describe the signed and notarized app experience and simplify the steps for handling any remaining security prompts.