### PR TITLE
Switch docs tooling to properdocs and mkdocs-materialx

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -36,7 +36,7 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
             if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               # Stable release (e.g., 5.0.0) - deploy as latest
-              mike deploy --push --update-aliases -f properdocs.yml $VERSION latest
+              mike deploy --push --update-aliases -F properdocs.yml $VERSION latest
               mike set-default --push latest
 
               # Delete any preview versions for this release (e.g., 5.0.0-preview1)
@@ -50,14 +50,14 @@ jobs:
           ")
               if [[ -n "$PREVIEWS" ]]; then
                 for PREVIEW in $PREVIEWS; do
-                  mike delete -f properdocs.yml "$PREVIEW"
+                  mike delete -F properdocs.yml "$PREVIEW"
                 done
                 git push origin gh-pages
               fi
             else
               # Preview/pre-release (e.g., 5.0.0-preview1) - deploy version only
-              mike deploy --push -f properdocs.yml $VERSION
+              mike deploy --push -F properdocs.yml $VERSION
             fi
           else
-            mike deploy --push -f properdocs.yml dev
+            mike deploy --push -F properdocs.yml dev
           fi

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -38,6 +38,22 @@ jobs:
               # Stable release (e.g., 5.0.0) - deploy as latest
               mike deploy --push --update-aliases -f properdocs.yml $VERSION latest
               mike set-default --push latest
+
+              # Delete any preview versions for this release (e.g., 5.0.0-preview1)
+              git fetch origin gh-pages
+              PREVIEWS=$(mike list --json | python3 -c "
+          import json, sys
+          base = '${VERSION}-'
+          for v in json.load(sys.stdin):
+              if v['version'].startswith(base):
+                  print(v['version'])
+          ")
+              if [[ -n "$PREVIEWS" ]]; then
+                for PREVIEW in $PREVIEWS; do
+                  mike delete -f properdocs.yml "$PREVIEW"
+                done
+                git push origin gh-pages
+              fi
             else
               # Preview/pre-release (e.g., 5.0.0-preview1) - deploy version only
               mike deploy --push -f properdocs.yml $VERSION

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-name: Deploy MkDocs Documentation
+name: Deploy Documentation
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -36,12 +36,12 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
             if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               # Stable release (e.g., 5.0.0) - deploy as latest
-              mike deploy --push --update-aliases $VERSION latest
+              mike deploy --push --update-aliases -f properdocs.yml $VERSION latest
               mike set-default --push latest
             else
               # Preview/pre-release (e.g., 5.0.0-preview1) - deploy version only
-              mike deploy --push $VERSION
+              mike deploy --push -f properdocs.yml $VERSION
             fi
           else
-            mike deploy --push dev
+            mike deploy --push -f properdocs.yml dev
           fi

--- a/.github/workflows/ghpages-test.yaml
+++ b/.github/workflows/ghpages-test.yaml
@@ -25,5 +25,5 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-docs.txt
 
-      - name: Test MkDocs build
-        run: mkdocs build --strict
+      - name: Test docs build
+        run: properdocs build -f properdocs.yml --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 ## Version 5.2.0 - In Progress
 
 * New Features
-  * EarShot input source
+  * WNP EarShot input source
     * New dedicated EarShot source for vinyl, CDJs, and analog mixers using
-      Shazam-based identification via the EarShot companion app
-    * Always-Accept mode runs EarShot as a secondary monitor alongside any
-      DJ software source; EarShot identifications automatically override the
+      Shazam-based identification via the WNP EarShot companion app
+    * Always-Accept mode runs WNP EarShot as a secondary monitor alongside any
+      DJ software source; WNP EarShot identifications automatically override the
       active source when a new track is detected, then yield back when the DJ
       software moves on
   * OBS Scene Collection exporter

--- a/docs/features.md
+++ b/docs/features.md
@@ -50,11 +50,11 @@ updates required.
 
 ### [Vinyl, CDJs & Analog Mixers](https://whatsnowplaying.com/earshot)
 
-* **[EarShot](https://whatsnowplaying.com/earshot)** — companion app for macOS, iOS, and
+* **[WNP EarShot](https://whatsnowplaying.com/earshot)** — companion app for macOS, iOS, and
   watchOS that uses Shazam-based audio identification to detect tracks playing on
   vinyl decks, standalone CDJs, Rekordbox, and analog mixers, then sends them to
   WNP automatically over the local network. No software integration with the
-  hardware required. Requires WNP 5.2.0 or later.
+  hardware required.
 
 ### [Remote WNP Instance](input/remote.md)
 

--- a/docs/input/earshot.md
+++ b/docs/input/earshot.md
@@ -1,12 +1,12 @@
-# EarShot
+# WNP EarShot
 
-EarShot is a companion app for macOS, iOS, and watchOS that uses Shazam-based
+WNP EarShot is a companion app for macOS, iOS, and watchOS that uses Shazam-based
 audio identification to detect tracks playing on vinyl decks, standalone CDJs,
 Rekordbox, and analog mixers, then sends them to **What's Now Playing** over
 the local network.
 
-> NOTE: EarShot must be installed and configured separately. See the
-> [EarShot website](https://whatsnowplaying.com/earshot) for installation instructions.
+> NOTE: WNP EarShot must be installed and configured separately. See the
+> [WNP EarShot website](https://whatsnowplaying.com/earshot) for installation instructions.
 
 ## Setup
 
@@ -18,7 +18,7 @@ the local network.
 4. Click Save
 
 This is the right choice when your entire setup is vinyl, CDJs, or an analog
-mixer — EarShot is the only source feeding track data.
+mixer — WNP EarShot is the only source feeding track data.
 
 ### Always-Accept Mode
 
@@ -32,29 +32,29 @@ If you mix vinyl or CDJs alongside DJ software (Serato, Traktor, etc.), use
 5. Click Save
 
 With this enabled, **What's Now Playing** runs a secondary EarShot monitor in
-the background. Whenever EarShot identifies a new track that differs from what
-the DJ software is reporting, EarShot's identification takes over. Once your DJ
-software moves on to a new track, it resumes control automatically.
+the background. Whenever WNP EarShot identifies a new track that differs from
+what the DJ software is reporting, EarShot's identification takes over. Once
+your DJ software moves on to a new track, it resumes control automatically.
 
 ## How It Works
 
-EarShot sends identified tracks to WNP's remote input endpoint over the local
-network. The EarShot source filters incoming remote tracks to only those
-originating from EarShot — other remote sources are ignored.
+WNP EarShot sends identified tracks to WNP's remote input endpoint over the
+local network. The EarShot source filters incoming remote tracks to only those
+originating from WNP EarShot — other remote sources are ignored.
 
 In always-accept mode, WNP compares artist and title between EarShot and the
-active DJ software source. If EarShot hears the same track the DJ software is
-already reporting (e.g. room audio bleed), it is treated as confirmation, not
-an override, so the display does not flicker.
+active DJ software source. If WNP EarShot hears the same track the DJ software
+is already reporting (e.g. room audio bleed), it is treated as confirmation,
+not an override, so the display does not flicker.
 
 ## Troubleshooting
 
-If EarShot identifications are not appearing:
+If WNP EarShot identifications are not appearing:
 
-1. Confirm the EarShot app is running and connected to the same local network
-   as **What's Now Playing**
+1. Confirm the WNP EarShot app is running and connected to the same local
+   network as **What's Now Playing**
 2. Verify the WNP webserver is enabled (Output & Display->Web Server) and
    listening on the correct port
-3. Check the EarShot app settings to confirm it is pointed at the correct
+3. Check the WNP EarShot app settings to confirm it is pointed at the correct
    WNP host and port
 4. Check the **What's Now Playing** logs for incoming remote input activity

--- a/docs/input/index.md
+++ b/docs/input/index.md
@@ -39,6 +39,6 @@ Network streaming and file-based sources:
 
 For hardware not directly supported by WNP:
 
-- **[EarShot](earshot.md)** - companion app for macOS, iOS, and watchOS that uses
+- **[WNP EarShot](earshot.md)** - companion app for macOS, iOS, and watchOS that uses
   Shazam-based audio identification to detect tracks from vinyl decks, standalone CDJs,
   Rekordbox, and analog mixers, then sends them to WNP over the local network.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,7 @@
 > no manual source selection required for most setups.
 > Supports Serato DJ, Traktor, Virtual DJ, Denon DJ, djay Pro, DJUCED, and more.
 > Vinyl decks, standalone CDJs, Rekordbox, and analog mixers are supported via
-> EarShot, a companion app using Shazam-based audio identification.
+> WNP EarShot, a companion app using Shazam-based audio identification.
 > Outputs to OBS, Twitch, Kick, Discord, and custom HTML overlays via a built-in
 > web server with Jinja2 templating. Includes OBS scene export to generate
 > ready-to-import OBS 28+ scene collection JSON files with pre-configured browser

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ On first launch, **What's Now Playing** attempts to auto-detect your DJ software
   actively broadcasting on the network
 * The first detected source wins. If multiple are found, you can change it afterwards.
 * For **vinyl decks, standalone CDJs, Rekordbox, and analog mixers**, use
-  [EarShot](https://whatsnowplaying.com/earshot) — a companion app that identifies
+  [WNP EarShot](https://whatsnowplaying.com/earshot) — a companion app that identifies
   tracks via Shazam and sends them to WNP automatically
 
 Before launching, make sure your DJ software has been run at least once. For Traktor, first

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -6,7 +6,7 @@ repo_url: https://github.com/whatsnowplaying/whats-now-playing
 repo_name: whatsnowplaying/whats-now-playing
 
 theme:
-  name: material
+  name: materialx
   custom_dir: overrides
   palette:
     # Palette toggle for light mode
@@ -95,6 +95,7 @@ nav:
       - M3U: input/m3u.md
       - MIXXX: input/mixxx.md
       - MPRIS2: input/mpris2.md
+      - EarShot: input/earshot.md
       - Remote: input/remote.md
       - Serato: input/serato.md
       - Serato (Legacy): input/serato3.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,4 @@
-mkdocs==1.6.1
-mkdocs-material==9.7.6
+properdocs==1.6.7
+mkdocs-materialx==10.1.3
 mike==2.2.0
 mkdocs-macros-plugin==1.5.0
-


### PR DESCRIPTION
Replace mkdocs + mkdocs-material with properdocs + mkdocs-materialx. Rename mkdocs.yml to properdocs.yml and update the deploy workflow to use properdocs CLI with -f properdocs.yml. Rename the workflow file from mkdocs-deploy.yaml to docs-deploy.yaml and update the action name to "Deploy Documentation". Use "WNP EarShot" consistently for the companion app name across docs, CHANGELOG, and llms.txt.

## Summary by Sourcery

Switch documentation tooling and config to use Properdocs with the MaterialX theme and align naming around the WNP EarShot companion app.

Enhancements:
- Adopt Properdocs configuration (properdocs.yml) with the MaterialX theme and update navigation to include the EarShot input page.
- Standardize the companion app branding to "WNP EarShot" across documentation and changelog content.

Build:
- Update documentation deployment workflow to use Properdocs configuration via mike with properdocs.yml and rename the workflow to a generic docs deploy job.

CI:
- Rename the MkDocs-specific deploy workflow to a more general docs deploy workflow and adjust its commands to reference Properdocs configuration.