### PR TITLE
Fix djay Pro one-track-behind detection on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
     OS color scheme; new Auto/Light/Dark override in General settings
   * Fixed dark mode rendering on several UI panels on Linux and Windows
 
+* djay Pro
+  * Fixed one-track-behind detection on Windows; djay Pro writes analysis data
+    and history in separate transactions, so track changes now debounce the WAL
+    file event to ensure both writes have landed before querying
+
 * VirtualDJ
   * Track metadata is now pulled from the local library database for previously
     cataloged tracks

--- a/nowplaying/inputs/djaypro.py
+++ b/nowplaying/inputs/djaypro.py
@@ -30,6 +30,7 @@ import logging
 import pathlib
 import sqlite3
 import sys
+import threading
 import urllib.parse
 from typing import TYPE_CHECKING
 
@@ -65,6 +66,8 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self.event_handler = None
         self.observer = None
         self.djaypro_dir = ""
+        self._wal_timer: threading.Timer | None = None
+        self._wal_timer_lock = threading.Lock()
         self.metadata: TrackMetadata = {
             "artist": None,
             "title": None,
@@ -151,12 +154,21 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
         filename = event.src_path
 
-        # Only process specific files
-        if not (filename.endswith("NowPlaying.txt") or filename.endswith("MediaLibrary.db-wal")):
+        if filename.endswith("NowPlaying.txt"):
+            self._check_for_new_track()
             return
 
-        # Do synchronous work directly in this thread
-        self._check_for_new_track()
+        if not filename.endswith("MediaLibrary.db-wal"):
+            return
+
+        # On Windows, djay Pro writes analysis rows first then historySessionItems
+        # in a separate transaction.  Debounce so we query after both land.
+        with self._wal_timer_lock:
+            if self._wal_timer is not None:
+                self._wal_timer.cancel()
+            self._wal_timer = threading.Timer(0.3, self._check_for_new_track)
+            self._wal_timer.daemon = True
+            self._wal_timer.start()
 
     def _check_for_new_track(self):
         """Check for new track from NowPlaying.txt (macOS) or database (Windows)"""
@@ -433,6 +445,10 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     async def stop(self):
         """stop the watcher"""
+        with self._wal_timer_lock:
+            if self._wal_timer is not None:
+                self._wal_timer.cancel()
+                self._wal_timer = None
         if self.observer:
             self.observer.stop()
             self.observer.join()

--- a/nowplaying/inputs/djaypro.py
+++ b/nowplaying/inputs/djaypro.py
@@ -52,6 +52,9 @@ if TYPE_CHECKING:
     import nowplaying.uihelp
 
 
+_WAL_DEBOUNCE_SECONDS = 0.3
+
+
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     """handler for djay Pro"""
 
@@ -166,9 +169,15 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         with self._wal_timer_lock:
             if self._wal_timer is not None:
                 self._wal_timer.cancel()
-            self._wal_timer = threading.Timer(0.3, self._check_for_new_track)
+            self._wal_timer = threading.Timer(_WAL_DEBOUNCE_SECONDS, self._wal_timer_fired)
             self._wal_timer.daemon = True
             self._wal_timer.start()
+
+    def _wal_timer_fired(self):
+        """Called by the debounce timer; clears the timer reference then checks."""
+        with self._wal_timer_lock:
+            self._wal_timer = None
+        self._check_for_new_track()
 
     def _check_for_new_track(self):
         """Check for new track from NowPlaying.txt (macOS) or database (Windows)"""


### PR DESCRIPTION
djay Pro writes analysis data (mediaItemAnalyzedData, mediaItemTitleIDs, mediaItemUserData, localMediaItemLocations) in one transaction, then historySessionItems in a separate transaction.  The WAL watchdog was firing on the first write before historySessionItems landed, so WNP always showed the previous track.

Debounce WAL filesystem events by 300ms so both transactions have time to commit before the database is queried.

## Summary by Sourcery

Debounce djay Pro WAL file events on Windows to ensure track detection waits for both analysis and history writes before querying, preventing one-track-behind behavior.

Bug Fixes:
- Ensure Windows djay Pro track detection waits for both analysis and history transactions by debouncing WAL filesystem events.
- Prevent stale track metadata by cancelling pending WAL timers when stopping the watcher.

Documentation:
- Document the djay Pro Windows track detection fix and WAL debounce behavior in the changelog.