### PR TITLE
Reduce MPRIS2 log noise for unavailable services and idle state

### DIFF
--- a/nowplaying/inputs/mpris2.py
+++ b/nowplaying/inputs/mpris2.py
@@ -37,7 +37,7 @@ MPRIS2_BASE = "org.mpris.MediaPlayer2"
 MIXXX_IDLE_ARTISTS = frozenset({"AutoDJ is ready!", "No track playing"})
 
 
-class MPRIS2Handler:
+class MPRIS2Handler:  # pylint: disable=too-many-instance-attributes
     """Read metadata from MPRIS2"""
 
     def __init__(self, service=None):
@@ -46,7 +46,8 @@ class MPRIS2Handler:
         self.introspection = None
         self.meta = None
         self.metadata = {}
-        self._unavailable_logged = False
+        self._service_unavailable_logged = False
+        self._idle_state_logged = False
 
         if not DBUS_STATUS:
             self.dbus_status = False
@@ -62,11 +63,11 @@ class MPRIS2Handler:
         self.service = service
 
         if "." not in service and not await self.find_service():
-            if not self._unavailable_logged:
+            if not self._service_unavailable_logged:
                 logging.warning(
                     "%s is not a known MPRIS2 service; will retry when it appears.", service
                 )
-                self._unavailable_logged = True
+                self._service_unavailable_logged = True
             else:
                 logging.debug("%s still not available.", service)
             return
@@ -78,13 +79,13 @@ class MPRIS2Handler:
             self.introspection = await self.bus.introspect(
                 f"{MPRIS2_BASE}.{self.service}", "/org/mpris/MediaPlayer2"
             )
-            self._unavailable_logged = False
+            self._service_unavailable_logged = False
         except Exception as error:  # pylint: disable=broad-exception-caught
-            if not self._unavailable_logged:
-                logging.warning("D-Bus connection error for %s: %s", service, error)
-                self._unavailable_logged = True
+            if not self._service_unavailable_logged:
+                logging.warning("D-Bus connection error for %s: %s", self.service, error)
+                self._service_unavailable_logged = True
             else:
-                logging.debug("D-Bus connection error for %s: %s", service, error)
+                logging.debug("D-Bus connection error for %s: %s", self.service, error)
             self.introspection = None
 
         self.meta = None
@@ -122,13 +123,13 @@ class MPRIS2Handler:
             self.meta = CIMultiDict(unpacked_result.get("Metadata", {}))
         except Exception as error:  # pylint: disable=broad-exception-caught
             # likely had a service and but now it is gone
-            if not self._unavailable_logged:
+            if not self._service_unavailable_logged:
                 logging.warning(
                     "D-Bus error for %s: %s; will retry when service reappears.",
                     self.service,
                     error,
                 )
-                self._unavailable_logged = True
+                self._service_unavailable_logged = True
             else:
                 logging.debug("D-Bus error for %s: %s", self.service, error)
             self.metadata = {}
@@ -176,13 +177,17 @@ class MPRIS2Handler:
         # no real track is loaded (e.g. AutoDJ idle, empty deck). Discard these.
         artist = builddata.get("artist")
         if title == "Mixxx" and artist in MIXXX_IDLE_ARTISTS:
-            if not self._unavailable_logged:
+            if not self._idle_state_logged:
                 logging.debug(
                     "Mixxx is idle (artist=%s); suppressing further idle messages.", artist
                 )
-                self._unavailable_logged = True
+                self._idle_state_logged = True
             builddata["title"] = None
             builddata["artist"] = None
+        else:
+            # Real track data — reset both suppression flags
+            self._service_unavailable_logged = False
+            self._idle_state_logged = False
 
         # it looks like there is a race condition in mixxx
         # probably should make this an option in the MPRIS2
@@ -191,7 +196,6 @@ class MPRIS2Handler:
         # if arturl:
         #     with urllib.request.urlopen(arturl) as coverart:
         #         builddata['coverimageraw'] = coverart.read()
-        self._unavailable_logged = False
         self.metadata = builddata
         return self.metadata
 

--- a/nowplaying/inputs/mpris2.py
+++ b/nowplaying/inputs/mpris2.py
@@ -68,8 +68,6 @@ class MPRIS2Handler:  # pylint: disable=too-many-instance-attributes
                     "%s is not a known MPRIS2 service; will retry when it appears.", service
                 )
                 self._service_unavailable_logged = True
-            else:
-                logging.debug("%s still not available.", service)
             return
 
         try:
@@ -106,7 +104,6 @@ class MPRIS2Handler:  # pylint: disable=too-many-instance-attributes
         if not self.introspection:
             await self.resetservice(self.service)
         if not self.introspection:
-            logging.debug("Service not available: %s", self.service)
             return builddata
 
         try:

--- a/nowplaying/inputs/mpris2.py
+++ b/nowplaying/inputs/mpris2.py
@@ -46,6 +46,7 @@ class MPRIS2Handler:
         self.introspection = None
         self.meta = None
         self.metadata = {}
+        self._unavailable_logged = False
 
         if not DBUS_STATUS:
             self.dbus_status = False
@@ -61,7 +62,13 @@ class MPRIS2Handler:
         self.service = service
 
         if "." not in service and not await self.find_service():
-            logging.error("%s is not a known MPRIS2 service.", service)
+            if not self._unavailable_logged:
+                logging.warning(
+                    "%s is not a known MPRIS2 service; will retry when it appears.", service
+                )
+                self._unavailable_logged = True
+            else:
+                logging.debug("%s still not available.", service)
             return
 
         try:
@@ -71,8 +78,13 @@ class MPRIS2Handler:
             self.introspection = await self.bus.introspect(
                 f"{MPRIS2_BASE}.{self.service}", "/org/mpris/MediaPlayer2"
             )
+            self._unavailable_logged = False
         except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.error("D-Bus connection error: %s", error)
+            if not self._unavailable_logged:
+                logging.warning("D-Bus connection error for %s: %s", service, error)
+                self._unavailable_logged = True
+            else:
+                logging.debug("D-Bus connection error for %s: %s", service, error)
             self.introspection = None
 
         self.meta = None
@@ -93,7 +105,7 @@ class MPRIS2Handler:
         if not self.introspection:
             await self.resetservice(self.service)
         if not self.introspection:
-            logging.error("Unknown service: %s", self.service)
+            logging.debug("Service not available: %s", self.service)
             return builddata
 
         try:
@@ -110,7 +122,15 @@ class MPRIS2Handler:
             self.meta = CIMultiDict(unpacked_result.get("Metadata", {}))
         except Exception as error:  # pylint: disable=broad-exception-caught
             # likely had a service and but now it is gone
-            logging.error("D-Bus error: %s", error)
+            if not self._unavailable_logged:
+                logging.warning(
+                    "D-Bus error for %s: %s; will retry when service reappears.",
+                    self.service,
+                    error,
+                )
+                self._unavailable_logged = True
+            else:
+                logging.debug("D-Bus error for %s: %s", self.service, error)
             self.metadata = {}
             self.introspection = None
             if self.bus:
@@ -156,7 +176,11 @@ class MPRIS2Handler:
         # no real track is loaded (e.g. AutoDJ idle, empty deck). Discard these.
         artist = builddata.get("artist")
         if title == "Mixxx" and artist in MIXXX_IDLE_ARTISTS:
-            logging.debug("Ignoring Mixxx idle state: artist=%s", artist)
+            if not self._unavailable_logged:
+                logging.debug(
+                    "Mixxx is idle (artist=%s); suppressing further idle messages.", artist
+                )
+                self._unavailable_logged = True
             builddata["title"] = None
             builddata["artist"] = None
 
@@ -167,6 +191,7 @@ class MPRIS2Handler:
         # if arturl:
         #     with urllib.request.urlopen(arturl) as coverart:
         #         builddata['coverimageraw'] = coverart.read()
+        self._unavailable_logged = False
         self.metadata = builddata
         return self.metadata
 


### PR DESCRIPTION
Warn once when a service is not found or D-Bus connection fails, then suppress to debug until it recovers. Same for Mixxx idle state chatter at debug level.

## Summary by Sourcery

Reduce noisy logging for unavailable MPRIS2 services and idle Mixxx states by tracking and throttling repeated warnings.

Bug Fixes:
- Prevent repeated high-level error logs when MPRIS2 services are temporarily unavailable or D-Bus connections fail.

Enhancements:
- Log initial MPRIS2 service discovery and D-Bus failures as one-time warnings and downgrade subsequent repeats to debug until the service recovers.
- Downgrade missing/unknown MPRIS2 service messages during track fetch to debug level to avoid log spam.
- Suppress repeated Mixxx idle-state debug messages by logging only the first occurrence until a real track is seen again.