### PR TITLE
Bump wnpmb to 0.2.0; handle tuple from find_recording

### DIFF
--- a/nowplaying/metadata/processors.py
+++ b/nowplaying/metadata/processors.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import url_normalize
 import wnpmb.artist_resolution
+import wnpmb.normalization
 
 import nowplaying.bootstrap
 import nowplaying.config
@@ -227,6 +228,10 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
             self.metadata["title"] = nowplaying.utils.filters.titlestripper(
                 config=self.config, title=self.metadata["title"]
             )
+            if isinstance(self.metadata.get("title"), str):
+                self.metadata["title"] = wnpmb.normalization.remove_duplicate_parentheticals(
+                    self.metadata["title"]
+                )
 
     def _uniqlists(self) -> None:
         if not self.metadata:

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import os
 import sys
-from typing import Any
+from typing import Any, NamedTuple
 
 from wnpmb import (
     MusicBrainzClient,
@@ -25,6 +25,13 @@ import nowplaying.config
 import nowplaying.utils.metadata
 
 logger = logging.getLogger(__name__)
+
+
+class _RecordingLookup(NamedTuple):
+    """Result of _lastditchrid: resolved data and whether it came from a stripped-title fallback."""
+
+    data: dict | None
+    is_fallback: bool
 
 
 class MusicBrainzHelper:
@@ -84,18 +91,23 @@ class MusicBrainzHelper:
             self.mb_client.cache_service = WNPCacheAdapter(nowplaying.apicache.get_cache())
             self.emailaddressset = True
 
-    async def _lastditchrid(self, metadata):
-        """extract fields and run search"""
+    async def _lastditchrid(self, metadata) -> _RecordingLookup:
+        """extract fields and run search
+
+        Returns a _RecordingLookup where is_fallback=True means the match was
+        found only after stripping a generic suffix from the title — caller should
+        use artist data only and not treat the recording fields as authoritative.
+        """
         if metadata.get("musicbrainzrecordingid"):
             logger.debug("Skipping fallback: already have a rid")
-            return None
+            return _RecordingLookup(data=None, is_fallback=False)
 
         artist = metadata.get("artist")
         title = metadata.get("title")
         album = metadata.get("album")
 
         if not artist or not title:
-            return None
+            return _RecordingLookup(data=None, is_fallback=False)
 
         self._setemail()
         year = nowplaying.utils.metadata.get_best_year(metadata)
@@ -109,10 +121,13 @@ class MusicBrainzHelper:
                     year=year,
                 )
 
-        mbid = await self._mb_op_with_retry(_find, "find_recording", None)
-        if mbid:
-            return await self.recordingid(mbid)
-        return None
+        result = await self._mb_op_with_retry(_find, "find_recording", (None, None))
+        exact_mbid, fallback_mbid = result if result else (None, None)
+        if exact_mbid:
+            return _RecordingLookup(data=await self.recordingid(exact_mbid), is_fallback=False)
+        if fallback_mbid:
+            return _RecordingLookup(data=await self.recordingid(fallback_mbid), is_fallback=True)
+        return _RecordingLookup(data=None, is_fallback=False)
 
     async def lastditcheffort(self, metadata):
         """there is like no data, so..."""
@@ -122,11 +137,18 @@ class MusicBrainzHelper:
 
         self._setemail()
 
-        riddata = await self._lastditchrid(metadata)
+        lookup = await self._lastditchrid(metadata)
+        riddata = lookup.data
 
         if riddata:
-            if normalize(riddata.get("title")) != normalize(metadata.get("title")):
-                logger.debug("No title match, so just using artist data")
+            use_artist_only = lookup.is_fallback or (
+                normalize(riddata.get("title")) != normalize(metadata.get("title"))
+            )
+            if use_artist_only:
+                logger.debug(
+                    "Using artist data only: %s",
+                    "fallback match on stripped title" if lookup.is_fallback else "title mismatch",
+                )
 
                 strict_album_matching = self.config.cparser.value(
                     "musicbrainz/strict_album_matching", True, type=bool

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -28,7 +28,7 @@ truststore==0.10.4
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.1.13/wnpmb-0.1.13-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.2.0/wnpmb-0.2.0-py3-none-any.whl
 zeroconf==0.148.0
 
 #


### PR DESCRIPTION
find_recording now returns (exact_mbid, fallback_mbid). Update _lastditchrid to unpack the tuple and propagate an is_fallback flag so lastditcheffort skips the title-mismatch check when wnpmb already stripped a generic suffix to find the match.

Wire in wnpmb.normalization.remove_duplicate_parentheticals for title cleaning in MetadataProcessors._strip_identifiers().

## Summary by Sourcery

Update MusicBrainz fallback recording lookup to handle tuple results and distinguish fallback matches, and enhance title normalization during metadata processing.

New Features:
- Propagate an is_fallback flag from recording lookup so callers can differentiate between exact and fallback recording matches.

Enhancements:
- Adjust last-ditch MusicBrainz recording lookup to interpret tuple results from find_recording and tailor how artist vs. recording data is used based on match quality.
- Improve title cleaning in metadata processing by removing duplicate parenthetical segments via the wnpmb normalization helper.