### PR TITLE
Add bpm, key, deck support to djay Pro plugin

### DIFF
--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -43,6 +43,7 @@ import logging
 import pathlib
 import sqlite3
 import threading
+import time
 from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
@@ -123,7 +124,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             "album": None,
             "filename": None,
             "bpm": None,
+            "deck": None,
             "duration": None,
+            "key": None,
         }
 
     async def setup_watcher(self, configkey: str = "djaypro/directory"):
@@ -215,22 +218,31 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         ):
             return
 
+        t_artist = track_data["artist"]
+        t_title = track_data["title"]
+
         # New track detected — look up filename if the history blob didn't include it
         if not track_data["filename"]:
-            t_artist = track_data["artist"]
-            t_title = track_data["title"]
             if isinstance(t_artist, str) and isinstance(t_title, str):
                 filename = self._get_filename_from_db(t_artist, t_title)
                 if filename:
                     track_data["filename"] = filename
+
+        # Supplement with analyzed data (bpm, key) if not already present
+        analyzed: dict = {}
+        if isinstance(t_artist, str) and isinstance(t_title, str):
+            if not track_data.get("bpm") or not track_data.get("key"):
+                analyzed = self._get_analyzed_data_from_db(t_artist, t_title)
 
         new_meta: TrackMetadata = {
             "artist": track_data["artist"],
             "title": track_data["title"],
             "album": track_data["album"],
             "filename": track_data["filename"],
-            "bpm": track_data["bpm"],
+            "bpm": track_data["bpm"] or analyzed.get("bpm"),
+            "deck": track_data.get("deck"),
             "duration": track_data["duration"],
+            "key": track_data.get("key") or analyzed.get("key"),
         }
         if isinstance(track_data.get("isrc"), str):
             new_meta["isrc"] = [track_data["isrc"]]
@@ -298,17 +310,27 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
         # Check if this is a new track
         if self.metadata.get("artist") != artist or self.metadata.get("title") != title:
-            # Supplement NowPlaying.txt with database lookups
+            # Supplement NowPlaying.txt with database lookups.
+            # djay Pro writes NowPlaying.txt before committing to
+            # localMediaItemLocations, so retry once after a short wait if
+            # the first lookup misses.
             filename = self._get_filename_from_db(artist, title)
+            if filename is None:
+                time.sleep(0.5)
+                filename = self._get_filename_from_db(artist, title)
+
             isrc = self._get_isrc_from_db(artist, title)
+            analyzed = self._get_analyzed_data_from_db(artist, title)
 
             new_meta: TrackMetadata = {
                 "artist": artist,
                 "title": title,
                 "album": album,
                 "filename": filename,
-                "bpm": None,
+                "bpm": analyzed.get("bpm"),
+                "deck": analyzed.get("deck"),
                 "duration": duration,
+                "key": analyzed.get("key"),
             }
             if isrc:
                 new_meta["isrc"] = [isrc]
@@ -352,6 +374,44 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             return nowplaying.utils.sqlite.retry_sqlite_operation(query_db)
         except (sqlite3.OperationalError, FileNotFoundError):
             return []
+
+    def _get_analyzed_data_from_db(self, artist: str, title: str) -> dict:
+        """Look up bpm and key from mediaItemAnalyzedData by artist/title match."""
+        dbfile = self._get_db_path()
+        if not dbfile:
+            return {}
+
+        artist_lower = artist.strip().lower()
+        title_lower = title.strip().lower()
+
+        def query_db() -> dict:
+            with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=1) as connection:
+                cursor = connection.cursor()
+                cursor.execute(
+                    "SELECT data FROM database2 WHERE collection='mediaItemAnalyzedData'"
+                )
+                for (blob,) in cursor:
+                    parsed = nowplaying.djaypro.tsaf.parse_blob(blob)
+                    p_artist = parsed.get("artist")
+                    p_title = parsed.get("title")
+                    if (
+                        isinstance(p_artist, str)
+                        and isinstance(p_title, str)
+                        and p_artist.strip().lower() == artist_lower
+                        and p_title.strip().lower() == title_lower
+                    ):
+                        result = {}
+                        if parsed.get("bpm"):
+                            result["bpm"] = parsed["bpm"]
+                        if parsed.get("key"):
+                            result["key"] = parsed["key"]
+                        return result
+            return {}
+
+        try:
+            return nowplaying.utils.sqlite.retry_sqlite_operation(query_db)
+        except (sqlite3.OperationalError, FileNotFoundError):
+            return {}
 
     def _get_isrc_from_db(self, artist: str, title: str) -> str | None:
         """Return the ISRC for the track by scanning recent historySessionItems.

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -403,6 +403,8 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                         result = {}
                         if parsed.get("bpm"):
                             result["bpm"] = parsed["bpm"]
+                        if parsed.get("deck"):
+                            result["deck"] = parsed["deck"]
                         if parsed.get("key"):
                             result["key"] = parsed["key"]
                         return result

--- a/nowplaying/djaypro/tsaf.py
+++ b/nowplaying/djaypro/tsaf.py
@@ -15,15 +15,25 @@ Type codes:
   0x00  end-of-object marker
   0x05  2-byte skip marker / field-count hint
   0x08  null-terminated UTF-8 string
+  0x0a  int16 (2-byte-aligned) — seen in contentPacks (sortOrder)
   0x0b  array (4-byte-aligned int32 count, then typed elements)
+  0x0c  int32 (4-byte-aligned) — seen in contentPacks / historySessions
+  0x0d  boolean False (implicit 0, zero-byte) — e.g. isStraightGrid; present on
+        tracks with a constant-tempo beatgrid; absent when analysis was skipped
+  0x0e  boolean True (implicit 1, zero-byte) — e.g. featured in contentPacks;
+        completes the 0x0d/0x0e implicit boolean pair
   0x0f  uint8 value (e.g. deckNumber on macOS)
+  0x11  uint32 (4-byte-aligned) — fileSize in contentPacks
+  0x12  uint64 (8-byte-aligned) — inferred; handles fileSize > 4 GB
   0x13  float32 (4-byte-aligned) — macOS only
   0x14  float64 (8-byte-aligned)
   0x15  binary blob: 4-byte-aligned uint32 length, then raw bytes
         (macOS: CFURLBookmarkData stored in urlBookmarkData)
+  0x1a  uint32 (4-byte-aligned) — colorIndex in mediaItemUserData
   0x21  string wrapper: skip 1 sub-type byte, read string, skip trailing 0x00
   0x2b  nested object whose fields merge into the parent
-  0x2d  implicit integer 1 (seen before deckNumber on macOS)
+  0x2d  implicit integer 1 (zero-byte) — seen before deckNumber on macOS
+  0x2e  implicit None (zero-byte) — keySignatureIndex not yet determined by djay
   0x30  timestamp float64 (8-byte-aligned)
 """
 
@@ -171,7 +181,14 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
             tc = blob[pos]
             pos += 1
 
-            if tc == 0x08:
+            if tc == 0x0A:
+                # int16 (2-byte-aligned) — sortOrder in contentPacks
+                rem = pos % 2
+                if rem:
+                    pos += 1
+                value: object = struct.unpack_from("<h", blob, pos)[0]
+                pos += 2
+            elif tc == 0x08:
                 value: object = read_string()
             elif tc == 0x0F:
                 # uint8: value is the next byte (e.g. deckNumber on macOS)
@@ -183,10 +200,27 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
             elif tc in (0x14, 0x30):
                 # float64 with 8-byte alignment; 0x30 = timestamp
                 value = read_float64()
+            elif tc == 0x0D:
+                # Boolean False marker (zero-byte, implicit 0).  Seen on
+                # isStraightGrid, which djay sets on tracks that have a
+                # constant-tempo (straight) beatgrid.  Absent when djay has not
+                # analysed the track or when the grid is dynamic/variable.
+                value = 0
+            elif tc == 0x0E:
+                # Boolean True marker (zero-byte, implicit 1).  Completes the
+                # 0x0d/0x0e implicit boolean pair.  Seen on the "featured" flag
+                # in contentPacks.
+                value = 1
             elif tc == 0x2D:
                 # Zero-byte integer marker seen before deckNumber=1 on macOS.
                 # The value is implicit (1); no value bytes precede the key.
                 value = 1
+            elif tc == 0x2E:
+                # Zero-byte null/indeterminate marker.  Seen before
+                # keySignatureIndex when djay has not determined the key for
+                # a track.  The value is implicit None; no value bytes precede
+                # the key.  Parsing continues so subsequent fields are read.
+                value = None
             elif tc == 0x2B:
                 # Inline nested object: merge fields into parent
                 sub = parse_object()
@@ -207,6 +241,32 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
                 value = read_string()
                 if pos < len(blob) and blob[pos] == 0x00:
                     pos += 1
+            elif tc == 0x0C:
+                # int32 (4-byte-aligned).  Seen in contentPacks and
+                # historySessions; not used for track metadata but handled
+                # so parsing continues past these fields without warnings.
+                rem = pos % 4
+                if rem:
+                    pos += 4 - rem
+                value = struct.unpack_from("<i", blob, pos)[0]
+                pos += 4
+            elif tc in (0x11, 0x1A):
+                # uint32 (4-byte-aligned).
+                # 0x11: fileSize in contentPacks
+                # 0x1a: colorIndex in mediaItemUserData
+                rem = pos % 4
+                if rem:
+                    pos += 4 - rem
+                value = struct.unpack_from("<I", blob, pos)[0]
+                pos += 4
+            elif tc == 0x12:
+                # uint64 (8-byte-aligned).  Inferred counterpart to 0x11;
+                # would be used for fileSize values exceeding 4 GB.
+                rem = pos % 8
+                if rem:
+                    pos += 8 - rem
+                value = struct.unpack_from("<Q", blob, pos)[0]
+                pos += 8
             elif tc == 0x15:
                 # Binary blob: 4-byte-aligned uint32 length, then raw bytes
                 # Used on macOS for CFURLBookmarkData (urlBookmarkData field)
@@ -246,6 +306,43 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
         return {}
     pos += 1
     return parse_object()
+
+
+# djay Pro keySignatureIndex → musical key name.
+#
+# Even indices are major keys (Camelot B ring); odd indices are their relative
+# minor keys (Camelot A ring).  Each pair (2n, 2n+1) shares the same Camelot
+# position.  The Camelot number is: (7 × (idx // 2) + 8) % 12, with 0 → 12.
+# Sequence starts at Camelot 8 (Db/Bbm) and follows the circle of fifths.
+#
+# Verified: idx 5 = Cm (10A), idx 8 = F (12B), idx 11 = Ebm (7A),
+#           idx 18 = Bb (11B).
+KEY_SIGNATURE_MAP: dict[int, str] = {
+    0: "Db",
+    1: "Bbm",  # Camelot 8B / 8A
+    2: "D",
+    3: "Bm",  # Camelot 3B / 3A
+    4: "Eb",
+    5: "Cm",  # Camelot 10B / 10A
+    6: "E",
+    7: "C#m",  # Camelot 5B / 5A
+    8: "F",
+    9: "Dm",  # Camelot 12B / 12A
+    10: "F#",
+    11: "Ebm",  # Camelot 7B / 7A
+    12: "G",
+    13: "Em",  # Camelot 2B / 2A
+    14: "Ab",
+    15: "Fm",  # Camelot 9B / 9A
+    16: "A",
+    17: "F#m",  # Camelot 4B / 4A
+    18: "Bb",
+    19: "Gm",  # Camelot 11B / 11A
+    20: "B",
+    21: "Abm",  # Camelot 6B / 6A
+    22: "C",
+    23: "Am",  # Camelot 1B / 1A
+}
 
 
 def flatten_tsaf_raw(raw: dict) -> dict[str, object]:
@@ -296,12 +393,13 @@ def resolve_bookmark(bookmark_data: bytes) -> str | None:
         components: object = bm.get(_kBookmarkPath, None)
         if isinstance(components, list) and components:
             return "/" + "/".join(str(c) for c in components)
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+        logging.debug("resolve_bookmark: no path components in bookmark")
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        logging.debug("resolve_bookmark: failed to parse bookmark: %s", err)
     return None
 
 
-def parse_blob(blob_data: bytes) -> dict[str, str | int | None]:
+def parse_blob(blob_data: bytes) -> dict[str, str | int | None]:  # pylint: disable=too-many-locals
     """Parse a TSAF blob and return a flat track-metadata dict."""
     try:
         flat = flatten_tsaf_raw(parse_tsaf(blob_data))
@@ -313,6 +411,13 @@ def parse_blob(blob_data: bytes) -> dict[str, str | int | None]:
             bookmark = flat.get("urlBookmarkData")
             if isinstance(bookmark, bytes):
                 file_path = resolve_bookmark(bookmark)
+                if file_path is None:
+                    logging.debug(
+                        "parse_blob: urlBookmarkData present but resolve_bookmark returned None"
+                        " for artist=%r title=%r",
+                        flat.get("artist"),
+                        flat.get("title"),
+                    )
 
         duration_raw = flat.get("duration")
         duration: int | None = int(duration_raw) if isinstance(duration_raw, float) else None
@@ -323,6 +428,16 @@ def parse_blob(blob_data: bytes) -> dict[str, str | int | None]:
         isrc_raw = flat.get("isrc")
         isrc: str | None = str(isrc_raw) if isinstance(isrc_raw, str) and isrc_raw else None
 
+        deck_raw = flat.get("deckNumber")
+        deck: str | None = str(int(deck_raw)) if isinstance(deck_raw, (int, float)) else None
+
+        key_idx_raw = flat.get("keySignatureIndex")
+        key: str | None = (
+            KEY_SIGNATURE_MAP.get(int(key_idx_raw))
+            if isinstance(key_idx_raw, (int, float))
+            else None
+        )
+
         return {
             "artist": flat.get("artist") or None,  # type: ignore[return-value]
             "title": flat.get("title") or None,  # type: ignore[return-value]
@@ -330,8 +445,10 @@ def parse_blob(blob_data: bytes) -> dict[str, str | int | None]:
             "source": flat.get("originSourceID") or None,  # type: ignore[return-value]
             "filename": file_path,
             "bpm": bpm,
+            "deck": deck,
             "duration": duration,
             "isrc": isrc,
+            "key": key,
         }
     except Exception as err:  # pylint: disable=broad-exception-caught
         logging.debug("Failed to parse blob: %s", err)

--- a/nowplaying/djaypro/tsaf.py
+++ b/nowplaying/djaypro/tsaf.py
@@ -94,6 +94,15 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
         pos += 8
         return val
 
+    def read_aligned_int(width: int, fmt: str) -> int:
+        nonlocal pos
+        rem = pos % width
+        if rem:
+            pos += width - rem
+        val = struct.unpack_from(fmt, blob, pos)[0]
+        pos += width
+        return val
+
     def _merge_list_into(target: dict, items: list) -> None:
         """Merge dict items from a keyless array into *target* (first-seen wins)."""
         for item in items:
@@ -183,11 +192,7 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
 
             if tc == 0x0A:
                 # int16 (2-byte-aligned) — sortOrder in contentPacks
-                rem = pos % 2
-                if rem:
-                    pos += 1
-                value: object = struct.unpack_from("<h", blob, pos)[0]
-                pos += 2
+                value: object = read_aligned_int(2, "<h")
             elif tc == 0x08:
                 value: object = read_string()
             elif tc == 0x0F:
@@ -229,11 +234,7 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
                 continue  # no separate key
             elif tc == 0x0B:
                 # Array: 4-byte-aligned int32 count, then elements
-                rem = pos % 4
-                if rem:
-                    pos += 4 - rem
-                count = struct.unpack_from("<i", blob, pos)[0]
-                pos += 4
+                count = read_aligned_int(4, "<i")
                 value = [read_array_element() for _ in range(count) if pos < len(blob)]
             elif tc == 0x21:
                 if pos < len(blob):
@@ -245,36 +246,20 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
                 # int32 (4-byte-aligned).  Seen in contentPacks and
                 # historySessions; not used for track metadata but handled
                 # so parsing continues past these fields without warnings.
-                rem = pos % 4
-                if rem:
-                    pos += 4 - rem
-                value = struct.unpack_from("<i", blob, pos)[0]
-                pos += 4
+                value = read_aligned_int(4, "<i")
             elif tc in (0x11, 0x1A):
                 # uint32 (4-byte-aligned).
                 # 0x11: fileSize in contentPacks
                 # 0x1a: colorIndex in mediaItemUserData
-                rem = pos % 4
-                if rem:
-                    pos += 4 - rem
-                value = struct.unpack_from("<I", blob, pos)[0]
-                pos += 4
+                value = read_aligned_int(4, "<I")
             elif tc == 0x12:
                 # uint64 (8-byte-aligned).  Inferred counterpart to 0x11;
                 # would be used for fileSize values exceeding 4 GB.
-                rem = pos % 8
-                if rem:
-                    pos += 8 - rem
-                value = struct.unpack_from("<Q", blob, pos)[0]
-                pos += 8
+                value = read_aligned_int(8, "<Q")
             elif tc == 0x15:
                 # Binary blob: 4-byte-aligned uint32 length, then raw bytes
                 # Used on macOS for CFURLBookmarkData (urlBookmarkData field)
-                rem = pos % 4
-                if rem:
-                    pos += 4 - rem
-                length = struct.unpack_from("<I", blob, pos)[0]
-                pos += 4
+                length = read_aligned_int(4, "<I")
                 value = bytes(blob[pos : pos + length])
                 pos += length
             else:

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -28,7 +28,7 @@ truststore==0.10.4
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.2.1/wnpmb-0.2.1-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.2.2/wnpmb-0.2.2-py3-none-any.whl
 zeroconf==0.148.0
 
 #

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -23,6 +23,7 @@ def _build_tsaf_blob(
     fields: list of (value, key) tuples where value is one of:
     - str   → 0x08 null-terminated string
     - float → 0x14 float64 with 8-byte alignment
+    - int   → 0x0F uint8 (e.g. deckNumber)
     - list[str] → 0x0b array of 0x21-wrapped strings with 4-byte-aligned count
     """
     header = b"TSAF" + b"\x00" * 16  # 20-byte header
@@ -42,6 +43,13 @@ def _build_tsaf_blob(
             encoded = value.encode("utf-8")
             field_bytes += b"\x08" + encoded + b"\x00"
             current_offset += 1 + len(encoded) + 1
+        elif isinstance(value, bool):
+            # bool is a subclass of int — handle before int to avoid misclassification
+            raise TypeError("Use int for uint8 values, not bool")
+        elif isinstance(value, int):
+            # 0x0F uint8 — type byte + 1-byte value, no alignment
+            field_bytes += bytes([0x0F, value & 0xFF])
+            current_offset += 2
         elif isinstance(value, float):
             field_bytes += b"\x14"
             current_offset += 1
@@ -261,6 +269,228 @@ def test_parse_blob_malformed():
 
     assert result["artist"] is None
     assert result["title"] is None
+
+
+@pytest.mark.parametrize(
+    "deck_num,expected",
+    [
+        (1, "1"),
+        (2, "2"),
+    ],
+)
+def test_parse_blob_deck_uint8(deck_num, expected):
+    """_parse_blob extracts deckNumber from a 0x0F uint8 field."""
+    blob = _build_tsaf_blob(
+        "ADCHistorySessionItem",
+        [
+            ("Test Artist", "artist"),
+            ("Test Title", "title"),
+            (deck_num, "deckNumber"),
+        ],
+    )
+
+    result = nowplaying.djaypro.tsaf.parse_blob(blob)
+
+    assert result["deck"] == expected
+
+
+@pytest.mark.parametrize(
+    "key_index,expected_key",
+    [
+        (5, "Cm"),  # Camelot 10A — confirmed from Ladytron "Cease2xist"
+        (8, "F"),  # Camelot 12B — confirmed from Sinéad O'Connor "Silent Night"
+        (9, "Dm"),  # Camelot 12A — relative minor of F (8)
+        (10, "F#"),  # Camelot 7B
+        (11, "Ebm"),  # Camelot 7A — confirmed from Amanda Palmer "On The Door"
+        (0, "Db"),  # Camelot 8B
+        (1, "Bbm"),  # Camelot 8A — relative minor of Db (0)
+        (17, "F#m"),  # Camelot 4A
+    ],
+)
+def test_parse_blob_key_signature(key_index, expected_key):
+    """_parse_blob maps keySignatureIndex to the correct key name (Camelot wheel order)."""
+    blob = _build_tsaf_blob(
+        "ADCMediaItemAnalyzedData",
+        [
+            ("Test Artist", "artist"),
+            ("Test Title", "title"),
+            (float(key_index), "keySignatureIndex"),
+        ],
+    )
+
+    result = nowplaying.djaypro.tsaf.parse_blob(blob)
+
+    assert result["key"] == expected_key
+
+
+def test_parse_blob_key_out_of_range():
+    """_parse_blob returns key=None for an out-of-range keySignatureIndex."""
+    blob = _build_tsaf_blob(
+        "ADCMediaItemAnalyzedData",
+        [
+            ("Test Artist", "artist"),
+            (99.0, "keySignatureIndex"),
+        ],
+    )
+
+    result = nowplaying.djaypro.tsaf.parse_blob(blob)
+
+    assert result["key"] is None
+
+
+def test_parse_blob_deck_none_when_absent():
+    """_parse_blob returns deck=None when deckNumber field is not present."""
+    blob = _build_tsaf_blob(
+        "ADCHistorySessionItem",
+        [("Artist", "artist"), ("Title", "title")],
+    )
+
+    result = nowplaying.djaypro.tsaf.parse_blob(blob)
+
+    assert result["deck"] is None
+
+
+# ---------------------------------------------------------------------------
+# _get_analyzed_data_from_db integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_collections(dbfile: pathlib.Path, blobs_by_collection: dict[str, list]) -> None:
+    """Create a MediaLibrary.db with the given blobs in each collection."""
+    conn = sqlite3.connect(dbfile)
+    conn.execute(
+        "CREATE TABLE database2 (rowid INTEGER PRIMARY KEY, collection CHAR, "
+        "key CHAR, data BLOB, metadata BLOB)"
+    )
+    for collection, blobs in blobs_by_collection.items():
+        for i, blob in enumerate(blobs):
+            conn.execute(
+                "INSERT INTO database2 (collection, key, data) VALUES (?, ?, ?)",
+                (collection, f"key-{i}", blob),
+            )
+    conn.commit()
+    conn.close()
+
+
+def test_get_analyzed_data_from_db_returns_bpm_and_key(bootstrap):
+    """_get_analyzed_data_from_db returns bpm and key for a matching track."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+
+        analyzed_blob = _build_tsaf_blob(
+            "ADCMediaItemAnalyzedData",
+            [
+                ("DJ Artist", "artist"),
+                ("Club Track", "title"),
+                (128.0, "bpm"),
+                (8.0, "keySignatureIndex"),  # F major (Camelot 12B, confirmed)
+            ],
+        )
+        _make_db_with_collections(dbfile, {"mediaItemAnalyzedData": [analyzed_blob]})
+
+        result = plugin._get_analyzed_data_from_db("DJ Artist", "Club Track")
+
+        assert result["bpm"] == "128.0"
+        assert result["key"] == "F"
+
+
+def test_get_analyzed_data_from_db_case_insensitive(bootstrap):
+    """_get_analyzed_data_from_db matches artist/title case-insensitively."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+
+        analyzed_blob = _build_tsaf_blob(
+            "ADCMediaItemAnalyzedData",
+            [
+                ("DJ Artist", "artist"),
+                ("Club Track", "title"),
+                (140.0, "bpm"),
+            ],
+        )
+        _make_db_with_collections(dbfile, {"mediaItemAnalyzedData": [analyzed_blob]})
+
+        result = plugin._get_analyzed_data_from_db("dj artist", "club track")
+
+        assert result["bpm"] == "140.0"
+
+
+def test_get_analyzed_data_from_db_no_match(bootstrap):
+    """_get_analyzed_data_from_db returns empty dict when no match is found."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+
+        analyzed_blob = _build_tsaf_blob(
+            "ADCMediaItemAnalyzedData",
+            [("Other Artist", "artist"), ("Other Track", "title"), (120.0, "bpm")],
+        )
+        _make_db_with_collections(dbfile, {"mediaItemAnalyzedData": [analyzed_blob]})
+
+        result = plugin._get_analyzed_data_from_db("DJ Artist", "Club Track")
+
+        assert not result
+
+
+def test_get_analyzed_data_from_db_missing_db(bootstrap):
+    """_get_analyzed_data_from_db returns empty dict when database is absent."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        # No MediaLibrary.db created
+
+        result = plugin._get_analyzed_data_from_db("Artist", "Title")
+
+        assert not result
+
+
+def test_check_for_new_track_uses_analyzed_bpm(bootstrap):
+    """_check_for_new_track supplements missing bpm from mediaItemAnalyzedData."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+
+        history_blob = _build_tsaf_blob(
+            "ADCHistorySessionItem",
+            [("Beat Artist", "artist"), ("Kick Drum", "title")],
+        )
+        analyzed_blob = _build_tsaf_blob(
+            "ADCMediaItemAnalyzedData",
+            [
+                ("Beat Artist", "artist"),
+                ("Kick Drum", "title"),
+                (174.0, "bpm"),
+                (22.0, "keySignatureIndex"),  # C major (Camelot 1B, idx=22)
+            ],
+        )
+        _make_db_with_collections(
+            dbfile,
+            {
+                "historySessionItems": [history_blob],
+                "mediaItemAnalyzedData": [analyzed_blob],
+            },
+        )
+
+        plugin._check_for_new_track()
+
+        assert plugin.metadata["artist"] == "Beat Artist"
+        assert plugin.metadata["bpm"] == "174.0"
+        assert plugin.metadata["key"] == "C"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -351,6 +351,49 @@ def test_parse_blob_deck_none_when_absent():
 
 
 # ---------------------------------------------------------------------------
+# parse_tsaf primitive type smoke tests
+# ---------------------------------------------------------------------------
+
+
+def _build_typed_tsaf(tc: int, alignment: int, value_bytes: bytes, key: str) -> bytes:
+    """Build a minimal TSAF blob with one typed field for parse_tsaf testing.
+
+    Computes alignment padding so the value starts at the correct boundary.
+    The prefix is 29 bytes; the value begins at offset 30 (after the tc byte).
+    """
+    prefix = b"TSAF" + b"\x00" * 16 + b"\x2b\x08C\x00\x08I\x00\x05\x01"
+    value_offset = len(prefix) + 1  # offset where value bytes start (after tc byte)
+    pad = 0
+    if alignment > 1:
+        rem = value_offset % alignment
+        if rem:
+            pad = alignment - rem
+    key_bytes = b"\x08" + key.encode() + b"\x00"
+    return prefix + bytes([tc]) + b"\x00" * pad + value_bytes + key_bytes
+
+
+@pytest.mark.parametrize(
+    "tc,alignment,value_bytes,key,expected",
+    [
+        (0x0A, 2, struct.pack("<h", -5), "sortOrder", -5),
+        (0x0C, 4, struct.pack("<i", 100), "playCount", 100),
+        (0x11, 4, struct.pack("<I", 10_000_000), "fileSize", 10_000_000),
+        (0x1A, 4, struct.pack("<I", 3), "colorIndex", 3),
+        (0x12, 8, struct.pack("<Q", 5_000_000_000), "fileSizeLarge", 5_000_000_000),
+        (0x0D, 1, b"", "isStraightGrid", 0),
+        (0x0E, 1, b"", "featured", 1),
+    ],
+)
+def test_parse_tsaf_primitive_types(tc, alignment, value_bytes, key, expected):
+    """parse_tsaf correctly decodes new primitive type codes."""
+    blob = _build_typed_tsaf(tc, alignment, value_bytes, key)
+
+    result = nowplaying.djaypro.tsaf.parse_tsaf(blob)
+
+    assert result.get(key) == expected
+
+
+# ---------------------------------------------------------------------------
 # _get_analyzed_data_from_db integration tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Parse 0x0d (isStraightGrid boolean) and 0x2e (indeterminate key) TSAF type codes so parsing continues past those fields
- Add empirically-derived KEY_SIGNATURE_MAP for keySignatureIndex (Camelot wheel order, verified against 6 live tracks)
- Read bpm/key/deck from mediaItemAnalyzedData for both macOS NowPlaying.txt and Windows DB paths
- Add _get_analyzed_data_from_db() and supporting tests
- Bump wnpmb to 0.2.2; fix compound artist MB lookup
- Parse TSAF type 0x0c (int32) to eliminate parse warnings
- Add TSAF types 0x0a (int16), 0x0e (bool True), 0x11/0x12 (uint32/uint64), 0x1a (uint32) from live DB analysis
- Fix NowPlaying.txt race condition: retry filename DB lookup once after 0.5s if localMediaItemLocations not yet committed
- Add resolve_bookmark failure debug logging

## Summary by Sourcery

Add support for extracting deck, bpm, and key metadata from djay Pro TSAF blobs and media library data, and improve robustness of TSAF parsing and database lookups.

New Features:
- Expose deck, bpm, and musical key fields from parsed TSAF blobs into track metadata.
- Derive musical key names from djay Pro keySignatureIndex using a Camelot-based key map.
- Augment NowPlaying.txt metadata with analyzed bpm/key and deck information from the MediaLibrary database.

Bug Fixes:
- Handle previously unparsed TSAF field types and indeterminate key markers to prevent parse interruptions and warnings.
- Mitigate a race where NowPlaying.txt is written before filename records are committed by retrying the filename database lookup once after a short delay.

Enhancements:
- Extend TSAF parser support for additional integer and boolean field types, including implicit boolean and size-related fields, and log failures when resolving URL bookmarks.
- Refine djay Pro plugin metadata handling to include deck and key fields and to supplement missing bpm/key from analyzed data when available.

Tests:
- Add unit tests for parsing deckNumber and keySignatureIndex fields from TSAF blobs, including out-of-range handling.
- Add integration tests for _get_analyzed_data_from_db and for using analyzed bpm/key data during new track detection.