### PR TITLE
Twitch stream title updates on track change

### DIFF
--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -269,6 +269,9 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
     def _defaults_chat_services(self, settings: QSettings) -> None:
         """default values for chat services"""
         settings.setValue("twitchbot/enabled", False)
+        settings.setValue(
+            "twitchbot/streamtitle", str(self.templatedir.joinpath("twitchbot_streamtitle.txt"))
+        )
         settings.setValue("kick/enabled", False)
         settings.setValue("kick/chat", False)
         settings.setValue("kick/announce", str(self.templatedir.joinpath("kickbot_track.txt")))

--- a/nowplaying/preview/textwindow.py
+++ b/nowplaying/preview/textwindow.py
@@ -173,6 +173,12 @@ class TextPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods
         logging.debug("TextPreviewWindow rendered %d chars from %s", len(rendered), tmpl_path)
         self.text_edit.setPlainText(rendered)
 
+    def select_template(self, name: str) -> None:
+        """Select a template by filename in the combo box."""
+        idx = self.template_combo.findData(name)
+        if idx >= 0:
+            self.template_combo.setCurrentIndex(idx)
+
     def _on_template_selected(self) -> None:
         self._render()
 

--- a/nowplaying/resources/ui/twitch.ui
+++ b/nowplaying/resources/ui/twitch.ui
@@ -164,6 +164,47 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="streamtitle_checkbox">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Update stream title on track change</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QLineEdit" name="streamtitle_lineedit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="streamtitle_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Template</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="streamtitle_preview_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Preview ...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QTextBrowser" name="help_text">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -249,6 +290,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
    <sender>enable_checkbox</sender>
    <signal>toggled(bool)</signal>
    <receiver>copy_chat_auth_button</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>streamtitle_checkbox</receiver>
    <slot>setEnabled(bool)</slot>
   </connection>
  </connections>

--- a/nowplaying/templates/twitchbot_streamtitle.txt
+++ b/nowplaying/templates/twitchbot_streamtitle.txt
@@ -1,0 +1,1 @@
+Currently playing: {% if artist %}{{ artist }} - {% endif %}{{ title }}

--- a/nowplaying/twitch/broadcaster.py
+++ b/nowplaying/twitch/broadcaster.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Twitch broadcaster-level API functionality"""
+
+import asyncio
+import logging
+import pathlib
+from typing import Any
+
+import aiohttp
+import jinja2  # pylint: disable=import-error
+
+import nowplaying.db
+import nowplaying.twitch.oauth2
+import nowplaying.twitch.utils
+
+TWITCH_TITLE_MAX_LEN = 140
+
+
+class TwitchBroadcaster:
+    """Handle broadcaster-level Twitch API calls (stream title, etc.)"""
+
+    def __init__(
+        self,
+        config: "nowplaying.config.ConfigFile" = None,
+        stopevent: asyncio.Event = None,
+    ):
+        self.config = config
+        self.stopevent = stopevent
+        self.metadb = nowplaying.db.MetadataDB()
+        self._last_title: str | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._jinja_env: jinja2.Environment | None = None
+        self._jinja_template_dir: str | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Return the shared aiohttp session, creating it if needed."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    def _get_jinja_env(self, template_dir: str) -> jinja2.Environment:
+        """Return a cached Jinja2 environment for the given template directory."""
+        if self._jinja_env is None or self._jinja_template_dir != template_dir:
+            self._jinja_env = jinja2.Environment(
+                loader=jinja2.FileSystemLoader(template_dir),
+                finalize=self._finalize,
+                trim_blocks=True,
+            )
+            self._jinja_template_dir = template_dir
+        return self._jinja_env
+
+    async def on_track_change(self) -> None:
+        """Called by TwitchLaunch when a track change is detected"""
+        self.config.get()
+        await self._update_stream_title()
+
+    async def _update_stream_title(self) -> None:  # pylint: disable=too-many-return-statements
+        """Update the Twitch stream title from the configured Jinja2 template file"""
+        if not self.config.cparser.value("twitchbot/streamtitle_enabled", type=bool):
+            return
+
+        template_path_str: str = self.config.cparser.value(
+            "twitchbot/streamtitle", defaultValue=""
+        )
+        if not template_path_str:
+            return
+
+        template_path = pathlib.Path(template_path_str)
+        if not template_path.is_file():
+            logging.warning("Stream title template not found: %s", template_path)
+            return
+
+        metadata = await self.metadb.read_last_meta_async()
+        if not metadata:
+            return
+        if not metadata.get("artist") and not metadata.get("title"):
+            return
+
+        try:
+            env = self._get_jinja_env(str(template_path.parent))
+            title = env.get_template(template_path.name).render(metadata).strip()
+            title = title[:TWITCH_TITLE_MAX_LEN]
+        except Exception as error:  # pylint: disable=broad-except
+            logging.error("Stream title template error: %s", error)
+            return
+
+        if not title or title == self._last_title:
+            return
+
+        self._last_title = title
+
+        oauth = nowplaying.twitch.oauth2.TwitchOAuth2(self.config)
+        access_token, _ = oauth.get_stored_tokens()
+        if not access_token:
+            logging.warning("No broadcaster token available for stream title update")
+            return
+        oauth.access_token = access_token
+        session = await self._get_session()
+        await nowplaying.twitch.utils.update_stream_title(oauth, title, session=session)
+
+    async def stop(self) -> None:
+        """Release shared resources"""
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    @staticmethod
+    def _finalize(variable: Any) -> Any | str:
+        """helper routine to avoid NoneType exceptions in templates"""
+        if variable is not None:
+            return variable
+        return ""

--- a/nowplaying/twitch/chat.py
+++ b/nowplaying/twitch/chat.py
@@ -73,7 +73,6 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
     ):
         self.config = config
         self.stopevent = stopevent
-        self.watcher = None
         self.requests = nowplaying.trackrequests.Requests(config=config, stopevent=stopevent)
         self.guessgame = nowplaying.guessgame.GuessGame(config=config, stopevent=stopevent)
         self.metadb = nowplaying.db.MetadataDB()
@@ -399,13 +398,12 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
         self.tasks.add(task)
         task.add_done_callback(self.tasks.discard)
 
-    async def _cleanup_on_exit(self, twitchlogin: nowplaying.twitch.utils.TwitchLogin) -> None:
+    async def _cleanup_on_exit(self, twitchlogin: nowplaying.twitch.utils.TwitchLogin) -> None:  # pylint: disable=unused-argument
         """Clean up resources when exiting"""
+        # Never revoke tokens on exit — preserve them for restart.
+        # launch.py.stop() handles clearing the in-memory OAUTH_CLIENT.
         if self.twitch:
-            if self.twitchcustom:
-                await self.twitch.close()
-            else:
-                await twitchlogin.api_logout()
+            await self.twitch.close()
 
     async def on_twitchchat_incoming_message(self, msg: ChatMessage):
         """handle incoming chat messages for special responses"""
@@ -723,25 +721,11 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
         )
 
     async def _setup_timer(self):
-        """need to watch the metadata db to know to send announcement"""
-        # Prevent multiple watcher instances
-        if self.watcher is not None:
-            logging.debug("Twitch chat watcher already exists, stopping previous instance")
-            self.watcher.stop()
-            self.watcher = None
-
-        self.watcher = self.metadb.watcher()
-        self.watcher.start(customhandler=self._announce_track)
-        await self._async_announce_track()
+        """Run the guess game polling loop"""
         while not nowplaying.utils.safe_stopevent_check(self.stopevent):
             await asyncio.sleep(1)
-            # Check for new guess games to announce
             await self._check_and_announce_new_game()
-
-        logging.debug("watcher stop event received")
-        if self.watcher:
-            self.watcher.stop()
-            self.watcher = None
+        logging.debug("guess game polling stop event received")
 
     async def _delay_write(self):
         """handle the twitch chat delay"""
@@ -759,21 +743,9 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
         """intelligently split long messages at sentence or word boundaries"""
         return nowplaying.utils.smart_split_message(message, max_length)
 
-    def _announce_track(self, event):  # pylint: disable=unused-argument
-        logging.debug("watcher event called")
-        try:
-            try:
-                loop = asyncio.get_running_loop()
-                task = loop.create_task(self._async_announce_track())
-                self.tasks.add(task)
-                task.add_done_callback(self.tasks.discard)
-            except Exception:  # pylint: disable=broad-except
-                loop = asyncio.new_event_loop()
-                loop.run_until_complete(self._async_announce_track())
-        except Exception:  # pylint: disable=broad-except
-            for line in traceback.format_exc().splitlines():
-                logging.error(line)
-            logging.error("watcher failed")
+    async def on_track_change(self) -> None:
+        """Called by TwitchLaunch when a track change is detected"""
+        await self._async_announce_track()
 
     async def _async_announce_track(self):
         """announce new tracks"""
@@ -949,9 +921,6 @@ class TwitchChat:  # pylint: disable=too-many-instance-attributes
 
     async def stop(self):
         """stop the twitch chat support"""
-        if self.watcher:
-            self.watcher.stop()
-            self.watcher = None
         if self.chat:
             self.chat.stop()
         self.chat = None

--- a/nowplaying/twitch/constants.py
+++ b/nowplaying/twitch/constants.py
@@ -22,6 +22,7 @@ CHAT_BOT_AUTH_SCOPES: list[AuthScope] = [
 # Broadcaster scopes (chat scopes + additional broadcaster permissions)
 BROADCASTER_AUTH_SCOPES: list[AuthScope] = CHAT_BOT_AUTH_SCOPES + [
     AuthScope.CHANNEL_READ_REDEMPTIONS,
+    AuthScope.CHANNEL_MANAGE_BROADCAST,
 ]
 
 # Build scope strings from enums using TwitchAPI helper

--- a/nowplaying/twitch/launch.py
+++ b/nowplaying/twitch/launch.py
@@ -5,7 +5,8 @@ import asyncio
 import contextlib
 import logging
 import signal
-
+import nowplaying.db
+import nowplaying.twitch.broadcaster
 import nowplaying.twitch.chat
 import nowplaying.twitch.redemptions
 import nowplaying.twitch.utils
@@ -23,6 +24,7 @@ class TwitchLaunch:  # pylint: disable=too-many-instance-attributes
         self.config = config
         self.stopevent = stopevent or asyncio.Event()
         self.widgets = None
+        self.broadcaster = None
         self.chat = None
         self.redemptions = None
         self.loop = None
@@ -66,6 +68,12 @@ class TwitchLaunch:  # pylint: disable=too-many-instance-attributes
             self.config.cparser.setValue(BROADCASTER_OAUTH_STATUS_KEY, OAUTH_STATUS_EXPIRED)
             self.config.cparser.sync()
 
+        logging.info("Starting Twitch track watcher task")
+        task = self.loop.create_task(self._run_track_watcher(), name="twitch_track_watcher")
+        self.tasks.add(task)
+        task.add_done_callback(self.tasks.discard)
+        task.add_done_callback(self.log_task_exception)
+
         if self.chat:
             logging.info("Starting Twitch chat task")
             task = self.loop.create_task(self.chat.run_chat(self.twitchlogin), name="twitch_chat")
@@ -82,6 +90,49 @@ class TwitchLaunch:  # pylint: disable=too-many-instance-attributes
             task.add_done_callback(self.tasks.discard)
             task.add_done_callback(self.log_task_exception)
 
+    def _on_watcher_event(self, event):  # pylint: disable=unused-argument
+        """Watcher callback — schedule a track-change dispatch on the running loop"""
+        if not self.loop or not self.loop.is_running():
+            return
+        try:
+            future = asyncio.run_coroutine_threadsafe(self._dispatch_track_change(), self.loop)
+            future.add_done_callback(
+                lambda f: (
+                    logging.error("Track watcher dispatch failed: %s", f.exception())
+                    if not f.cancelled() and f.exception() is not None
+                    else None
+                )
+            )
+        except Exception:  # pylint: disable=broad-except
+            logging.exception("Track watcher dispatch failed")
+
+    async def _dispatch_track_change(self) -> None:
+        """Dispatch a track-change event to all consumers"""
+        if self.broadcaster:
+            try:
+                await self.broadcaster.on_track_change()
+            except Exception:  # pylint: disable=broad-except
+                logging.exception("Broadcaster track change handler failed")
+        if self.chat:
+            try:
+                await self.chat.on_track_change()
+            except Exception:  # pylint: disable=broad-except
+                logging.exception("Chat track change handler failed")
+
+    async def _run_track_watcher(self) -> None:
+        """Own the metadb watcher and dispatch track changes to all consumers"""
+        metadb = nowplaying.db.MetadataDB()
+        watcher = metadb.watcher()
+        try:
+            watcher.start(customhandler=self._on_watcher_event)
+            # Initial dispatch so consumers get the current track on startup
+            await self._dispatch_track_change()
+            while not nowplaying.utils.safe_stopevent_check(self.stopevent):
+                await asyncio.sleep(1)
+        finally:
+            logging.debug("track watcher stop event received")
+            watcher.stop()
+
     async def _watch_for_exit(self):
         while not nowplaying.utils.safe_stopevent_check(self.stopevent):
             await asyncio.sleep(1)
@@ -90,7 +141,10 @@ class TwitchLaunch:  # pylint: disable=too-many-instance-attributes
     def start(self):
         """start twitch support"""
         try:
-            logging.info("Creating Twitch chat and redemptions objects")
+            logging.info("Creating Twitch broadcaster, chat and redemptions objects")
+            self.broadcaster = nowplaying.twitch.broadcaster.TwitchBroadcaster(
+                config=self.config, stopevent=self.stopevent
+            )
             self.chat = nowplaying.twitch.chat.TwitchChat(
                 config=self.config, stopevent=self.stopevent
             )
@@ -121,6 +175,8 @@ class TwitchLaunch:  # pylint: disable=too-many-instance-attributes
 
     async def stop(self):
         """stop the twitch support"""
+        if self.broadcaster:
+            await self.broadcaster.stop()
         if self.redemptions:
             await self.redemptions.stop()
         if self.chat:

--- a/nowplaying/twitch/settings.py
+++ b/nowplaying/twitch/settings.py
@@ -2,11 +2,13 @@
 """twitch settings"""
 
 import logging
+import pathlib
 import time
 
-from PySide6.QtCore import QTimer  # pylint: disable=no-name-in-module
+from PySide6.QtCore import QTimer, Slot  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QApplication, QMessageBox  # pylint: disable=no-name-in-module
 
+import nowplaying.preview.textwindow
 import nowplaying.twitch.oauth2
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.twitch.constants import (
@@ -27,6 +29,9 @@ class TwitchSettings:
         self.uihelp = None
         self.oauth = None
         self.status_timer = None
+        self._streamtitle_preview_window: (
+            nowplaying.preview.textwindow.TextPreviewWindow | None
+        ) = None
 
     def connect(self, uihelp, widget):
         """connect twitch"""
@@ -39,6 +44,11 @@ class TwitchSettings:
         widget.clientid_lineedit.editingFinished.connect(self.update_oauth_status)
         widget.secret_lineedit.editingFinished.connect(self.update_oauth_status)
 
+        # Stream title
+        widget.streamtitle_checkbox.toggled.connect(self._on_streamtitle_toggled)
+        widget.streamtitle_button.clicked.connect(self.on_streamtitle_button)
+        widget.streamtitle_preview_button.clicked.connect(self.on_streamtitle_preview_button)
+
     def load(self, config, widget, uihelp):  # pylint: disable=unused-argument
         """load the settings window"""
         self.widget = widget
@@ -46,6 +56,15 @@ class TwitchSettings:
         widget.clientid_lineedit.setText(config.cparser.value("twitchbot/clientid"))
         widget.channel_lineedit.setText(config.cparser.value("twitchbot/channel"))
         widget.secret_lineedit.setText(config.cparser.value("twitchbot/secret"))
+
+        streamtitle_enabled = config.cparser.value("twitchbot/streamtitle_enabled", type=bool)
+        widget.streamtitle_checkbox.setChecked(streamtitle_enabled)
+        widget.streamtitle_lineedit.setText(
+            config.cparser.value("twitchbot/streamtitle", defaultValue="")
+        )
+        widget.streamtitle_lineedit.setEnabled(streamtitle_enabled)
+        widget.streamtitle_button.setEnabled(streamtitle_enabled)
+        widget.streamtitle_preview_button.setEnabled(streamtitle_enabled)
 
         # Redirect URI info is displayed as static text in UI instructions
 
@@ -72,6 +91,12 @@ class TwitchSettings:
         config.cparser.setValue("twitchbot/channel", newchannel)
         config.cparser.setValue("twitchbot/clientid", newclientid)
         config.cparser.setValue("twitchbot/secret", newsecret)
+        config.cparser.setValue(
+            "twitchbot/streamtitle_enabled", widget.streamtitle_checkbox.isChecked()
+        )
+        config.cparser.setValue(
+            "twitchbot/streamtitle", widget.streamtitle_lineedit.text().strip()
+        )
 
         # Redirect URI is dynamically generated, not stored in config
 
@@ -210,6 +235,44 @@ class TwitchSettings:
     def cleanup(self):
         """Clean up resources when settings UI is closed"""
         self.stop_status_timer()
+
+    def _on_streamtitle_toggled(self, enabled: bool) -> None:
+        """Enable/disable stream title template widgets based on checkbox state"""
+        self.widget.streamtitle_lineedit.setEnabled(enabled)
+        self.widget.streamtitle_button.setEnabled(enabled)
+        self.widget.streamtitle_preview_button.setEnabled(enabled)
+
+    @Slot()
+    def on_streamtitle_button(self) -> None:
+        """Open template file picker for stream title"""
+        self.uihelp.template_picker_lineedit(
+            self.widget.streamtitle_lineedit, limit="twitchbot_*.txt"
+        )
+
+    @Slot()
+    def on_streamtitle_preview_button(self) -> None:
+        """Open or raise the stream title template preview window"""
+        if self._streamtitle_preview_window is None:
+            self._streamtitle_preview_window = nowplaying.preview.textwindow.TextPreviewWindow(
+                config=self.oauth.config,
+                glob_pattern="twitchbot_*.txt",
+                config_key="twitchbot/streamtitle",
+                enable_select_button=True,
+            )
+            self._streamtitle_preview_window.template_selected.connect(
+                self._on_streamtitle_template_selected
+            )
+        current = pathlib.Path(self.widget.streamtitle_lineedit.text()).name
+        if current:
+            self._streamtitle_preview_window.select_template(current)
+        self._streamtitle_preview_window.show()
+        self._streamtitle_preview_window.raise_()
+
+    @Slot(str)
+    def _on_streamtitle_template_selected(self, template_name: str) -> None:
+        self.widget.streamtitle_lineedit.setText(
+            str(pathlib.Path(self.oauth.config.templatedir) / template_name)
+        )
 
     def clear_authentication(self):
         """clear stored authentication tokens (OAuth2 and chat)"""

--- a/nowplaying/twitch/utils.py
+++ b/nowplaying/twitch/utils.py
@@ -68,6 +68,73 @@ async def get_user_image(
     return image
 
 
+async def update_stream_title(
+    oauth: "nowplaying.twitch.oauth2.TwitchOAuth2",
+    title: str,
+    session: aiohttp.ClientSession | None = None,
+) -> bool:
+    """Update the broadcaster's Twitch stream title via the Helix API"""
+    try:
+        if not oauth or not oauth.access_token or not oauth.client_id:
+            logging.error("OAuth2 client or access token not available for title update")
+            return False
+
+        headers = {
+            "Authorization": f"Bearer {oauth.access_token}",
+            "Client-Id": oauth.client_id,
+            "Content-Type": "application/json",
+        }
+        timeout = aiohttp.ClientTimeout(total=10)
+
+        async def _do_requests(session: aiohttp.ClientSession) -> bool:
+            async with session.get(
+                f"{oauth.api_host}/users",
+                headers=headers,
+                timeout=timeout,
+            ) as resp:
+                if resp.status != 200:
+                    logging.error("Failed to get broadcaster user info: %s", resp.status)
+                    return False
+                user_data = await resp.json()
+                if not (users := user_data.get("data", [])):
+                    logging.error("No user data returned for broadcaster")
+                    return False
+                broadcaster_id = users[0]["id"]
+
+            async with session.patch(
+                f"{oauth.api_host}/channels",
+                headers=headers,
+                params={"broadcaster_id": broadcaster_id},
+                json={"title": title},
+                timeout=timeout,
+            ) as resp:
+                if resp.status == 204:
+                    logging.info("Stream title updated: %s", title)
+                    return True
+                if resp.status == 401:
+                    logging.error(
+                        "Stream title update denied (HTTP 401) — broadcaster token is missing"
+                        " channel:manage:broadcast scope; re-authenticate to fix"
+                    )
+                elif resp.status == 403:
+                    logging.error(
+                        "Stream title update denied (HTTP 403) — token is valid but"
+                        " not authorized for this channel; check broadcaster account"
+                    )
+                else:
+                    logging.error("Failed to update stream title: HTTP %s", resp.status)
+                return False
+
+        if session is not None:
+            return await _do_requests(session)
+        async with aiohttp.ClientSession() as owned_session:
+            return await _do_requests(owned_session)
+
+    except Exception as error:  # pylint: disable=broad-except
+        logging.error("Error updating stream title: %s", error)
+        return False
+
+
 async def async_validate_token(
     oauth_client: "nowplaying.twitch.oauth2.TwitchOAuth2", token: str | None = None
 ) -> str | None:
@@ -121,6 +188,14 @@ class TwitchLogin:
                     oauth_client.access_token = access_token
                     oauth_client.refresh_token = refresh_token
                     logging.debug("Existing Twitch token is valid")
+                    token_scopes = validation.get("scopes", [])
+                    missing = [s for s in BROADCASTER_SCOPE_STRINGS if s not in token_scopes]
+                    if missing:
+                        logging.warning(
+                            "Broadcaster token is missing scopes: %s — re-authenticate to enable"
+                            " all features",
+                            missing,
+                        )
                     self.config.cparser.setValue(
                         BROADCASTER_OAUTH_STATUS_KEY, OAUTH_STATUS_AUTHENTICATED
                     )


### PR DESCRIPTION
Lift the metadb watcher out of TwitchChat and into TwitchLaunch so track-change events dispatch to all consumers independently of whether chat is enabled.

New TwitchBroadcaster class handles broadcaster-level API calls (stream title for now; pin messages and similar can follow). On each track change TwitchLaunch dispatches to both broadcaster and chat.

TwitchChat._setup_timer() is now just the guess game polling loop. The metadb watcher and _announce_track() sync callback are removed; on_track_change() is the new public entry point called by TwitchLaunch.

Stream title update: configured via a Jinja2 template string on the main Twitch settings page (not gated on chat being enabled). Requires re-authentication to grant the new channel:manage:broadcast scope. Preview button renders the template against current track metadata.

## Summary by Sourcery

Add broadcaster-level Twitch support so track changes can update the stream title and be dispatched independently of chat.

New Features:
- Introduce a TwitchBroadcaster component that reacts to track changes and updates the Twitch stream title from a configurable Jinja2 template.
- Add UI options and preview support for configuring and testing a Twitch stream title template independent of chat enablement.

Enhancements:
- Move metadata DB watcher ownership from TwitchChat into TwitchLaunch so track-change events are centrally dispatched to broadcaster and chat consumers.
- Extend OAuth validation and scopes to include broadcaster permissions required for managing the Twitch stream title.
- Refine TwitchChat lifecycle handling so tokens are preserved on exit and the periodic timer only drives the guess game polling loop.
- Add a helper in the preview text window to programmatically select templates and set a default Twitch stream title template path in configuration.