### PR TITLE
Add EarShot input plugin with always-accept override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ## Version 5.2.0 - In Progress
 
 * New Features
+  * EarShot input source
+    * New dedicated EarShot source for vinyl, CDJs, and analog mixers using
+      Shazam-based identification via the EarShot companion app
+    * Always-Accept mode runs EarShot as a secondary monitor alongside any
+      DJ software source; EarShot identifications automatically override the
+      active source when a new track is detected, then yield back when the DJ
+      software moves on
   * OBS Scene Collection exporter
     * New "Export for OBS..." system tray menu item generates a ready-to-import
       OBS 28+ scene collection JSON file with pre-configured browser sources

--- a/docs/input/earshot.md
+++ b/docs/input/earshot.md
@@ -1,0 +1,60 @@
+# EarShot
+
+EarShot is a companion app for macOS, iOS, and watchOS that uses Shazam-based
+audio identification to detect tracks playing on vinyl decks, standalone CDJs,
+Rekordbox, and analog mixers, then sends them to **What's Now Playing** over
+the local network.
+
+> NOTE: EarShot must be installed and configured separately. See the
+> [EarShot website](https://whatsnowplaying.com/earshot) for installation instructions.
+
+## Setup
+
+### Select EarShot as the Input Source
+
+1. Open Settings from the **What's Now Playing** icon
+2. Select Core Settings->Source from the left-hand column
+3. Select EarShot from the list of available input sources
+4. Click Save
+
+This is the right choice when your entire setup is vinyl, CDJs, or an analog
+mixer — EarShot is the only source feeding track data.
+
+### Always-Accept Mode
+
+If you mix vinyl or CDJs alongside DJ software (Serato, Traktor, etc.), use
+**Always-Accept** mode instead of switching sources:
+
+1. Open Settings from the **What's Now Playing** icon
+2. Select Input Sources->EarShot from the left-hand column
+3. Check **Always use EarShot when it identifies a new track**
+4. Select your DJ software as the active source under Core Settings->Source
+5. Click Save
+
+With this enabled, **What's Now Playing** runs a secondary EarShot monitor in
+the background. Whenever EarShot identifies a new track that differs from what
+the DJ software is reporting, EarShot's identification takes over. Once your DJ
+software moves on to a new track, it resumes control automatically.
+
+## How It Works
+
+EarShot sends identified tracks to WNP's remote input endpoint over the local
+network. The EarShot source filters incoming remote tracks to only those
+originating from EarShot — other remote sources are ignored.
+
+In always-accept mode, WNP compares artist and title between EarShot and the
+active DJ software source. If EarShot hears the same track the DJ software is
+already reporting (e.g. room audio bleed), it is treated as confirmation, not
+an override, so the display does not flicker.
+
+## Troubleshooting
+
+If EarShot identifications are not appearing:
+
+1. Confirm the EarShot app is running and connected to the same local network
+   as **What's Now Playing**
+2. Verify the WNP webserver is enabled (Output & Display->Web Server) and
+   listening on the correct port
+3. Check the EarShot app settings to confirm it is pointed at the correct
+   WNP host and port
+4. Check the **What's Now Playing** logs for incoming remote input activity

--- a/docs/input/index.md
+++ b/docs/input/index.md
@@ -39,7 +39,6 @@ Network streaming and file-based sources:
 
 For hardware not directly supported by WNP:
 
-- **[EarShot](https://whatsnowplaying.com/earshot)** - companion app for macOS, iOS, and
-  watchOS that uses Shazam-based audio identification to detect tracks from vinyl decks,
-  standalone CDJs, Rekordbox, and analog mixers, then sends them to WNP over the local
-  network. Requires WNP 5.2.0 or later.
+- **[EarShot](earshot.md)** - companion app for macOS, iOS, and watchOS that uses
+  Shazam-based audio identification to detect tracks from vinyl decks, standalone CDJs,
+  Rekordbox, and analog mixers, then sends them to WNP over the local network.

--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -9,9 +9,9 @@ import platform
 import socket
 import sys
 
+import PySide6.QtSvg  # noqa: F401  # pylint: disable=import-error, no-name-in-module, unused-import
 from PySide6.QtCore import QCoreApplication, Qt  # pylint: disable=import-error, no-name-in-module
 from PySide6.QtGui import QIcon  # pylint: disable=import-error, no-name-in-module
-import PySide6.QtSvg  # noqa: F401  # pylint: disable=import-error, no-name-in-module, unused-import
 from PySide6.QtWidgets import QApplication  # pylint: disable=import-error, no-name-in-module
 
 import nowplaying.bootstrap

--- a/nowplaying/inputs/earshot.py
+++ b/nowplaying/inputs/earshot.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""EarShot input plugin"""
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtWidgets import QWidget  # pylint: disable=import-error, no-name-in-module
+
+import nowplaying.inputs.remote
+from nowplaying.types import TrackMetadata
+
+if TYPE_CHECKING:
+    import nowplaying.config
+
+
+class Plugin(nowplaying.inputs.remote.Plugin):
+    """Input plugin for EarShot — accepts only EarShot-identified tracks."""
+
+    def __init__(
+        self,
+        config: "nowplaying.config.ConfigFile | None" = None,
+        qsettings: QWidget | None = None,
+    ):
+        super().__init__(config=config, qsettings=qsettings)
+        self.displayname = "EarShot"
+
+    def get_source_agent_data(self) -> dict:
+        """EarShot preserves source_agent data set by the sender."""
+        return {}
+
+    async def getplayingtrack(self) -> TrackMetadata | None:
+        """Return metadata only when it originated from EarShot."""
+        meta = self.metadata
+        if not meta:
+            return None
+        agent = meta.get("source_agent_name") or ""
+        if not agent.startswith("wnpearshot"):
+            return None
+        return meta
+
+    def load_settingsui(self, qwidget: "QWidget"):
+        """Load settings into the UI."""
+        if not self.config:
+            return
+        qwidget.earshot_always_checkbox.setChecked(  # type: ignore[attr-defined]
+            self.config.cparser.value("earshot/always_accept", type=bool, defaultValue=True)
+        )
+
+    def save_settingsui(self, qwidget: "QWidget"):
+        """Save settings from the UI."""
+        if not self.config:
+            return
+        self.config.cparser.setValue(
+            "earshot/always_accept",
+            qwidget.earshot_always_checkbox.isChecked(),  # type: ignore[attr-defined]
+        )
+
+    def verify_settingsui(self, qwidget: "QWidget"):
+        """Nothing to verify."""
+
+    def connect_settingsui(self, qwidget: "QWidget", uihelp):
+        """No connections needed."""
+        self.qwidget = qwidget
+        self.uihelp = uihelp
+
+    def desc_settingsui(self, qwidget: "QWidget"):
+        """Description shown in the source list."""
+        qwidget.setText(
+            "EarShot identifies tracks via Shazam on vinyl, CDJs, Rekordbox, and analog mixers."
+        )

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -85,7 +85,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         await self.setup_watcher()
         self.remotedb = nowplaying.db.MetadataDB(databasefile=str(self.remotedbfile))
 
-    async def getplayingtrack(self):
+    async def getplayingtrack(self) -> TrackMetadata | None:
         """wrapper to call getplayingtrack"""
         return self.metadata
 

--- a/nowplaying/metadata/__init__.py
+++ b/nowplaying/metadata/__init__.py
@@ -10,8 +10,8 @@ from nowplaying.metadata.processors import MetadataProcessors, main, recognition
 from nowplaying.metadata.tinytag_runner import (
     AUDIO_CONTAINER_EXCLUSIONS,
     AUDIO_EXTENSIONS,
-    TinyTagRunner,
     VIDEO_EXTENSIONS,
+    TinyTagRunner,
 )
 
 __all__ = [

--- a/nowplaying/notifications/remote.py
+++ b/nowplaying/notifications/remote.py
@@ -75,30 +75,30 @@ class Plugin(NotificationPlugin):
             debug_data["secret"] = "***REDACTED***"
 
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
+            async with (
+                aiohttp.ClientSession() as session,
+                session.post(
                     f"http://{self.server}:{self.port}/v1/remoteinput", json=remote_data
-                ) as response:
-                    logging.debug("Sending to %s:%s", self.server, self.port)
-                    if response.status == 200:
-                        try:
-                            result = await response.json()
-                            dbid = result.get("dbid")
-                            logging.debug("Remote server accepted track update, dbid: %s", dbid)
-                        except Exception as exc:  # pylint: disable=broad-except
-                            logging.warning("Failed to parse remote server response: %s", exc)
-                    elif response.status == 403:
-                        logging.error("Remote server authentication failed - check remote secret")
-                    elif response.status == 405:
-                        logging.error("Remote server method not allowed - check endpoint")
-                    else:
-                        try:
-                            error_text = await response.text()
-                            logging.error(
-                                "Remote server error %d: %s", response.status, error_text
-                            )
-                        except Exception:  # pylint: disable=broad-except
-                            logging.error("Remote server returned status %d", response.status)
+                ) as response,
+            ):
+                logging.debug("Sending to %s:%s", self.server, self.port)
+                if response.status == 200:
+                    try:
+                        result = await response.json()
+                        dbid = result.get("dbid")
+                        logging.debug("Remote server accepted track update, dbid: %s", dbid)
+                    except Exception as exc:  # pylint: disable=broad-except
+                        logging.warning("Failed to parse remote server response: %s", exc)
+                elif response.status == 403:
+                    logging.error("Remote server authentication failed - check remote secret")
+                elif response.status == 405:
+                    logging.error("Remote server method not allowed - check endpoint")
+                else:
+                    try:
+                        error_text = await response.text()
+                        logging.error("Remote server error %d: %s", response.status, error_text)
+                    except Exception:  # pylint: disable=broad-except
+                        logging.error("Remote server returned status %d", response.status)
         except aiohttp.ClientError as exc:
             logging.error(
                 "Failed to connect to remote server %s:%s - %s", self.server, self.port, exc

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -488,7 +488,7 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             await asyncio.sleep(1)
             return
 
-        nextmeta, earshot_overrode = await self._check_earshot_override(nextmeta)
+        nextmeta, _ = await self._check_earshot_override(nextmeta)
 
         if self._ismetaempty(nextmeta) or self._isignored(nextmeta):
             return

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -360,10 +360,11 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
 
         # EarShot has not changed — suppress main source if it is still reporting
         # the same stale track it was showing when EarShot last overrode.
+        # Return empty so _ismetaempty() at the call site skips the publish.
         if self.main_source_suppressed_meta and self._earshot_track_key(
             main_nextmeta
         ) == self._earshot_track_key(self.main_source_suppressed_meta):
-            return main_nextmeta, False  # caller will treat as empty / same
+            return {}, False
 
         # Main source has a genuinely new track — clear suppression.
         if self.main_source_suppressed_meta:
@@ -489,12 +490,7 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
 
         nextmeta, earshot_overrode = await self._check_earshot_override(nextmeta)
 
-        # Suppress the main source if EarShot overrode it and it hasn't changed yet.
-        if (
-            self._ismetaempty(nextmeta)
-            or self._isignored(nextmeta)
-            or (not earshot_overrode and bool(self.main_source_suppressed_meta))
-        ):
+        if self._ismetaempty(nextmeta) or self._isignored(nextmeta):
             return
 
         if self._ismetasame(nextmeta):

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -87,6 +87,13 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         self.guessgame: nowplaying.guessgame.GuessGame | None = None
         self._pending_meta: TrackMetadata | None = None
 
+        # EarShot secondary monitor (runs alongside any non-EarShot source)
+        self.earshot_plugin: nowplaying.inputs.InputPlugin | None = None
+        self.earshot_last_meta: TrackMetadata = {}
+        # When EarShot overrides, remember what the main source was reporting
+        # so its stale data does not immediately win back.
+        self.main_source_suppressed_meta: TrackMetadata = {}
+
     @classmethod
     def create_with_plugins(
         cls,
@@ -174,7 +181,34 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
                 logging.error("cannot start %s: %s", self.previousinput, error)
                 return False
 
+        await self._manage_earshot_plugin()
         return True
+
+    async def _manage_earshot_plugin(self):
+        """Start or stop the secondary EarShot monitor based on config and active source."""
+        active = self.config.cparser.value("settings/input")
+        always_accept = self.config.cparser.value(
+            "earshot/always_accept", type=bool, defaultValue=True
+        )
+        earshot_key = "nowplaying.inputs.earshot"
+        should_run = (
+            always_accept and active not in ("earshot", "remote") and earshot_key in self.plugins
+        )
+
+        if should_run and self.earshot_plugin is None:
+            logging.info("Starting secondary EarShot monitor")
+            self.earshot_plugin = self.plugins[earshot_key].Plugin(config=self.config)
+            try:
+                await self.earshot_plugin.start()
+            except Exception as err:  # pylint: disable=broad-except
+                logging.error("Cannot start EarShot secondary monitor: %s", err)
+                self.earshot_plugin = None
+        elif not should_run and self.earshot_plugin is not None:
+            logging.info("Stopping secondary EarShot monitor")
+            await self.earshot_plugin.stop()
+            self.earshot_plugin = None
+            self.earshot_last_meta = {}
+            self.main_source_suppressed_meta = {}
 
     async def run(self):
         """track polling process"""
@@ -237,6 +271,9 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
                 logging.warning("imagecache did not stop cleanly, terminating")
                 self.icprocess.terminate()
                 self.icprocess.join(timeout=5)
+        if self.earshot_plugin:
+            await self.earshot_plugin.stop()
+            self.earshot_plugin = None
         if self.input:
             await self.input.stop()
         self.plugins = None
@@ -281,6 +318,59 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             title = None
 
         return title, filename
+
+    @staticmethod
+    def _earshot_track_key(meta: TrackMetadata) -> tuple[str, str]:
+        """Stable (artist, title) key for EarShot change detection."""
+        return (meta.get("artist") or "", meta.get("title") or "")
+
+    async def _check_earshot_override(
+        self, main_nextmeta: TrackMetadata
+    ) -> tuple[TrackMetadata, bool]:
+        """Check whether a new EarShot identification should override the main source.
+
+        Returns (metadata_to_use, earshot_overrode) where earshot_overrode is True
+        when EarShot fired.  Also handles suppression of the main source's stale
+        last-seen track so it does not immediately win back after an EarShot override.
+        """
+        if not self.earshot_plugin:
+            return main_nextmeta, False
+
+        try:
+            earshot_meta = await self.earshot_plugin.getplayingtrack() or {}
+        except Exception as err:  # pylint: disable=broad-except
+            logging.error("EarShot secondary poll failed: %s", err)
+            return main_nextmeta, False
+
+        if earshot_meta and self._earshot_track_key(earshot_meta) != self._earshot_track_key(
+            self.earshot_last_meta
+        ):
+            if self._earshot_track_key(earshot_meta) == self._earshot_track_key(main_nextmeta):
+                logging.debug("EarShot heard the same track as main source; not overriding")
+                self.earshot_last_meta = earshot_meta
+            else:
+                logging.info(
+                    "EarShot identified new track: %s / %s",
+                    earshot_meta.get("artist"),
+                    earshot_meta.get("title"),
+                )
+                self.earshot_last_meta = earshot_meta
+                self.main_source_suppressed_meta = main_nextmeta
+                return earshot_meta, True
+
+        # EarShot has not changed — suppress main source if it is still reporting
+        # the same stale track it was showing when EarShot last overrode.
+        if self.main_source_suppressed_meta and self._earshot_track_key(
+            main_nextmeta
+        ) == self._earshot_track_key(self.main_source_suppressed_meta):
+            return main_nextmeta, False  # caller will treat as empty / same
+
+        # Main source has a genuinely new track — clear suppression.
+        if self.main_source_suppressed_meta:
+            logging.debug("Main source reports new track; clearing EarShot suppression")
+            self.main_source_suppressed_meta = {}
+
+        return main_nextmeta, False
 
     @staticmethod
     def _ismetaempty(metadata: TrackMetadata) -> bool:
@@ -397,7 +487,14 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             await asyncio.sleep(1)
             return
 
-        if self._ismetaempty(nextmeta) or self._isignored(nextmeta):
+        nextmeta, earshot_overrode = await self._check_earshot_override(nextmeta)
+
+        # Suppress the main source if EarShot overrode it and it hasn't changed yet.
+        if (
+            self._ismetaempty(nextmeta)
+            or self._isignored(nextmeta)
+            or (not earshot_overrode and bool(self.main_source_suppressed_meta))
+        ):
             return
 
         if self._ismetasame(nextmeta):
@@ -436,9 +533,7 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         logging.debug("_fill_inmetadata took %.3f seconds", fill_duration)
 
         # Set timestamp and version when track is accepted as current
-        self.currentmeta["track_received"] = datetime.datetime.now(
-            datetime.timezone.utc
-        ).isoformat()
+        self.currentmeta["track_received"] = datetime.datetime.now(datetime.UTC).isoformat()
         self.currentmeta["version"] = nowplaying.version.__VERSION__  # pylint: disable=no-member
 
         logging.info(

--- a/nowplaying/resources/ui/inputs_earshot.ui
+++ b/nowplaying/resources/ui/inputs_earshot.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>inputs_earshot_ui</class>
+ <widget class="QWidget" name="inputs_earshot_ui">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>EarShot</string>
+  </property>
+  <property name="displayName" stdset="0">
+   <string>EarShot</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout">
+   <property name="margin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <item>
+    <widget class="QCheckBox" name="earshot_always_checkbox">
+     <property name="text">
+      <string>Always use EarShot when it identifies a new track</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="description_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body&gt;
+&lt;p&gt;EarShot is a companion app for macOS, iOS, and watchOS that uses Shazam-based audio identification to detect tracks playing on vinyl decks, standalone CDJs, Rekordbox, and analog mixers.&lt;/p&gt;
+&lt;p&gt;When &lt;span style=&quot;font-weight:600;&quot;&gt;Always use EarShot when it identifies a new track&lt;/span&gt; is enabled, EarShot track identifications will override the currently active source whenever EarShot reports a new track. This is useful when switching between DJ software and vinyl during a set.&lt;/p&gt;
+&lt;p&gt;See &lt;a href=&quot;https://whatsnowplaying.com/earshot&quot;&gt;whatsnowplaying.com/earshot&lt;/a&gt; for setup instructions.&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/test_inputs_earshot.py
+++ b/tests/test_inputs_earshot.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""tests for the EarShot input plugin"""
+
+import pytest  # pylint: disable=import-error
+
+import nowplaying.inputs.earshot  # pylint: disable=import-error
+
+
+@pytest.mark.parametrize(
+    "metadata,should_return",
+    [
+        # EarShot source agents — should pass through
+        ({"artist": "Artist", "title": "Track", "source_agent_name": "wnpearshot"}, True),
+        ({"artist": "Artist", "title": "Track", "source_agent_name": "wnpearshot-1.0"}, True),
+        ({"artist": "Artist", "title": "Track", "source_agent_name": "wnpearshot-2.3.1"}, True),
+        # Non-EarShot source agents — should be filtered out
+        ({"artist": "Artist", "title": "Track", "source_agent_name": "serato"}, False),
+        ({"artist": "Artist", "title": "Track", "source_agent_name": "remote"}, False),
+        ({"artist": "Artist", "title": "Track", "source_agent_name": "traktor"}, False),
+        # Missing source agent — should be filtered out
+        ({"artist": "Artist", "title": "Track"}, False),
+        ({"artist": "Artist", "title": "Track", "source_agent_name": None}, False),
+        ({"artist": "Artist", "title": "Track", "source_agent_name": ""}, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_earshot_getplayingtrack_filter(bootstrap, metadata, should_return):
+    """getplayingtrack only returns tracks from EarShot source agents"""
+    plugin = nowplaying.inputs.earshot.Plugin(config=bootstrap)
+    plugin.metadata = metadata
+
+    result = await plugin.getplayingtrack()
+
+    if should_return:
+        assert result == metadata
+    else:
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_earshot_getplayingtrack_no_metadata(bootstrap):
+    """getplayingtrack returns None when no metadata is set"""
+    plugin = nowplaying.inputs.earshot.Plugin(config=bootstrap)
+    plugin.metadata = {"artist": None, "title": None, "filename": None}
+
+    result = await plugin.getplayingtrack()
+
+    assert result is None
+
+
+def test_earshot_displayname(bootstrap):
+    """EarShot plugin has correct display name"""
+    plugin = nowplaying.inputs.earshot.Plugin(config=bootstrap)
+    assert plugin.displayname == "EarShot"
+
+
+def test_earshot_settings_load_save(bootstrap):
+    """load and save of earshot_always_accept setting round-trips correctly"""
+    plugin = nowplaying.inputs.earshot.Plugin(config=bootstrap)
+
+    bootstrap.cparser.setValue("earshot/always_accept", False)
+
+    import unittest.mock  # pylint: disable=import-outside-toplevel
+
+    qwidget = unittest.mock.MagicMock()
+    qwidget.earshot_always_checkbox.isChecked.return_value = True
+
+    plugin.load_settingsui(qwidget)
+    qwidget.earshot_always_checkbox.setChecked.assert_called_once_with(False)
+
+    plugin.save_settingsui(qwidget)
+    assert bootstrap.cparser.value("earshot/always_accept", type=bool, defaultValue=False) is True

--- a/tests/test_trackpoll.py
+++ b/tests/test_trackpoll.py
@@ -672,6 +672,7 @@ async def test_check_earshot_override_suppresses_stale_main_source(trackpoll_tes
 
     result, overrode = await tptest._check_earshot_override(stale_main)  # pylint: disable=protected-access
 
+    assert result == {}
     assert overrode is False
     # suppression still active — suppressed_meta not cleared
     assert tptest.main_source_suppressed_meta == stale_main  # pylint: disable=protected-access

--- a/tests/test_trackpoll.py
+++ b/tests/test_trackpoll.py
@@ -590,7 +590,7 @@ def test_artfallbacks_preexisting_cover_not_overwritten(bootstrap, trackpoll_tes
         ({"artist": None, "title": None}, ("", "")),
     ],
 )
-def test_earshot_track_key(meta, expected, trackpoll_testmode):  # pylint: disable=redefined-outer-name
+def test_earshot_track_key(meta, expected):
     """_earshot_track_key returns stable (artist, title) tuple"""
     result = nowplaying.processes.trackpoll.TrackPoll._earshot_track_key(meta)  # pylint: disable=protected-access
     assert result == expected

--- a/tests/test_trackpoll.py
+++ b/tests/test_trackpoll.py
@@ -573,3 +573,170 @@ def test_artfallbacks_preexisting_cover_not_overwritten(bootstrap, trackpoll_tes
 
     assert tptest.currentmeta.get("coverimageraw") == original
     mock_ic.random_image_fetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# EarShot override tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "meta,expected",
+    [
+        ({}, ("", "")),
+        ({"artist": "Artist"}, ("Artist", "")),
+        ({"title": "Title"}, ("", "Title")),
+        ({"artist": "Artist", "title": "Title"}, ("Artist", "Title")),
+        ({"artist": None, "title": None}, ("", "")),
+    ],
+)
+def test_earshot_track_key(meta, expected, trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """_earshot_track_key returns stable (artist, title) tuple"""
+    result = nowplaying.processes.trackpoll.TrackPoll._earshot_track_key(meta)  # pylint: disable=protected-access
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_no_plugin(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """when no earshot plugin is running meta passes through unchanged"""
+    tptest = trackpoll_testmode
+    main_meta = {"artist": "Serato Artist", "title": "Serato Track"}
+    result, overrode = await tptest._check_earshot_override(main_meta)  # pylint: disable=protected-access
+    assert result == main_meta
+    assert overrode is False
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_new_track(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """new EarShot track overrides main source and updates state"""
+    tptest = trackpoll_testmode
+    main_meta = {"artist": "Serato Artist", "title": "Serato Track"}
+    earshot_meta = {
+        "artist": "Vinyl Artist",
+        "title": "Vinyl Track",
+        "source_agent_name": "wnpearshot-1.0",
+    }
+
+    mock_plugin = unittest.mock.AsyncMock()
+    mock_plugin.getplayingtrack.return_value = earshot_meta
+    tptest.earshot_plugin = mock_plugin  # pylint: disable=protected-access
+
+    result, overrode = await tptest._check_earshot_override(main_meta)  # pylint: disable=protected-access
+
+    assert result == earshot_meta
+    assert overrode is True
+    assert tptest.earshot_last_meta == earshot_meta  # pylint: disable=protected-access
+    assert tptest.main_source_suppressed_meta == main_meta  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_same_track_no_suppression(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """EarShot unchanged and no suppression active — main source passes through"""
+    tptest = trackpoll_testmode
+    earshot_meta = {
+        "artist": "Vinyl Artist",
+        "title": "Vinyl Track",
+        "source_agent_name": "wnpearshot-1.0",
+    }
+    tptest.earshot_last_meta = earshot_meta  # pylint: disable=protected-access
+
+    mock_plugin = unittest.mock.AsyncMock()
+    mock_plugin.getplayingtrack.return_value = earshot_meta
+    tptest.earshot_plugin = mock_plugin  # pylint: disable=protected-access
+
+    main_meta = {"artist": "Serato Artist", "title": "Serato Track"}
+    result, overrode = await tptest._check_earshot_override(main_meta)  # pylint: disable=protected-access
+
+    assert result == main_meta
+    assert overrode is False
+    assert tptest.main_source_suppressed_meta == {}  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_suppresses_stale_main_source(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """main source reporting same stale track is suppressed after EarShot override"""
+    tptest = trackpoll_testmode
+    earshot_meta = {
+        "artist": "Vinyl Artist",
+        "title": "Vinyl Track",
+        "source_agent_name": "wnpearshot-1.0",
+    }
+    stale_main = {"artist": "Serato Artist", "title": "Serato Track"}
+
+    tptest.earshot_last_meta = earshot_meta  # pylint: disable=protected-access
+    tptest.main_source_suppressed_meta = stale_main  # pylint: disable=protected-access
+
+    mock_plugin = unittest.mock.AsyncMock()
+    mock_plugin.getplayingtrack.return_value = earshot_meta
+    tptest.earshot_plugin = mock_plugin  # pylint: disable=protected-access
+
+    result, overrode = await tptest._check_earshot_override(stale_main)  # pylint: disable=protected-access
+
+    assert overrode is False
+    # suppression still active — suppressed_meta not cleared
+    assert tptest.main_source_suppressed_meta == stale_main  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_clears_suppression_on_new_main_track(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """genuinely new main source track clears EarShot suppression"""
+    tptest = trackpoll_testmode
+    earshot_meta = {
+        "artist": "Vinyl Artist",
+        "title": "Vinyl Track",
+        "source_agent_name": "wnpearshot-1.0",
+    }
+    stale_main = {"artist": "Serato Artist", "title": "Serato Track"}
+    new_main = {"artist": "Serato Artist", "title": "New Serato Track"}
+
+    tptest.earshot_last_meta = earshot_meta  # pylint: disable=protected-access
+    tptest.main_source_suppressed_meta = stale_main  # pylint: disable=protected-access
+
+    mock_plugin = unittest.mock.AsyncMock()
+    mock_plugin.getplayingtrack.return_value = earshot_meta
+    tptest.earshot_plugin = mock_plugin  # pylint: disable=protected-access
+
+    result, overrode = await tptest._check_earshot_override(new_main)  # pylint: disable=protected-access
+
+    assert result == new_main
+    assert overrode is False
+    assert tptest.main_source_suppressed_meta == {}  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_poll_failure(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """EarShot poll exception is caught and main source passes through"""
+    tptest = trackpoll_testmode
+    main_meta = {"artist": "Serato Artist", "title": "Serato Track"}
+
+    mock_plugin = unittest.mock.AsyncMock()
+    mock_plugin.getplayingtrack.side_effect = RuntimeError("connection lost")
+    tptest.earshot_plugin = mock_plugin  # pylint: disable=protected-access
+
+    result, overrode = await tptest._check_earshot_override(main_meta)  # pylint: disable=protected-access
+
+    assert result == main_meta
+    assert overrode is False
+
+
+@pytest.mark.asyncio
+async def test_check_earshot_override_ignores_same_as_main(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """EarShot hearing the same track as main source does not trigger an override"""
+    tptest = trackpoll_testmode
+    main_meta = {"artist": "Vinyl Artist", "title": "Vinyl Track", "source_agent_name": "serato"}
+    earshot_meta = {
+        "artist": "Vinyl Artist",
+        "title": "Vinyl Track",
+        "source_agent_name": "wnpearshot",
+    }
+
+    mock_plugin = unittest.mock.AsyncMock()
+    mock_plugin.getplayingtrack.return_value = earshot_meta
+    tptest.earshot_plugin = mock_plugin  # pylint: disable=protected-access
+
+    result, overrode = await tptest._check_earshot_override(main_meta)  # pylint: disable=protected-access
+
+    assert overrode is False
+    assert result == main_meta
+    # earshot_last_meta updated so next poll does not recheck
+    assert tptest.earshot_last_meta == earshot_meta  # pylint: disable=protected-access


### PR DESCRIPTION
Adds a dedicated EarShot input source that filters remote tracks to only those identified by wnpearshot agents.  When earshot/always_accept is enabled, a secondary EarShot monitor runs alongside any non-EarShot source and overrides it whenever EarShot identifies a new track, with suppression logic to prevent stale DJ software data from immediately winning back the display.  EarShot hearing the same track as the main source (e.g. via room audio) is ignored, not treated as a new override.

## Summary by Sourcery

Introduce an EarShot-specific input source and integrate it as an optional always-accept secondary monitor that can override other inputs when it identifies new tracks, including supporting documentation and tests.

New Features:
- Add a dedicated EarShot input plugin that only accepts tracks identified by EarShot source agents and exposes configurable Always-Accept behavior.
- Enable TrackPoll to run EarShot as a secondary monitor alongside non-EarShot inputs and optionally override the main source when EarShot detects a new track, with suppression logic to avoid stale data regaining control.
- Document EarShot as a first-class input source with setup instructions and an Always-Accept mode guide, and add a dedicated EarShot settings UI.

Enhancements:
- Extend track polling to track EarShot state, manage the lifecycle of the secondary EarShot plugin, and coordinate override/suppression behavior based on artist/title changes.
- Improve the remote notification client to use an async context manager pattern for HTTP requests and handle responses more robustly.
- Tighten type hints and minor imports for the remote input plugin and metadata module.

Documentation:
- Add dedicated EarShot input documentation describing setup, Always-Accept mode, behavior, and troubleshooting.
- Update the main input documentation and changelog to present EarShot as a dedicated input source with Always-Accept mode.

Tests:
- Add unit tests for the EarShot input plugin filtering, display name, and settings round-trip behavior.
- Add async tests covering EarShot override behavior in TrackPoll, including new-track overrides, suppression of stale main-source tracks, handling of identical tracks, and error handling.
- Extend existing test coverage to validate the EarShot track key helper used for change detection.