### PR TITLE
Harden trackpoll loop against crashes and sleep/wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version 5.2.1 - in progress
+
+### Bug Fixes
+
+* Fixed trackpoll loop silently stopping after a system sleep/wake cycle or
+    transient error; the loop now recovers automatically
+
+### djay Pro
+
+* Added `has_tracks_by_artist` support for track requests
+* Added playlist support: available playlists can now be selected for
+    artist queries
+
 ## Version 5.2.0 - 2026-05-04
 
 ### New Features

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -233,15 +233,16 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
 
         while not nowplaying.utils.safe_stopevent_check(self.stopevent):
             await asyncio.sleep(0.5)
-            self.config.get()
-
-            if not await self.switch_input_plugin():
-                continue
-
             try:
+                self.config.get()
+
+                if not await self.switch_input_plugin():
+                    continue
+
                 await self.gettrack()
             except Exception as error:  # pylint: disable=broad-except
                 logging.error("Failed attempting to get a track: %s", error, exc_info=True)
+                self.previousinput = None  # force input plugin restart on next iteration
 
         if not self.testmode and self.config.cparser.value("setlist/enabled", type=bool):
             nowplaying.db.create_setlist(self.config)


### PR DESCRIPTION
Wrap config.get() and switch_input_plugin() in the existing
broad-except so any transient error (file lock, bad config
state after sleep/wake, plugin key lookup failure) logs and
retries instead of silently killing the polling task.

Reset previousinput on exception to force a clean input
plugin stop/restart on the next iteration rather than
continuing to call a potentially broken plugin.

## Summary by Sourcery

Harden the track polling loop to automatically recover from transient errors and sleep/wake issues instead of silently stopping.

Bug Fixes:
- Ensure the track polling loop continues running and recovers after system sleep/wake cycles or transient configuration/plugin errors by handling exceptions around configuration reload and input plugin switching.

Enhancements:
- Reset the previous input plugin state on polling errors to force a clean plugin restart on the next iteration.
- Document the new behavior and djay Pro playlist/artist track request support in the changelog for version 5.2.1.

Documentation:
- Update the changelog with the upcoming 5.2.1 bug fix and djay Pro feature notes.