### PR TITLE
Fix stray QThread crash in systemtray tests  (#1644)

### DIFF
--- a/tests-qt/conftest.py
+++ b/tests-qt/conftest.py
@@ -18,7 +18,12 @@ def detect_stray_threads(request):
     running' crashes in subsequent tests are surfaced at the test that caused
     the leak rather than the test that happened to be running when Qt noticed.
     """
+    # Snapshot Python threads and QThread instances before the test so that
+    # long-lived global threads are not incorrectly flagged as leaks.
     threads_before = {t.ident for t in threading.enumerate()}
+    gc.collect()
+    qt_before = {id(obj) for obj in gc.get_objects() if isinstance(obj, QThread)}
+
     yield
 
     # Brief grace period for threads that are legitimately winding down.
@@ -31,18 +36,21 @@ def detect_stray_threads(request):
         if t.ident not in threads_before and not t.daemon and t.is_alive()
     ]
 
-    # Check for leaked QThread instances still running (catches PySide6 threads
-    # whose Python wrapper may outlive the test scope).
+    # Check for QThread instances created during the test that are still running.
     gc.collect()
-    stray_qt = [obj for obj in gc.get_objects() if isinstance(obj, QThread) and obj.isRunning()]
+    stray_qt = [
+        obj
+        for obj in gc.get_objects()
+        if isinstance(obj, QThread) and obj.isRunning() and id(obj) not in qt_before
+    ]
 
     messages = []
     if stray_python:
-        names = [t.name or f"<unnamed ident={t.ident}>" for t in stray_python]
-        messages.append(f"stray Python thread(s): {names}")
+        reprs = [f"{t.name or '<unnamed>'}(ident={t.ident}, {repr(t)})" for t in stray_python]
+        messages.append(f"stray Python thread(s): {reprs}")
     if stray_qt:
-        names = [type(obj).__name__ for obj in stray_qt]
-        messages.append(f"stray QThread(s) still running: {names}")
+        reprs = [f"{type(obj).__name__}({repr(obj)})" for obj in stray_qt]
+        messages.append(f"stray QThread(s) still running: {reprs}")
 
     if messages:
         pytest.fail(

--- a/tests-qt/conftest.py
+++ b/tests-qt/conftest.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""pytest fixtures for Qt tests"""
+
+import gc
+import threading
+import time
+
+import pytest
+from PySide6.QtCore import QThread  # pylint: disable=no-name-in-module
+
+
+@pytest.fixture(autouse=True)
+def detect_stray_threads(request):
+    """Fail when a test leaves background threads running after it completes.
+
+    Catches both plain Python threads (threading.enumerate) and Qt threads
+    (QThread.isRunning) so that 'QThread: Destroyed while thread is still
+    running' crashes in subsequent tests are surfaced at the test that caused
+    the leak rather than the test that happened to be running when Qt noticed.
+    """
+    threads_before = {t.ident for t in threading.enumerate()}
+    yield
+
+    # Brief grace period for threads that are legitimately winding down.
+    time.sleep(0.15)
+
+    # Check for leaked plain Python threads.
+    stray_python = [
+        t
+        for t in threading.enumerate()
+        if t.ident not in threads_before and not t.daemon and t.is_alive()
+    ]
+
+    # Check for leaked QThread instances still running (catches PySide6 threads
+    # whose Python wrapper may outlive the test scope).
+    gc.collect()
+    stray_qt = [obj for obj in gc.get_objects() if isinstance(obj, QThread) and obj.isRunning()]
+
+    messages = []
+    if stray_python:
+        names = [t.name or f"<unnamed ident={t.ident}>" for t in stray_python]
+        messages.append(f"stray Python thread(s): {names}")
+    if stray_qt:
+        names = [type(obj).__name__ for obj in stray_qt]
+        messages.append(f"stray QThread(s) still running: {names}")
+
+    if messages:
+        pytest.fail(
+            f"{request.node.nodeid} left background thread(s) running — "
+            + "; ".join(messages)
+            + "\nThis causes 'QThread: Destroyed while thread is still running' "
+            "crashes in subsequent tests."
+        )

--- a/tests-qt/test_systemtray.py
+++ b/tests-qt/test_systemtray.py
@@ -182,6 +182,10 @@ class MockMetadataDB:
 @pytest.fixture
 def mock_dependencies():
     """Mock all the heavy dependencies for systemtray testing"""
+    # Capture the real implementation before it gets patched, so individual
+    # tests that specifically exercise vacuum logic can still call it.
+    real_start_background_vacuum = nowplaying.systemtray.Tray._start_background_vacuum
+
     with (
         patch("nowplaying.config.ConfigFile", MockConfig),
         patch("nowplaying.subprocesses.SubprocessManager", MockSubprocessManager),
@@ -192,6 +196,8 @@ def mock_dependencies():
         patch("nowplaying.db.MetadataDB", MockMetadataDB),
         patch("nowplaying.apicache.APIResponseCache.vacuum_database_file") as mock_api_vacuum,
         patch("nowplaying.guessgame.GuessGame.vacuum_database"),
+        patch("nowplaying.guessgame.GuessGame.initialize_database"),
+        patch("nowplaying.systemtray.Tray._start_background_vacuum"),
         patch("nowplaying.systemtray.QFileSystemWatcher") as mock_watcher,
     ):
         mock_load_ui.return_value = MagicMock()
@@ -206,6 +212,7 @@ def mock_dependencies():
             "api_vacuum": mock_api_vacuum,
             "mock_watcher": mock_watcher,
             "mock_watcher_instance": mock_watcher_instance,
+            "real_start_background_vacuum": real_start_background_vacuum,
         }
 
 
@@ -266,10 +273,11 @@ def test_start_background_vacuum(qtbot, mock_dependencies):
         mock_thread_instance = MagicMock()
         mock_thread_class.return_value = mock_thread_instance
 
-        with patch("nowplaying.systemtray.Tray._start_background_vacuum"):
-            tray = nowplaying.systemtray.Tray()
+        tray = nowplaying.systemtray.Tray()
 
-        tray._start_background_vacuum()
+        # Call the real implementation via the saved reference, bypassing the
+        # fixture's patch so we can verify it creates and starts a VacuumThread.
+        mock_dependencies["real_start_background_vacuum"](tray)
 
         mock_thread_class.assert_called_once_with()
         mock_thread_instance.start.assert_called_once()


### PR DESCRIPTION
Add _start_background_vacuum and initialize_database to the mock_dependencies fixture so no real QThread or SQLite call happens in tests that don't specifically exercise those paths. Previously, tests that created Tray() without patching _start_background_vacuum leaked a _VacuumThread that Qt would destroy mid-GC in the next test, causing an abort.

test_start_background_vacuum now calls the real implementation via a saved reference captured before the fixture patches it.

Add tests-qt/conftest.py with an autouse detect_stray_threads fixture that fails fast when a test leaves non-daemon Python threads or running QThread instances behind, pointing the blame at the leaking test rather than the one that aborts.

## Summary by Sourcery

Improve reliability of Qt system tray tests by isolating background vacuum behavior and detecting leaked threads.

Bug Fixes:
- Prevent tests that instantiate Tray from leaking background vacuum threads by mocking vacuum startup and database initialization in the shared fixture.
- Ensure the start_background_vacuum behavior is still verified by calling the original implementation outside the fixture patching.

Tests:
- Add an autouse pytest fixture for Qt tests that detects and fails on stray non-daemon Python threads or running QThreads left after a test completes.