### PR TITLE
Fix macOS Intel codesign hang and add build diagnostics

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -61,7 +61,8 @@ jobs:
           echo "$MACOS_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
           KEYCHAIN_PWD=$(openssl rand -base64 32)
           KEYCHAIN_PATH="$HOME/Library/Keychains/build.keychain-db"
-          security create-keychain -p "$KEYCHAIN_PWD" build.keychain
+          security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          # No -l (lock on sleep) and no -t (timeout) = never lock
           security set-keychain-settings "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -30,6 +30,14 @@ jobs:
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
     steps:
+      - name: cpu diagnostics
+        run: |
+          echo "=== CPU info ==="
+          sysctl -n machdep.cpu.brand_string
+          echo "=== Load average ==="
+          uptime
+          echo "=== Top CPU consumers ==="
+          ps aux --sort=-%cpu 2>/dev/null | head -20 || ps aux | sort -rk3 | head -20
       - name: icu
         run: |
           brew update --preinstall || true
@@ -52,13 +60,14 @@ jobs:
         run: |
           echo "$MACOS_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
           KEYCHAIN_PWD=$(openssl rand -base64 32)
+          KEYCHAIN_PATH="$HOME/Library/Keychains/build.keychain-db"
           security create-keychain -p "$KEYCHAIN_PWD" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PWD" build.keychain
-          security list-keychains -d user -s build.keychain $(security list-keychains -d user | tr -d '"')
-          security import /tmp/certificate.p12 -k build.keychain \
+          security set-keychain-settings "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security import /tmp/certificate.p12 -k "$KEYCHAIN_PATH" \
             -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PWD" build.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           rm -f /tmp/certificate.p12
       - name: run builder
         env:

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -34,6 +34,7 @@ jobs:
       artifact-name: macos15-intel-dist
       environment: >-
         ${{ (github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/macos-signing' ||
         startsWith(github.ref, 'refs/tags/')) && 'macos-signing' || '' }}
 
 

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -34,7 +34,6 @@ jobs:
       artifact-name: macos15-intel-dist
       environment: >-
         ${{ (github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/macos-signing' ||
         startsWith(github.ref, 'refs/tags/')) && 'macos-signing' || '' }}
 
 


### PR DESCRIPTION
- Use full keychain path to prevent silent access failures on Intel
- Set keychain to never lock to prevent mid-build lockout
- Add CPU diagnostics step to surface runner health on each run
- Enable macos-signing branch builds for testing

## Summary by Sourcery

Improve macOS CI build reliability and enable additional branch builds for signing tests.

CI:
- Add a CPU diagnostics step to the macOS build workflow to capture runner health information.
- Update macOS keychain setup in the build workflow to use the full keychain path and prevent automatic locking during builds.
- Allow the macos-signing branch to trigger the macOS signing environment in the PyInstaller workflow.