### PR TITLE
Add CHANGELOG.md to docs site via mkdocs hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+docs/changelog.md
 
 # mypy
 .mypy_cache/

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -72,6 +72,9 @@ markdown_extensions:
   - toc:
       permalink: true
 
+hooks:
+  - properdocs_hooks.py
+
 docs_dir: docs
 site_dir: site
 
@@ -82,6 +85,7 @@ nav:
   - Quickstart: quickstart.md
   - Usage: usage.md
   - Upgrading: upgrading.md
+  - Changelog: changelog.md
   - Core Settings:
       - General: settings/index.md
       - Source: input/index.md

--- a/properdocs_hooks.py
+++ b/properdocs_hooks.py
@@ -1,0 +1,8 @@
+"""mkdocs build hooks for What's Now Playing documentation."""
+
+import shutil
+
+
+def on_pre_build(config):  # pylint: disable=unused-argument
+    """Copy repo-root CHANGELOG.md into docs/ before each build."""
+    shutil.copy("CHANGELOG.md", "docs/changelog.md")


### PR DESCRIPTION
properdocs_hooks.py copies CHANGELOG.md into docs/changelog.md before each build so it appears in the rendered site. Added Changelog nav entry after Upgrading. docs/changelog.md is gitignored since it is generated at build time.

## Summary by Sourcery

Add a MkDocs pre-build hook to include the project changelog in the generated documentation site.

Build:
- Register a MkDocs hook script in properdocs.yml to run before each documentation build.

Documentation:
- Expose CHANGELOG.md in the docs site by copying it to docs/changelog.md and adding it to the navigation.

Chores:
- Ignore the generated docs/changelog.md file in version control.