### PR TITLE
Improve docs, add authoritative QSettings defaults

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -55,6 +55,10 @@ updates required.
   vinyl decks, standalone CDJs, Rekordbox, and analog mixers, then sends them to
   WNP automatically over the local network. No software integration with the
   hardware required.
+* **Always-Accept mode** — enabled by default. When EarShot identifies a track it
+  overrides the active DJ software source automatically, with no manual source switching
+  required mid-set. Can be disabled for setups where EarShot should only be used as the
+  primary source.
 
 ### [Remote WNP Instance](input/remote.md)
 
@@ -108,7 +112,7 @@ overlays using the Jinja2 template engine. Supports:
 
 * Real-time updates via WebSockets
 * Full HTML, CSS, and JavaScript customization
-* Bundled template library with multiple styles
+* 15 bundled OBS browser overlay templates, including 6 WebGL animated effects
 * Access to all track metadata as template variables
 * Remote control APIs
 
@@ -127,6 +131,7 @@ variable and exportable.
 ### Twitch Bot
 
 * Automatic track announcements when tracks change
+* 36 bundled announcement and response templates for Twitch, Kick, and text output
 * Configurable announcement templates with full Jinja2 support
 * Chat commands for viewers: `!track`, `!artist`, `!album`, and more
 * Contextual help via `!track help`

--- a/docs/help/linux.md
+++ b/docs/help/linux.md
@@ -1,0 +1,35 @@
+# Linux Setup
+
+## Running the Binary
+
+Download the zip for your architecture, extract it, and run the `WhatsNowPlaying` binary.
+
+A desktop environment is required. This software does not run headless.
+
+## Missing Dependencies
+
+If the binary fails to start, install the following packages (Debian/Ubuntu):
+
+```bash
+sudo apt-get install \
+  libegl1 \
+  libgl1 \
+  libdbus-1-3 \
+  libfontconfig1 \
+  libglib2.0-0 \
+  libx11-xcb1 \
+  libxcb-cursor0 \
+  libxcb-icccm4 \
+  libxcb-image0 \
+  libxcb-keysyms1 \
+  libxcb-randr0 \
+  libxcb-render-util0 \
+  libxcb-shape0 \
+  libxcb-xinerama0 \
+  libxcb-xkb1 \
+  libxkbcommon-x11-0
+```
+
+## Building from Source
+
+If you need to build from source, follow the [developer guide](developers.md).

--- a/docs/input/earshot.md
+++ b/docs/input/earshot.md
@@ -29,7 +29,7 @@ If you mix vinyl or CDJs alongside DJ software (Serato, Traktor, etc.), use
 
 1. Open Settings from the **What's Now Playing** icon
 2. Select Input Sources->EarShot from the left-hand column
-3. Check **Always use EarShot when it identifies a new track**
+3. Confirm **Always use EarShot when it identifies a new track** is checked (enabled by default)
 4. Select your DJ software as the active source under Core Settings->Source
 5. Click Save
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ This guide walks you through getting **What's Now Playing** up and running for t
 **[Download the latest release](https://whatsnowplaying.com/download)**
 for your platform.
 
-See [Platform Notes](#platform-notes) below if you have trouble launching the app.
+Linux users: see [Linux Setup](help/linux.md) if the app fails to start.
 
 ## Step 2: Connect Your DJ Software
 
@@ -31,9 +31,10 @@ A few things to know about auto-detection:
 * Hardware-based sources (Denon StageLinQ) require the device to be connected and
   actively broadcasting on the network
 * The first detected source wins. If multiple are found, you can change it afterwards.
-* For **vinyl decks, standalone CDJs, Rekordbox, and analog mixers**, use
-  [WNP EarShot](https://whatsnowplaying.com/earshot) — a companion app that identifies
-  tracks via Shazam and sends them to WNP automatically
+* For **vinyl decks, standalone CDJs, Rekordbox, and analog mixers** (optional):
+  [WNP EarShot](https://whatsnowplaying.com/earshot) is a separate companion app that
+  identifies tracks via Shazam and sends them to WNP automatically. Only needed if
+  your setup does not use DJ software.
 
 See [Input Sources](input/index.md) for per-source setup details.
 
@@ -60,14 +61,19 @@ browser sources pre-configured — no manual URL copying or source sizing requir
 5. Relaunch OBS Studio — the new **WhatsNowPlaying** scene collection will appear
    under **Scene Collection** in the menu bar
 
-The exported collection contains pre-built scenes for your overlays and the Guess Game
-(including WebGL-enhanced versions). Copy the individual browser sources into your
-own scenes as needed.
+WNP ships with 15 browser overlay templates (including 6 WebGL animated effects) and
+36 text templates for Twitch, Kick, and plain text output, all ready to use without
+any editing. The exported collection contains pre-built scenes for your overlays and
+the Guess Game (including WebGL-enhanced versions). Copy the individual browser sources
+into your own scenes as needed.
 
 See [Export for OBS](output/obs-export.md) for full details.
 
 If you prefer to set up OBS manually, see [Web Server](output/webserver.md) for
 instructions on adding a Browser Source by hand.
+
+> **That's it for basic setup.** If you just want a track overlay in OBS, you're done.
+> Everything below is optional. See the [Gallery](gallery/index.md) to browse all included templates.
 
 ## Step 5: Announce Tracks in Chat (Optional)
 
@@ -85,48 +91,3 @@ instructions on adding a Browser Source by hand.
 * **[Templates](reference/templatevariables.md)**: customize every aspect of what gets displayed
 * **[Charts](output/charts.md)**: track your play history, view listening stats, and unlock the
   online Guess Game board — sign up at <https://whatsnowplaying.com/signup>
-
----
-
-## Platform Notes
-
-### macOS
-
-The app is signed and notarized. macOS should open it without any security warnings.
-
-* Do not unzip the downloaded package directly to the folder you will run it from.
-  Unzip in `Downloads` first, then move `WhatsNowPlaying.app` to `Applications`.
-* If macOS still shows a security warning, open **System Settings → Privacy & Security**,
-  scroll down to the **Security** section, and click **Open Anyway**.
-
-### Linux
-
-* Download the zip for your architecture, extract it, and run the `WhatsNowPlaying` binary.
-* A desktop environment is required. This software does not run headless.
-* If the binary fails to start, install the following packages (Debian/Ubuntu):
-
-```bash
-sudo apt-get install \
-  libegl1 \
-  libgl1 \
-  libdbus-1-3 \
-  libfontconfig1 \
-  libglib2.0-0 \
-  libx11-xcb1 \
-  libxcb-cursor0 \
-  libxcb-icccm4 \
-  libxcb-image0 \
-  libxcb-keysyms1 \
-  libxcb-randr0 \
-  libxcb-render-util0 \
-  libxcb-shape0 \
-  libxcb-xinerama0 \
-  libxcb-xkb1 \
-  libxkbcommon-x11-0
-```
-
-* If you need to build from source, follow the [developer guide](help/developers.md).
-
-### Other Platforms
-
-Please follow the [developer guide](help/developers.md) to install and run.

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -21,6 +21,7 @@ from PySide6.QtCore import (  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QWidget  # pylint: disable=no-name-in-module
 
 import nowplaying.artistextras
+import nowplaying.guessgamesettings
 import nowplaying.inputs
 import nowplaying.notifications
 import nowplaying.pluginimporter
@@ -165,6 +166,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         self._defaults_general_settings(settings)
         self._defaults_output(settings)
         self._defaults_chat_services(settings)
+        nowplaying.guessgamesettings.GuessGameSettings.defaults(settings)
         self._defaults_quirks(settings)
         self._defaults_requests(settings)
         self._defaults_plugins(settings)

--- a/nowplaying/guessgamesettings.py
+++ b/nowplaying/guessgamesettings.py
@@ -25,6 +25,29 @@ class GuessGameSettings:
         self.widget = None
         self.uihelp = None
 
+    @staticmethod
+    def defaults(qsettings) -> None:
+        """Set default configuration values for the Guess Game."""
+        qsettings.setValue("guessgame/enabled", False)
+        qsettings.setValue("guessgame/command", "guess")
+        qsettings.setValue("guessgame/statscommand", "mypoints")
+        qsettings.setValue("guessgame/maxduration", 120)
+        qsettings.setValue("guessgame/leaderboard_size", 10)
+        qsettings.setValue("guessgame/difficulty_threshold", 0.70)
+        qsettings.setValue("guessgame/solve_mode", "separate_solves")
+        qsettings.setValue("guessgame/points_common_letter", 1)
+        qsettings.setValue("guessgame/points_uncommon_letter", 2)
+        qsettings.setValue("guessgame/points_rare_letter", 3)
+        qsettings.setValue("guessgame/points_correct_word", 10)
+        qsettings.setValue("guessgame/points_wrong_word", -1)
+        qsettings.setValue("guessgame/points_complete_solve", 100)
+        qsettings.setValue("guessgame/points_first_solver", 50)
+        qsettings.setValue("guessgame/auto_reveal_common_words", False)
+        qsettings.setValue("guessgame/time_bonus_enabled", False)
+        qsettings.setValue("guessgame/send_to_server", True)
+        qsettings.setValue("guessgame/grace_period", 5)
+        qsettings.setValue("guessgame/excluded_users", "")
+
     def connect(self, uihelp, widget):
         """Connect guess game settings UI"""
         self.widget = widget

--- a/nowplaying/inputs/earshot.py
+++ b/nowplaying/inputs/earshot.py
@@ -9,6 +9,7 @@ import nowplaying.inputs.remote
 from nowplaying.types import TrackMetadata
 
 if TYPE_CHECKING:
+    from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
     import nowplaying.config
 
 
@@ -36,6 +37,10 @@ class Plugin(nowplaying.inputs.remote.Plugin):
         if not agent.startswith("wnpearshot"):
             return None
         return meta
+
+    def defaults(self, qsettings: "QSettings") -> None:
+        """Set default configuration values for EarShot."""
+        qsettings.setValue("earshot/always_accept", True)
 
     def load_settingsui(self, qwidget: "QWidget"):
         """Load settings into the UI."""

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -133,6 +133,7 @@ nav:
   - Help:
       - Overview: help/index.md
       - How Do I?: help/howdoi.md
+      - Linux Setup: help/linux.md
       - Accuracy: help/accuracy.md
       - Troubleshooting: help/troubleshooting.md
       - Bug Reports: help/bugreports.md


### PR DESCRIPTION
Docs:
* Simplify quickstart: stop-here callout after OBS step, Linux
  setup moved to dedicated help/linux.md, macOS quarantine
  section removed (app is signed/notarized)
* Mark EarShot as optional; note Always-Accept is default-on
* Add template counts (15 OBS overlays, 36 text templates)
* Link to Gallery from stop-here callout
* Update features.md: EarShot Always-Accept, template counts

QSettings defaults:
* earshot: add defaults() setting earshot/always_accept=True
* guessgame: add GuessGameSettings.defaults() with all 20 keys
* config: call GuessGameSettings.defaults() from ConfigFile.defaults()

## Summary by Sourcery

Refresh documentation around setup, EarShot usage, and available templates while adding centralized QSettings defaults for EarShot and the Guess Game.

New Features:
- Introduce explicit QSettings defaults for EarShot, enabling Always-Accept mode by default.
- Define a centralized defaults() initializer for GuessGameSettings and hook it into the main configuration defaults.

Enhancements:
- Clarify EarShot as an optional companion app and document its default Always-Accept behavior in both features and input docs.
- Document the number and types of bundled overlay and chat templates, and link the quickstart flow to the template gallery.
- Streamline the quickstart guide by adding a clear stopping point for basic OBS use and moving platform-specific Linux instructions into a dedicated help page.

Documentation:
- Add a new Linux Setup help page and update navigation to reference it, removing inline platform notes from the quickstart.