### PR TITLE
Add Azure Trusted Signing for Windows binaries

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -27,6 +27,8 @@ jobs:
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
+    env:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
     steps:
       - name: icu
         run: |
@@ -43,7 +45,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: import signing certificate
-        if: ${{ secrets.MACOS_CERTIFICATE != '' }}
+        if: ${{ env.MACOS_CERTIFICATE != '' }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}

--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -31,6 +31,8 @@ jobs:
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
+    env:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
     steps:
       - name: icu
         env:
@@ -91,7 +93,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: import signing certificate
-        if: ${{ secrets.MACOS_CERTIFICATE != '' }}
+        if: ${{ env.MACOS_CERTIFICATE != '' }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -136,7 +136,7 @@ jobs:
         if: ${{ env.AZURE_CLIENT_ID != '' }}
         uses: azure/artifact-signing-action@v1
         with:
-          endpoint: https://cus.codesigning.azure.net/
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
           signing-account-name: com-whatsnowplaying-app
           certificate-profile-name: whatsnowplaying-cert-profile
           files-folder: ${{ github.workspace }}

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -147,10 +147,13 @@ jobs:
           timestamp-digest: SHA256
       - name: verify windows signing
         if: ${{ env.AZURE_CLIENT_ID != '' }}
-        shell: bash
+        shell: powershell
         run: |
-          BINARY=$(find WhatsNowPlaying-*-Windows -name "WhatsNowPlaying.exe" | head -1)
-          signtool.exe verify /pa /v "${BINARY}"
+          $binary = Get-ChildItem -Recurse -Filter "WhatsNowPlaying.exe" | Select-Object -First 1
+          $sig = Get-AuthenticodeSignature -FilePath $binary.FullName
+          Write-Output "Status: $($sig.Status)"
+          Write-Output "Subject: $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne 'Valid') { exit 1 }
       - name: smoke test binary
         shell: bash
         run: |

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -94,8 +94,10 @@ jobs:
 
   pyinstaller-win:
     runs-on: windows-2022
+    environment: windows-signing
     permissions:
       contents: read
+      id-token: write
     env:
       PYTHONIOENCODING: utf-8
       LANG: en_US.UTF-8
@@ -115,6 +117,26 @@ jobs:
         shell: bash
         run: |
           ./builder.sh
+      - name: azure login
+        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: sign windows binary
+        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        uses: azure/artifact-signing-action@v1
+        with:
+          endpoint: https://cus.codesigning.azure.net/
+          signing-account-name: com-whatsnowplaying-app
+          certificate-profile-name: whatsnowplaying-cert-profile
+          files-folder: ${{ github.workspace }}
+          files-folder-filter: exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
       - name: smoke test binary
         shell: bash
         run: |

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -102,6 +102,7 @@ jobs:
       PYTHONIOENCODING: utf-8
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -118,14 +119,14 @@ jobs:
         run: |
           ./builder.sh
       - name: azure login
-        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: sign windows binary
-        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
         uses: azure/artifact-signing-action@v1
         with:
           endpoint: https://cus.codesigning.azure.net/

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -20,7 +20,9 @@ jobs:
     with:
       runs-on: macos-15
       artifact-name: macos15-arm-dist
-      environment: macos-signing
+      environment: >-
+        ${{ (github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/tags/')) && 'macos-signing' || '' }}
 
   pyinstaller-macos-intel:
     uses: ./.github/workflows/macos-build.yml
@@ -30,7 +32,9 @@ jobs:
     with:
       runs-on: macos-15-intel
       artifact-name: macos15-intel-dist
-      environment: macos-signing
+      environment: >-
+        ${{ (github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/tags/')) && 'macos-signing' || '' }}
 
 
   pyinstaller-linux:
@@ -94,7 +98,10 @@ jobs:
 
   pyinstaller-win:
     runs-on: windows-2022
-    environment: windows-signing
+    environment: >-
+      ${{ (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/windows_signing' ||
+      startsWith(github.ref, 'refs/tags/')) && 'windows-signing' || '' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -145,6 +145,12 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+      - name: verify windows signing
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
+        shell: bash
+        run: |
+          BINARY=$(find WhatsNowPlaying-*-Windows -name "WhatsNowPlaying.exe" | head -1)
+          signtool.exe verify /pa /v "${BINARY}"
       - name: smoke test binary
         shell: bash
         run: |


### PR DESCRIPTION
Adds federated Azure login and code signing to the Windows pyinstaller job using Azure Trusted Signing:
- environment: windows-signing (holds AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID secrets)
- id-token: write permission for OIDC federated auth
- azure/login@v2 and azure/artifact-signing-action@v1
- Signs all .exe files under workspace after build
- Signing steps are conditional on AZURE_CLIENT_ID being set so unsigned builds still work without the environment

## Summary by Sourcery

Configure conditional code signing for macOS and Windows PyInstaller builds, integrating Azure Trusted Signing for Windows and tightening when signing runs.

Build:
- Make macOS PyInstaller workflows use a conditional environment for signing only on main branch and tags.
- Add Windows PyInstaller job environment and permissions for Azure federated login and trusted signing, gated to specific branches and tags.
- Expose required signing secrets as environment variables in macOS and Windows workflows so jobs can run with or without signing configured.

CI:
- Integrate Azure login and artifact signing actions into the Windows PyInstaller job to sign built executables when Azure credentials are available.
- Add verification step to ensure Windows binaries are correctly signed during CI runs.
- Adjust macOS build workflows to conditionally import signing certificates based on environment variables rather than secrets directly.