### PR TITLE
Fix docs header color and add preview version redirects

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -62,3 +62,14 @@ jobs:
           else
             mike deploy --push -F properdocs.yml dev
           fi
+
+      - name: Update root 404 redirect page
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          cp docs/404.html 404.html
+          git add 404.html
+          git diff --cached --quiet || \
+            git commit -m "ci: update root 404 redirect"
+          git push origin gh-pages
+          git checkout -

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -65,9 +65,10 @@ jobs:
 
       - name: Update root 404 redirect page
         run: |
+          cp docs/404.html /tmp/404.html
           git fetch origin gh-pages
-          git checkout gh-pages
-          cp docs/404.html 404.html
+          git checkout -b gh-pages origin/gh-pages
+          cp /tmp/404.html 404.html
           git add 404.html
           git diff --cached --quiet || \
             git commit -m "ci: update root 404 redirect"

--- a/docs/404.html
+++ b/docs/404.html
@@ -10,10 +10,19 @@
         var match = window.location.pathname.match(
           /^(.*?)\/([0-9]+\.[0-9]+\.[0-9]+)-preview\d+(\/.*)?$/
         );
+
+        // Derive the site root for the fallback link: use base from the
+        // preview match if available, otherwise take the first path segment
+        // (handles GitHub Pages project-site prefix like /whats-now-playing)
+        var base = match
+          ? match[1]
+          : (window.location.pathname.match(/^(\/[^/]+)/) || ['', ''])[1];
+        document.getElementById('latest-link').href = base + '/latest/';
+
         if (!match) { return; }
-        var base = match[1];          // e.g. '/whats-now-playing' or ''
-        var stableVersion = match[2]; // e.g. '5.0.0'
+        var stableVersion = match[2];
         var subpath = match[3] || '/';
+        var suffix = subpath + window.location.search + window.location.hash;
         fetch(base + '/versions.json')
           .then(function (r) { return r.json(); })
           .then(function (versions) {
@@ -21,14 +30,11 @@
               return v.version === stableVersion;
             });
             window.location.replace(
-              base + '/' + (exists ? stableVersion : 'latest') +
-              subpath +
-              window.location.search +
-              window.location.hash
+              base + '/' + (exists ? stableVersion : 'latest') + suffix
             );
           })
           .catch(function () {
-            window.location.replace(base + '/latest/');
+            window.location.replace(base + '/latest/' + suffix);
           });
       })();
     </script>
@@ -53,6 +59,6 @@
   <body>
     <h1>404 – Page Not Found</h1>
     <p>The page you requested could not be found.</p>
-    <p><a href="latest/">Go to the latest documentation</a></p>
+    <p><a id="latest-link" href="#">Go to the latest documentation</a></p>
   </body>
 </html>

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Page Not Found – What's Now Playing</title>
+    <script>
+      (function () {
+        // Match base/X.X.X-previewN/subpath — base handles any site prefix
+        var match = window.location.pathname.match(
+          /^(.*?)\/([0-9]+\.[0-9]+\.[0-9]+)-preview\d+(\/.*)?$/
+        );
+        if (!match) { return; }
+        var base = match[1];          // e.g. '/whats-now-playing' or ''
+        var stableVersion = match[2]; // e.g. '5.0.0'
+        var subpath = match[3] || '/';
+        fetch(base + '/versions.json')
+          .then(function (r) { return r.json(); })
+          .then(function (versions) {
+            var exists = versions.some(function (v) {
+              return v.version === stableVersion;
+            });
+            window.location.replace(
+              base + '/' + (exists ? stableVersion : 'latest') +
+              subpath +
+              window.location.search +
+              window.location.hash
+            );
+          })
+          .catch(function () {
+            window.location.replace(base + '/latest/');
+          });
+      })();
+    </script>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+        background: #fff;
+        color: #333;
+      }
+      h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+      p { color: #666; }
+      a { color: #2094f3; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <h1>404 – Page Not Found</h1>
+    <p>The page you requested could not be found.</p>
+    <p><a href="latest/">Go to the latest documentation</a></p>
+  </body>
+</html>

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -8,6 +8,7 @@ repo_name: whatsnowplaying/whats-now-playing
 theme:
   name: materialx
   custom_dir: overrides
+  topbar_style: primary
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
- properdocs.yml: set topbar_style: primary to restore solid
  blue header (materialx defaults to glass/transparent)
- docs/404.html: root-level 404 that JS-redirects
  X.X.X-previewN URLs to the stable X.X.X equivalent;
  fetches versions.json to verify target exists, falls back
  to latest/; extracts site base path from URL dynamically
- docs-deploy.yaml: push 404.html to gh-pages root on deploy

## Summary by Sourcery

Restore a solid primary-colored header in the generated documentation and introduce a 404-based redirect mechanism so deleted preview-version URLs automatically forward to stable or latest docs.

Enhancements:
- Configure the MaterialX docs theme to use a solid primary top bar instead of the default transparent style.

CI:
- Extend the docs deployment workflow to sync a root-level 404 redirect page to the gh-pages branch.

Documentation:
- Add a custom 404 page that both presents a not-found message and redirects preview-version URLs to the corresponding stable or latest documentation when available.

## Summary by Sourcery

Update docs configuration and deployment workflow to restore the solid header style and support redirects from removed preview documentation versions.

New Features:
- Add a docs 404 page that redirects removed preview version URLs to the corresponding stable or latest documentation.

Enhancements:
- Configure the MaterialX docs theme to use a solid primary topbar instead of the default transparent style.

CI:
- Extend the docs deployment workflow to keep the root 404 redirect page on the gh-pages branch up to date.