### PR TITLE
Ping version check endpoint with charts key on startup

### DIFF
--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
 )
 
 import nowplaying.apicache
+import nowplaying.upgrades
 import nowplaying.obs.exportdialog
 import nowplaying.version  # pylint: disable=no-name-in-module,import-error
 import nowplaying.config
@@ -457,7 +458,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.vacuum_thread.start()
 
     def _setup_charts_key(self) -> None:
-        """Generate anonymous charts key if none exists"""
+        """Generate anonymous charts key if none exists, or ping version if key already present"""
         self._update_startup_progress("Setting up Charts service...")
         existing_key = self.config.cparser.value("charts/charts_key", defaultValue="")
         if not existing_key:
@@ -469,6 +470,8 @@ class Tray:  # pylint: disable=too-many-instance-attributes
                 logging.info("Generated and saved anonymous charts key during startup")
             else:
                 logging.warning("Failed to generate anonymous key during startup")
+        else:
+            nowplaying.upgrades.ping_version(self.config)
 
     def _requestswindow(self) -> None:
         if self.config.cparser.value("settings/requests", type=bool) and self.requestswindow:

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -10,6 +10,9 @@ import requests
 
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
 
+if t.TYPE_CHECKING:
+    import nowplaying.config
+
 UPDATE_CHECK_URL = "https://whatsnowplaying.com/api/v1/check-version"
 
 _PRERELEASE_MARKERS = ("-rc", "-preview", "+")
@@ -189,6 +192,27 @@ class Version:
 def _is_prerelease(version: str) -> bool:
     """Return True if the version string indicates a pre-release"""
     return any(marker in version for marker in _PRERELEASE_MARKERS)
+
+
+def ping_version(config: "nowplaying.config.ConfigFile") -> None:
+    """Ping the version-check endpoint with the charts key.
+
+    Fire-and-forget: called at startup when a charts key already exists so the
+    server can correlate the running version with a known user account.
+    Only called when a key is present; callers should check first.
+    """
+    current_version: str = nowplaying.version.__VERSION__  # pylint: disable=no-member
+    charts_key: str = config.cparser.value("charts/charts_key", defaultValue="", type=str)
+
+    try:
+        requests.get(
+            UPDATE_CHECK_URL,
+            params={"version": current_version},
+            headers={"X-API-Key": charts_key},
+            timeout=10,
+        )
+    except Exception:  # pylint: disable=broad-except
+        logging.debug("Version ping failed", exc_info=True)
 
 
 def check_for_update(platform_info: dict[str, t.Any]) -> dict[str, t.Any] | None:

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -9,6 +9,7 @@ import typing as t
 import requests
 
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
+from nowplaying.upgrades.platform import PlatformDetector
 
 if t.TYPE_CHECKING:
     import nowplaying.config
@@ -194,38 +195,8 @@ def _is_prerelease(version: str) -> bool:
     return any(marker in version for marker in _PRERELEASE_MARKERS)
 
 
-def ping_version(config: "nowplaying.config.ConfigFile") -> None:
-    """Ping the version-check endpoint with the charts key.
-
-    Fire-and-forget: called at startup when a charts key already exists so the
-    server can correlate the running version with a known user account.
-
-    If the charts key is missing or empty, this function returns without
-    making a request.
-    """
-    current_version: str = nowplaying.version.__VERSION__  # pylint: disable=no-member
-    charts_key: str = config.cparser.value("charts/charts_key", defaultValue="", type=str)
-
-    if not charts_key:
-        return
-
-    try:
-        requests.get(
-            UPDATE_CHECK_URL,
-            params={"version": current_version},
-            headers={"X-API-Key": charts_key},
-            timeout=1,
-        )
-    except requests.RequestException:
-        logging.debug("Version ping failed", exc_info=True)
-
-
-def check_for_update(platform_info: dict[str, t.Any]) -> dict[str, t.Any] | None:
-    """Check for updates via whatsnowplaying.com API.
-
-    Sends current version and platform info to the API.
-    Returns the response dict if an update is available, None otherwise.
-    """
+def _build_version_params(platform_info: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Build query params for the version-check API from platform info."""
     current_version = nowplaying.version.__VERSION__  # pylint: disable=no-member
 
     params: dict[str, t.Any] = {
@@ -239,6 +210,45 @@ def check_for_update(platform_info: dict[str, t.Any]) -> dict[str, t.Any] | None
         params["macos_version"] = macos_version
     if _is_prerelease(current_version):
         params["track"] = "prerelease"
+
+    return params
+
+
+def ping_version(config: "nowplaying.config.ConfigFile") -> None:
+    """Ping the version-check endpoint with the charts key.
+
+    Fire-and-forget: called at startup when a charts key already exists so the
+    server can correlate the running version with a known user account.
+
+    If the charts key is missing or empty, this function returns without
+    making a request.
+    """
+    charts_key: str = config.cparser.value("charts/charts_key", defaultValue="", type=str)
+
+    if not charts_key:
+        return
+
+    params = _build_version_params(PlatformDetector.get_platform_info())
+
+    try:
+        response = requests.get(
+            UPDATE_CHECK_URL,
+            params=params,
+            headers={"X-API-Key": charts_key},
+            timeout=1,
+        )
+        logging.debug("Version ping succeeded: HTTP %s", response.status_code)
+    except requests.RequestException:
+        logging.debug("Version ping failed", exc_info=True)
+
+
+def check_for_update(platform_info: dict[str, t.Any]) -> dict[str, t.Any] | None:
+    """Check for updates via whatsnowplaying.com API.
+
+    Sends current version and platform info to the API.
+    Returns the response dict if an update is available, None otherwise.
+    """
+    params = _build_version_params(platform_info)
 
     try:
         response = requests.get(UPDATE_CHECK_URL, params=params, timeout=10)

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -199,19 +199,24 @@ def ping_version(config: "nowplaying.config.ConfigFile") -> None:
 
     Fire-and-forget: called at startup when a charts key already exists so the
     server can correlate the running version with a known user account.
-    Only called when a key is present; callers should check first.
+
+    If the charts key is missing or empty, this function returns without
+    making a request.
     """
     current_version: str = nowplaying.version.__VERSION__  # pylint: disable=no-member
     charts_key: str = config.cparser.value("charts/charts_key", defaultValue="", type=str)
+
+    if not charts_key:
+        return
 
     try:
         requests.get(
             UPDATE_CHECK_URL,
             params={"version": current_version},
             headers={"X-API-Key": charts_key},
-            timeout=10,
+            timeout=1,
         )
-    except Exception:  # pylint: disable=broad-except
+    except requests.RequestException:
         logging.debug("Version ping failed", exc_info=True)
 
 

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -152,7 +152,7 @@ def test_check_for_update_sends_correct_params(
 
 
 def test_ping_version_sends_key(bootstrap, monkeypatch):
-    """ping_version sends version and charts_key to the update check URL"""
+    """ping_version sends version, os, and X-API-Key header to the update check URL"""
     monkeypatch.setattr(nowplaying.version, "__VERSION__", "5.2.0", raising=False)  # pylint: disable=no-member
     bootstrap.cparser.setValue("charts/charts_key", "testkey1234")
 
@@ -163,6 +163,7 @@ def test_ping_version_sends_key(bootstrap, monkeypatch):
         sent_headers = kwargs.get("headers", {})
 
     assert sent_params.get("version") == "5.2.0"
+    assert "os" in sent_params
     assert sent_headers.get("X-API-Key") == "testkey1234"
 
 

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -149,6 +149,30 @@ def test_check_for_update_sends_correct_params(
         assert "macos_version" not in sent_params
 
 
+def test_ping_version_sends_key(bootstrap, monkeypatch):
+    """ping_version sends version and charts_key to the update check URL"""
+    monkeypatch.setattr(nowplaying.version, "__VERSION__", "5.2.0", raising=False)  # pylint: disable=no-member
+    bootstrap.cparser.setValue("charts/charts_key", "testkey1234")
+
+    with patch("requests.get") as mock_get:
+        nowplaying.upgrades.ping_version(bootstrap)
+        _, kwargs = mock_get.call_args
+        sent_params = kwargs.get("params", {})
+        sent_headers = kwargs.get("headers", {})
+
+    assert sent_params.get("version") == "5.2.0"
+    assert sent_headers.get("X-API-Key") == "testkey1234"
+
+
+def test_ping_version_network_failure(bootstrap, monkeypatch):
+    """ping_version silently ignores network failures"""
+    monkeypatch.setattr(nowplaying.version, "__VERSION__", "5.2.0", raising=False)  # pylint: disable=no-member
+    bootstrap.cparser.setValue("charts/charts_key", "testkey1234")
+
+    with patch("requests.get", side_effect=ConnectionError("network down")):
+        nowplaying.upgrades.ping_version(bootstrap)  # should not raise
+
+
 def test_check_for_update_prerelease_sends_track_param(monkeypatch, up_to_date_response):  # pylint: disable=redefined-outer-name
     """prerelease builds send track=prerelease and the correct version"""
     monkeypatch.setattr(nowplaying.version, "__VERSION__", "5.1.0-rc1", raising=False)  # pylint: disable=no-member

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import requests
+
 import nowplaying.upgrades
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
 
@@ -165,12 +167,24 @@ def test_ping_version_sends_key(bootstrap, monkeypatch):
 
 
 def test_ping_version_network_failure(bootstrap, monkeypatch):
-    """ping_version silently ignores network failures"""
+    """ping_version silently ignores network failures but still attempts the call"""
     monkeypatch.setattr(nowplaying.version, "__VERSION__", "5.2.0", raising=False)  # pylint: disable=no-member
     bootstrap.cparser.setValue("charts/charts_key", "testkey1234")
 
-    with patch("requests.get", side_effect=ConnectionError("network down")):
+    with patch("requests.get", side_effect=requests.RequestException("network down")) as mock_get:
         nowplaying.upgrades.ping_version(bootstrap)  # should not raise
+
+    mock_get.assert_called_once()
+
+
+def test_ping_version_no_key_skips_request(bootstrap, monkeypatch):
+    """ping_version makes no request when charts key is absent"""
+    monkeypatch.setattr(nowplaying.version, "__VERSION__", "5.2.0", raising=False)  # pylint: disable=no-member
+
+    with patch("requests.get") as mock_get:
+        nowplaying.upgrades.ping_version(bootstrap)
+
+    mock_get.assert_not_called()
 
 
 def test_check_for_update_prerelease_sends_track_param(monkeypatch, up_to_date_response):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
When a charts key already exists at startup, ping the version-check
endpoint with the key so the server can correlate the running version
with the user account. Previously the key-exists branch did nothing.

## Summary by Sourcery

Ping the version-check API at startup when an existing charts key is present so the running version can be associated with the user account.

New Features:
- Add a fire-and-forget version ping that sends the current version and charts API key when a charts key already exists at startup.

Enhancements:
- Integrate the new version ping into charts key setup so existing users are reported to the version-check service.

Tests:
- Add tests covering version ping parameter and header payload, behavior without a charts key, and resilience to network failures.