### PR TITLE
Enhance djay Pro ISRC, source field, and analysis delay

### DIFF
--- a/docs/input/djaypro.md
+++ b/docs/input/djaypro.md
@@ -2,8 +2,6 @@
 
 djay Pro is DJ software by Algoriddim available for macOS and Windows.
 
-> NOTE: This is basic support with the groundwork in place. Artist query features are not yet implemented.
->
 > NOTE: Only tested with djay Pro 5.x on macOS and Windows
 >
 > NOTE: iOS and Android versions are not supported
@@ -24,21 +22,37 @@ djay Pro is DJ software by Algoriddim available for macOS and Windows.
    * Windows: `%USERPROFILE%\Music\djay\djay Media Library`
 3. Click Save
 
-## How It Works
+## Settings
 
-**What's Now Playing** monitors djay Pro in two ways:
+### Artist Query Scope
 
-* **NowPlaying.txt file** (macOS): djay Pro writes current track info to this file in real-time
-* **Media Library database**: Queries the play history from djay Pro's SQLite database
+Controls which tracks are searched for the `!hasartist` Twitch chat command and roulette playlist
+requests. Choose **Entire Library** to search all tracks, or **Selected Playlists** and enter
+comma-separated playlist names to limit the search to specific playlists.
 
-The plugin automatically uses the appropriate method based on your platform and djay Pro configuration.
+> NOTE: **Selected Playlists** only searches playlists created natively in djay Pro. Playlists
+> from iTunes/Music or other sources are not visible to this feature.
 
-## Known Limitations
+### Analysis Delay
 
-* Artist query features are not supported
-  * The !hasartist Twitch chat command will not work
-  * Roulette playlist requests are not available
-* Only "newest" mix mode is supported
+djay Pro writes the new track name immediately but commits BPM, key, and file path data in a
+separate database transaction that arrives shortly after. **Analysis Delay** controls how long
+(in seconds) What's Now Playing waits for that second write before reporting the track.
+
+The default of `0.5` seconds works for most systems. If BPM, key, or the file path are
+consistently missing, increase the value. On fast NVMe storage you may be able to lower it.
+
+Note that the file path is also required for What's Now Playing to read tags stored in the audio
+file itself (cover art, ISRC, MusicBrainz IDs, and other metadata not kept in djay Pro's
+database). If the file path is missing, those tags will not be available.
+
+## Metadata provided
+
+* Artist, title, duration
+* Album (macOS only)
+* BPM and musical key (from djay Pro's own analysis, when available)
+* Deck number
+* Filename / file path (local tracks only)
 
 ## Troubleshooting
 
@@ -49,3 +63,10 @@ If tracks are not being detected:
 3. Ensure the MediaLibrary.db file exists in the configured directory
 4. Try playing a few tracks to populate the play history
 5. Check the **What's Now Playing** logs for database connection errors
+
+If BPM, key, or file path are missing:
+
+* Increase the **Analysis Delay** setting — djay Pro may be writing analysis data slower than
+  the default 0.5 s wait on your hardware
+* BPM and key are only available after djay Pro has analysed the track; newly imported tracks
+  may not have this data yet

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -203,7 +203,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             self._wal_timer = None
         self._check_for_new_track()
 
-    def _supplement_from_db(
+    def _supplement_from_db(  # pylint: disable=too-many-arguments
         self,
         artist: str,
         title: str,
@@ -349,7 +349,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             source=track_data.get("source"),
         )
 
-    def _read_nowplaying_file(self):
+    def _read_nowplaying_file(self):  # pylint: disable=too-many-locals,too-many-branches
         """Read NowPlaying.txt file for current track (macOS)"""
         nowplaying_file = pathlib.Path(self.djaypro_dir).joinpath("NowPlaying.txt")
         if not nowplaying_file.exists():

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -39,6 +39,7 @@ Database Location:
 """
 
 import asyncio
+import dataclasses
 import logging
 import pathlib
 import sqlite3
@@ -66,6 +67,14 @@ if TYPE_CHECKING:
 
 
 _WAL_DEBOUNCE_SECONDS = 0.3
+_ANALYZED_DATA_RETRY_DEFAULT = 0.5
+
+
+@dataclasses.dataclass
+class _HistoryExtras:
+    isrc: str | None = None
+    source: str | None = None
+    deck: str | None = None
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -194,6 +203,93 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             self._wal_timer = None
         self._check_for_new_track()
 
+    def _supplement_from_db(
+        self,
+        artist: str,
+        title: str,
+        *,
+        seed_bpm: str | None = None,
+        seed_key: str | None = None,
+        retry_filename: bool = False,
+    ) -> tuple[str | None, dict, str | None]:
+        """Look up file path, analyzed data, and location ISRC from the database.
+
+        seed_bpm / seed_key: BPM/key already known from historySessionItems
+        (Windows path). When both are provided the mediaItemAnalyzedData lookup
+        is skipped entirely.
+
+        retry_filename: retry the filename lookup on first miss (macOS path,
+        where NowPlaying.txt fires before localMediaItemLocations is committed).
+
+        Returns (filename, analyzed, loc_isrc).
+        """
+        filename, track_uuid, loc_isrc = self._get_filename_from_db(artist, title)
+
+        need_analyzed = not seed_bpm or not seed_key
+        analyzed: dict = {}
+        if need_analyzed:
+            analyzed = self._get_analyzed_data_by_uuid(track_uuid or "")
+
+        needs_retry = (retry_filename and filename is None) or (
+            need_analyzed and (not analyzed.get("bpm") or not analyzed.get("key"))
+        )
+        if needs_retry:
+            delay = self.config.cparser.value(
+                "djaypro/analyzed_data_delay",
+                defaultValue=_ANALYZED_DATA_RETRY_DEFAULT,
+                type=float,
+            )
+            time.sleep(delay)
+            if retry_filename and filename is None:
+                filename, track_uuid, loc_isrc = self._get_filename_from_db(artist, title)
+            if need_analyzed and (not analyzed.get("bpm") or not analyzed.get("key")):
+                analyzed = self._get_analyzed_data_by_uuid(track_uuid or "")
+
+        return filename, analyzed, loc_isrc
+
+    def _commit_new_track(  # pylint: disable=too-many-arguments
+        self,
+        *,
+        artist: str | None,
+        title: str | None,
+        album: str | None,
+        duration: int | None,
+        filename: str | None,
+        bpm: str | None,
+        key: str | None,
+        deck: str | None,
+        isrc: str | None,
+        source: str | None,
+    ) -> None:
+        """Assemble new_meta from resolved fields, commit it, and log the track."""
+        new_meta: TrackMetadata = {
+            "artist": artist,
+            "title": title,
+            "album": album,
+            "filename": filename,
+            "bpm": bpm,
+            "deck": deck,
+            "duration": duration,
+            "key": key,
+        }
+        if isrc:
+            new_meta["isrc"] = [isrc]
+        if source:
+            new_meta["source"] = source
+        self.metadata = new_meta
+        logging.info(
+            "New track detected: %s - %s%s%s%s%s%s%s%s",
+            artist,
+            title,
+            f" (BPM: {bpm})" if bpm else "",
+            f" (Key: {key})" if key else "",
+            f" [deck {deck}]" if deck else "",
+            f" [source: {source}]" if source else "",
+            f" [{album}]" if album else "",
+            f" - {filename}" if filename else " (no filename found)",
+            f" ISRC:{isrc}" if isrc else "",
+        )
+
     def _check_for_new_track(self):
         """Check for new track from NowPlaying.txt (macOS) or database (Windows)"""
         # Try NowPlaying.txt first (macOS)
@@ -212,55 +308,50 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             return
 
         track_data = records[0]
-        if not (
-            self.metadata.get("artist") != track_data["artist"]
-            or self.metadata.get("title") != track_data["title"]
+        if (
+            self.metadata.get("artist") == track_data["artist"]
+            and self.metadata.get("title") == track_data["title"]
         ):
             return
 
         t_artist = track_data["artist"]
         t_title = track_data["title"]
+        if not isinstance(t_title, str):
+            return
 
-        # New track detected — look up filename if the history blob didn't include it
-        if not track_data["filename"]:
-            if isinstance(t_artist, str) and isinstance(t_title, str):
-                filename = self._get_filename_from_db(t_artist, t_title)
-                if filename:
-                    track_data["filename"] = filename
+        # localMediaItemLocations is authoritative for file paths; supplement
+        # historySessionItems BPM/key with mediaItemAnalyzedData when missing.
+        # retry_filename=True because localMediaItemLocations is written in the
+        # same second transaction as analyzedData and may not yet be present.
+        filename, analyzed, loc_isrc = self._supplement_from_db(
+            t_artist or "",
+            t_title,
+            seed_bpm=track_data.get("bpm"),
+            seed_key=track_data.get("key"),
+            retry_filename=True,
+        )
+        if filename:
+            track_data["filename"] = filename
 
-        # Supplement with analyzed data (bpm, key) if not already present
-        analyzed: dict = {}
-        if isinstance(t_artist, str) and isinstance(t_title, str):
-            if not track_data.get("bpm") or not track_data.get("key"):
-                analyzed = self._get_analyzed_data_from_db(t_artist, t_title)
+        # Prefer history blob ISRC (streaming); fall back to location blob (local files).
+        isrc_str = track_data.get("isrc") if isinstance(track_data.get("isrc"), str) else loc_isrc
 
-        new_meta: TrackMetadata = {
-            "artist": track_data["artist"],
-            "title": track_data["title"],
-            "album": track_data["album"],
-            "filename": track_data["filename"],
-            "bpm": track_data["bpm"] or analyzed.get("bpm"),
-            "deck": track_data.get("deck"),
-            "duration": track_data["duration"],
-            "key": track_data.get("key") or analyzed.get("key"),
-        }
-        if isinstance(track_data.get("isrc"), str):
-            new_meta["isrc"] = [track_data["isrc"]]
-        self.metadata = new_meta
-        logging.info(
-            "New track detected: %s - %s%s%s%s%s",
-            track_data["artist"],
-            track_data["title"],
-            f" (BPM: {track_data['bpm']})" if track_data["bpm"] else "",
-            f" [{track_data['album']}]" if track_data["album"] else "",
-            f" - {track_data['filename']}" if track_data["filename"] else "",
-            f" ISRC:{track_data['isrc']}" if track_data.get("isrc") else "",
+        self._commit_new_track(
+            artist=t_artist,
+            title=t_title,
+            album=track_data.get("album"),
+            duration=track_data.get("duration"),
+            filename=track_data.get("filename"),
+            bpm=track_data.get("bpm") or analyzed.get("bpm"),
+            key=track_data.get("key") or analyzed.get("key"),
+            deck=track_data.get("deck"),
+            isrc=isrc_str,
+            source=track_data.get("source"),
         )
 
-    def _read_nowplaying_file(self):  # pylint: disable=too-many-locals,too-many-branches
+    def _read_nowplaying_file(self):
         """Read NowPlaying.txt file for current track (macOS)"""
         nowplaying_file = pathlib.Path(self.djaypro_dir).joinpath("NowPlaying.txt")
-
         if not nowplaying_file.exists():
             return
 
@@ -278,7 +369,6 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         if not content:
             return
 
-        # Parse line by line
         track_data = {}
         for line in content.split("\n"):
             line = line.strip()
@@ -308,43 +398,29 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             except (ValueError, IndexError):
                 pass
 
-        # Check if this is a new track
-        if self.metadata.get("artist") != artist or self.metadata.get("title") != title:
-            # Supplement NowPlaying.txt with database lookups.
-            # djay Pro writes NowPlaying.txt before committing to
-            # localMediaItemLocations, so retry once after a short wait if
-            # the first lookup misses.
-            filename = self._get_filename_from_db(artist, title)
-            if filename is None:
-                time.sleep(0.5)
-                filename = self._get_filename_from_db(artist, title)
+        if self.metadata.get("artist") == artist and self.metadata.get("title") == title:
+            return
 
-            isrc = self._get_isrc_from_db(artist, title)
-            analyzed = self._get_analyzed_data_from_db(artist, title)
+        # NowPlaying.txt fires before localMediaItemLocations and
+        # mediaItemAnalyzedData are committed — retry once after the delay.
+        filename, analyzed, loc_isrc = self._supplement_from_db(artist, title, retry_filename=True)
 
-            new_meta: TrackMetadata = {
-                "artist": artist,
-                "title": title,
-                "album": album,
-                "filename": filename,
-                "bpm": analyzed.get("bpm"),
-                "deck": analyzed.get("deck"),
-                "duration": duration,
-                "key": analyzed.get("key"),
-            }
-            if isrc:
-                new_meta["isrc"] = [isrc]
-            self.metadata = new_meta
+        # ISRC, source, and deck come from historySessionItems; fall back to location blob ISRC.
+        extras = self._get_history_extras_from_db(artist, title)
+        isrc = extras.isrc if extras.isrc is not None else loc_isrc
 
-            logging.info(
-                "New track detected: %s - %s%s%s%s%s",
-                artist,
-                title,
-                f" [{album}]" if album else "",
-                f" ({time_str})" if time_str else "",
-                f" - {filename}" if filename else " (no filename found)",
-                f" ISRC:{isrc}" if isrc else "",
-            )
+        self._commit_new_track(
+            artist=artist,
+            title=title,
+            album=album,
+            duration=duration,
+            filename=filename,
+            bpm=analyzed.get("bpm"),
+            key=analyzed.get("key"),
+            deck=extras.deck,
+            isrc=isrc,
+            source=extras.source,
+        )
 
     @staticmethod
     def _query_recent_history(dbfile: pathlib.Path, limit: int = 20) -> list[dict]:
@@ -375,48 +451,45 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         except (sqlite3.OperationalError, FileNotFoundError):
             return []
 
-    def _get_analyzed_data_from_db(self, artist: str, title: str) -> dict:
-        """Look up bpm and key from mediaItemAnalyzedData by artist/title match."""
-        dbfile = self._get_db_path()
-        if not dbfile:
-            return {}
+    def _get_analyzed_data_by_uuid(self, track_uuid: str) -> dict:
+        """Look up bpm, deck, and key from mediaItemAnalyzedData by track UUID.
 
-        artist_lower = artist.strip().lower()
-        title_lower = title.strip().lower()
+        Uses the database key column for an O(1) lookup rather than scanning
+        all blobs.  The track UUID is the shared key between
+        localMediaItemLocations and mediaItemAnalyzedData.
+        """
+        dbfile = self._get_db_path()
+        if not dbfile or not track_uuid:
+            return {}
 
         def query_db() -> dict:
             with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=1) as connection:
                 cursor = connection.cursor()
                 cursor.execute(
-                    "SELECT data FROM database2 WHERE collection='mediaItemAnalyzedData'"
+                    "SELECT data FROM database2"
+                    " WHERE collection='mediaItemAnalyzedData' AND key=?",
+                    (track_uuid,),
                 )
-                for (blob,) in cursor:
-                    parsed = nowplaying.djaypro.tsaf.parse_blob(blob)
-                    p_artist = parsed.get("artist")
-                    p_title = parsed.get("title")
-                    if (
-                        isinstance(p_artist, str)
-                        and isinstance(p_title, str)
-                        and p_artist.strip().lower() == artist_lower
-                        and p_title.strip().lower() == title_lower
-                    ):
-                        result = {}
-                        if parsed.get("bpm"):
-                            result["bpm"] = parsed["bpm"]
-                        if parsed.get("deck"):
-                            result["deck"] = parsed["deck"]
-                        if parsed.get("key"):
-                            result["key"] = parsed["key"]
-                        return result
-            return {}
+                row = cursor.fetchone()
+                if not row:
+                    return {}
+                parsed = nowplaying.djaypro.tsaf.parse_blob(row[0])
+                result = {}
+                if parsed.get("bpm"):
+                    result["bpm"] = parsed["bpm"]
+                if parsed.get("deck"):
+                    result["deck"] = parsed["deck"]
+                if parsed.get("key"):
+                    result["key"] = parsed["key"]
+                return result
 
         try:
             return nowplaying.utils.sqlite.retry_sqlite_operation(query_db)
         except (sqlite3.OperationalError, FileNotFoundError):
             return {}
 
-    def _get_isrc_from_db(self, artist: str, title: str) -> str | None:
-        """Return the ISRC for the track by scanning recent historySessionItems.
+    def _get_history_extras_from_db(self, artist: str, title: str) -> _HistoryExtras:
+        """Return isrc, source, and deck for a track by scanning recent historySessionItems.
 
         The most recently added history entry is almost always the currently
         playing track, so we scan from the end and stop as soon as we find a
@@ -425,7 +498,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         """
         dbfile = self._get_db_path()
         if not dbfile:
-            return None
+            return _HistoryExtras()
 
         artist_lower = artist.strip().lower()
         title_lower = title.strip().lower()
@@ -439,56 +512,90 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 and p_artist.strip().lower() == artist_lower
                 and p_title.strip().lower() == title_lower
             ):
-                return parsed.get("isrc")  # type: ignore[return-value]
-        return None
+                isrc = parsed.get("isrc")
+                source = parsed.get("source")
+                deck = parsed.get("deck")
+                return _HistoryExtras(
+                    isrc=isrc if isinstance(isrc, str) else None,
+                    source=source if isinstance(source, str) else None,
+                    deck=deck if isinstance(deck, str) else None,
+                )
+        return _HistoryExtras()
 
-    def _get_filename_from_db(self, artist: str, title: str) -> str | None:
-        """Get filename from database by querying localMediaItemLocations"""
-        dbfile = pathlib.Path(self.djaypro_dir).joinpath("MediaLibrary.db")
-        if not dbfile.exists():
-            return None
+    def _get_filename_from_db(
+        self, artist: str, title: str
+    ) -> tuple[str | None, str | None, str | None]:
+        """Get filename, track UUID, and ISRC from localMediaItemLocations.
 
-        def query_db():
+        Returns (filename, track_uuid, isrc).  Any value may be None.
+        The track UUID is the shared key between localMediaItemLocations
+        and mediaItemAnalyzedData, used for O(1) BPM/key lookup.
+        ISRC is returned when djay Pro has stored it in the location blob
+        (e.g. for local files that carry an embedded ISRC tag).
+        """
+        dbfile = self._get_db_path()
+        if not dbfile:
+            return None, None, None
+
+        def query_db() -> tuple[str | None, str | None, str | None]:
             with nowplaying.utils.sqlite.sqlite_connection(
                 str(dbfile), timeout=1, row_factory=sqlite3.Row
             ) as connection:
                 cursor = connection.cursor()
-                filename = self._get_filename_for_track(cursor, artist, title)
-                return filename
+                return self._get_filename_for_track(cursor, artist, title)
 
         try:
             return nowplaying.utils.sqlite.retry_sqlite_operation(query_db)
         except (sqlite3.OperationalError, FileNotFoundError):
-            return None
+            return None, None, None
 
     @staticmethod
-    def _get_filename_for_track(cursor, artist: str, title: str) -> str | None:
-        """Query localMediaItemLocations collection for file path"""
+    def _get_filename_for_track(
+        cursor, artist: str, title: str
+    ) -> tuple[str | None, str | None, str | None]:
+        """Query localMediaItemLocations for file path, track UUID, and ISRC.
+
+        Returns (filename, track_uuid, isrc).  Matches on title+artist when
+        both are present; falls back to title-only when artist is absent from
+        the caller or from the stored blob (common on Windows for files that
+        have no artist tag).
+        """
         try:
-            cursor.execute("SELECT data FROM database2 WHERE collection='localMediaItemLocations'")
+            cursor.execute(
+                "SELECT key, data FROM database2"
+                " WHERE collection IN"
+                " ('localMediaItemLocations', 'globalMediaItemLocations')"
+            )
+
+            artist_norm = artist.strip().lower() if artist else ""
+            title_norm = title.strip().lower() if title else ""
+            if not title_norm:
+                return None, None, None
 
             # Iterate the cursor lazily — fetchall() would load the whole library
             # into memory before we even start comparing.
             for row in cursor:
-                blob_data = row[0]
-                parsed = nowplaying.djaypro.tsaf.parse_blob(blob_data)
+                track_uuid = row[0]
+                parsed = nowplaying.djaypro.tsaf.parse_blob(row[1])
 
-                # Case-insensitive, whitespace-normalized comparison
-                artist_norm = artist.strip().lower() if artist else ""
-                title_norm = title.strip().lower() if title else ""
-                if not (artist_norm and title_norm and parsed["artist"] and parsed["title"]):
+                p_title = parsed.get("title")
+                p_artist = parsed.get("artist")
+                if not isinstance(p_title, str):
                     continue
-                if (
-                    parsed["artist"].strip().lower() == artist_norm
-                    and parsed["title"].strip().lower() == title_norm
-                ):
-                    if parsed["filename"]:
-                        return parsed["filename"]
+                if p_title.strip().lower() != title_norm:
+                    continue
+                # Accept when either side has no artist; require match when both do.
+                if artist_norm and isinstance(p_artist, str):
+                    if p_artist.strip().lower() != artist_norm:
+                        continue
+
+                isrc = parsed.get("isrc")
+                return parsed.get("filename"), track_uuid, isrc if isinstance(isrc, str) else None
 
         except Exception as err:  # pylint: disable=broad-exception-caught
             logging.debug("Error searching localMediaItemLocations: %s", err)
 
-        return None
+        return None, None, None
 
     async def stop(self):
         """stop the watcher"""
@@ -664,6 +771,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         qsettings.setValue("djaypro/directory", str(djaypro))
         qsettings.setValue("djaypro/artist_query_scope", "entire_library")
         qsettings.setValue("djaypro/selected_playlists", "")
+        qsettings.setValue("djaypro/analyzed_data_delay", _ANALYZED_DATA_RETRY_DEFAULT)
 
     def connect_settingsui(self, qwidget: "QWidget", uihelp: "nowplaying.uihelp.UIHelp"):
         """connect djay Pro button to filename picker"""
@@ -687,6 +795,16 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             self.config.cparser.value("djaypro/selected_playlists", defaultValue="")
         )
 
+        qwidget.djaypro_analyzed_delay_lineedit.setText(
+            str(
+                self.config.cparser.value(
+                    "djaypro/analyzed_data_delay",
+                    defaultValue=_ANALYZED_DATA_RETRY_DEFAULT,
+                    type=float,
+                )
+            )
+        )
+
     def verify_settingsui(self, qwidget: "QWidget"):
         """verify settings are valid"""
         if not pathlib.Path(qwidget.dir_lineedit.text()).exists():
@@ -705,6 +823,11 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self.config.cparser.setValue(
             "djaypro/selected_playlists", qwidget.djaypro_playlists_lineedit.text()
         )
+        try:
+            delay = float(qwidget.djaypro_analyzed_delay_lineedit.text())
+        except ValueError:
+            delay = _ANALYZED_DATA_RETRY_DEFAULT
+        self.config.cparser.setValue("djaypro/analyzed_data_delay", delay)
 
     def on_djaypro_dir_button(self):
         """open file browser to set djay Pro directory"""

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -585,14 +585,15 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 if p_title.strip().lower() != title_norm:
                     continue
                 # Accept when either side has no artist; require match when both do.
-                if artist_norm and isinstance(p_artist, str):
+                # Treat empty/whitespace-only stored artist as absent.
+                if artist_norm and isinstance(p_artist, str) and p_artist.strip():
                     if p_artist.strip().lower() != artist_norm:
                         continue
 
                 isrc = parsed.get("isrc")
                 return parsed.get("filename"), track_uuid, isrc if isinstance(isrc, str) else None
 
-        except Exception as err:  # pylint: disable=broad-exception-caught
+        except (sqlite3.Error, ValueError, KeyError) as err:
             logging.debug("Error searching localMediaItemLocations: %s", err)
 
         return None, None, None
@@ -827,6 +828,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             delay = float(qwidget.djaypro_analyzed_delay_lineedit.text())
         except ValueError:
             delay = _ANALYZED_DATA_RETRY_DEFAULT
+        delay = max(0.0, min(delay, 10.0))
         self.config.cparser.setValue("djaypro/analyzed_data_delay", delay)
 
     def on_djaypro_dir_button(self):

--- a/nowplaying/resources/ui/inputs_djaypro.ui
+++ b/nowplaying/resources/ui/inputs_djaypro.ui
@@ -79,6 +79,30 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="analyzed_delay_layout">
+     <item>
+      <widget class="QLabel" name="analyzed_delay_label">
+       <property name="text">
+        <string>Analysis Delay (secs)</string>
+       </property>
+       <property name="toolTip">
+        <string>How long to wait (in seconds) for djay Pro to finish writing BPM/key analysis data after a new track starts. Increase on slower hardware if BPM or key are missing.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="djaypro_analyzed_delay_lineedit">
+       <property name="toolTip">
+        <string>How long to wait (in seconds) for djay Pro to finish writing BPM/key analysis data after a new track starts. Increase on slower hardware if BPM or key are missing.</string>
+       </property>
+       <property name="placeholderText">
+        <string>0.5</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QTextBrowser" name="help_label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -394,29 +394,38 @@ def test_parse_tsaf_primitive_types(tc, alignment, value_bytes, key, expected):
 
 
 # ---------------------------------------------------------------------------
-# _get_analyzed_data_from_db integration tests
+# _get_analyzed_data_by_uuid integration tests
 # ---------------------------------------------------------------------------
 
 
 def _make_db_with_collections(dbfile: pathlib.Path, blobs_by_collection: dict[str, list]) -> None:
-    """Create a MediaLibrary.db with the given blobs in each collection."""
+    """Create a MediaLibrary.db with the given blobs in each collection.
+
+    Each collection's list may contain either:
+    - bytes: blob inserted with an auto-generated key
+    - tuple[str, bytes]: (key, blob) inserted with the given key
+    """
     conn = sqlite3.connect(dbfile)
     conn.execute(
         "CREATE TABLE database2 (rowid INTEGER PRIMARY KEY, collection CHAR, "
         "key CHAR, data BLOB, metadata BLOB)"
     )
-    for collection, blobs in blobs_by_collection.items():
-        for i, blob in enumerate(blobs):
+    for collection, items in blobs_by_collection.items():
+        for i, item in enumerate(items):
+            if isinstance(item, tuple):
+                key, blob = item
+            else:
+                key, blob = f"key-{i}", item
             conn.execute(
                 "INSERT INTO database2 (collection, key, data) VALUES (?, ?, ?)",
-                (collection, f"key-{i}", blob),
+                (collection, key, blob),
             )
     conn.commit()
     conn.close()
 
 
-def test_get_analyzed_data_from_db_returns_bpm_and_key(bootstrap):
-    """_get_analyzed_data_from_db returns bpm and key for a matching track."""
+def test_get_analyzed_data_by_uuid_returns_bpm_and_key(bootstrap):
+    """_get_analyzed_data_by_uuid returns bpm and key for a matching UUID."""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
@@ -433,40 +442,18 @@ def test_get_analyzed_data_from_db_returns_bpm_and_key(bootstrap):
                 (8.0, "keySignatureIndex"),  # F major (Camelot 12B, confirmed)
             ],
         )
-        _make_db_with_collections(dbfile, {"mediaItemAnalyzedData": [analyzed_blob]})
+        _make_db_with_collections(
+            dbfile, {"mediaItemAnalyzedData": [("track-uuid-1", analyzed_blob)]}
+        )
 
-        result = plugin._get_analyzed_data_from_db("DJ Artist", "Club Track")
+        result = plugin._get_analyzed_data_by_uuid("track-uuid-1")
 
         assert result["bpm"] == "128.0"
         assert result["key"] == "F"
 
 
-def test_get_analyzed_data_from_db_case_insensitive(bootstrap):
-    """_get_analyzed_data_from_db matches artist/title case-insensitively."""
-    config = bootstrap
-    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        plugin.djaypro_dir = tmpdir
-        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
-
-        analyzed_blob = _build_tsaf_blob(
-            "ADCMediaItemAnalyzedData",
-            [
-                ("DJ Artist", "artist"),
-                ("Club Track", "title"),
-                (140.0, "bpm"),
-            ],
-        )
-        _make_db_with_collections(dbfile, {"mediaItemAnalyzedData": [analyzed_blob]})
-
-        result = plugin._get_analyzed_data_from_db("dj artist", "club track")
-
-        assert result["bpm"] == "140.0"
-
-
-def test_get_analyzed_data_from_db_no_match(bootstrap):
-    """_get_analyzed_data_from_db returns empty dict when no match is found."""
+def test_get_analyzed_data_by_uuid_no_match(bootstrap):
+    """_get_analyzed_data_by_uuid returns empty dict when UUID is not found."""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
@@ -478,15 +465,17 @@ def test_get_analyzed_data_from_db_no_match(bootstrap):
             "ADCMediaItemAnalyzedData",
             [("Other Artist", "artist"), ("Other Track", "title"), (120.0, "bpm")],
         )
-        _make_db_with_collections(dbfile, {"mediaItemAnalyzedData": [analyzed_blob]})
+        _make_db_with_collections(
+            dbfile, {"mediaItemAnalyzedData": [("other-uuid", analyzed_blob)]}
+        )
 
-        result = plugin._get_analyzed_data_from_db("DJ Artist", "Club Track")
+        result = plugin._get_analyzed_data_by_uuid("track-uuid-1")
 
         assert not result
 
 
-def test_get_analyzed_data_from_db_missing_db(bootstrap):
-    """_get_analyzed_data_from_db returns empty dict when database is absent."""
+def test_get_analyzed_data_by_uuid_missing_db(bootstrap):
+    """_get_analyzed_data_by_uuid returns empty dict when database is absent."""
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
@@ -494,13 +483,17 @@ def test_get_analyzed_data_from_db_missing_db(bootstrap):
         plugin.djaypro_dir = tmpdir
         # No MediaLibrary.db created
 
-        result = plugin._get_analyzed_data_from_db("Artist", "Title")
+        result = plugin._get_analyzed_data_by_uuid("any-uuid")
 
         assert not result
 
 
 def test_check_for_new_track_uses_analyzed_bpm(bootstrap):
-    """_check_for_new_track supplements missing bpm from mediaItemAnalyzedData."""
+    """_check_for_new_track supplements missing bpm from mediaItemAnalyzedData.
+
+    The UUID from localMediaItemLocations links to mediaItemAnalyzedData so
+    BPM and key are retrieved even when absent from the history blob.
+    """
     config = bootstrap
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
@@ -508,15 +501,20 @@ def test_check_for_new_track_uses_analyzed_bpm(bootstrap):
         plugin.djaypro_dir = tmpdir
         dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
 
+        track_uuid = "beat-artist-kick-drum-uuid"
+
         history_blob = _build_tsaf_blob(
             "ADCHistorySessionItem",
+            [("Beat Artist", "artist"), ("Kick Drum", "title")],
+        )
+        # localMediaItemLocations blob links artist+title to the track UUID
+        location_blob = _build_tsaf_blob(
+            "ADCMediaItemLocation",
             [("Beat Artist", "artist"), ("Kick Drum", "title")],
         )
         analyzed_blob = _build_tsaf_blob(
             "ADCMediaItemAnalyzedData",
             [
-                ("Beat Artist", "artist"),
-                ("Kick Drum", "title"),
                 (174.0, "bpm"),
                 (22.0, "keySignatureIndex"),  # C major (Camelot 1B, idx=22)
             ],
@@ -525,7 +523,8 @@ def test_check_for_new_track_uses_analyzed_bpm(bootstrap):
             dbfile,
             {
                 "historySessionItems": [history_blob],
-                "mediaItemAnalyzedData": [analyzed_blob],
+                "localMediaItemLocations": [(track_uuid, location_blob)],
+                "mediaItemAnalyzedData": [(track_uuid, analyzed_blob)],
             },
         )
 
@@ -580,6 +579,7 @@ def test_check_for_new_track_empty_db(bootstrap):
 def test_check_for_new_track_with_data(bootstrap):
     """_check_for_new_track extracts track metadata from a valid TSAF blob."""
     config = bootstrap
+    config.cparser.setValue("djaypro/analyzed_data_delay", 0)
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -609,76 +609,79 @@ def test_check_for_new_track_with_data(bootstrap):
         assert plugin.metadata["title"] == "Test Song"
 
 
-def test_check_for_new_track_with_isrc(bootstrap):
-    """_check_for_new_track passes ISRC from history blob as list."""
+@pytest.mark.parametrize(
+    "artist,title,history_extra_fields,location_fields,expected_isrc",
+    [
+        # ISRC from historySessionItems (streaming track — no location blob needed)
+        (
+            "Missy Elliott",
+            "Work It",
+            [("USEE10240944", "isrc"), ("apple-music", "originSourceID")],
+            None,
+            ["USEE10240944"],
+        ),
+        # ISRC from localMediaItemLocations (local file — history has no ISRC)
+        (
+            "Local Artist",
+            "Local Track",
+            [],
+            [("Local Artist", "artist"), ("Local Track", "title"), ("USRC10000001", "isrc")],
+            ["USRC10000001"],
+        ),
+        # historySessionItems ISRC takes priority over localMediaItemLocations ISRC
+        (
+            "Missy Elliott",
+            "Work It",
+            [("USEE10240944", "isrc"), ("apple-music", "originSourceID")],
+            [("Missy Elliott", "artist"), ("Work It", "title"), ("DIFFERENT0001", "isrc")],
+            ["USEE10240944"],
+        ),
+        # No ISRC in either source — key must be absent from metadata
+        (
+            "Local Artist",
+            "Local Track",
+            [],
+            None,
+            None,
+        ),
+    ],
+    ids=["history_isrc", "location_isrc", "history_wins", "no_isrc"],
+)
+def test_check_for_new_track_isrc_sources(
+    bootstrap, artist, title, history_extra_fields, location_fields, expected_isrc
+):
+    """_check_for_new_track picks up ISRC from the correct source."""
     config = bootstrap
+    config.cparser.setValue("djaypro/analyzed_data_delay", 0)
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         plugin.djaypro_dir = tmpdir
         dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
 
-        conn = sqlite3.connect(dbfile)
-        conn.execute(
-            "CREATE TABLE database2 (rowid INTEGER PRIMARY KEY, collection CHAR, "
-            "key CHAR, data BLOB, metadata BLOB)"
-        )
-        blob = _build_tsaf_blob(
+        history_blob = _build_tsaf_blob(
             "ADCHistorySessionItem",
-            [
-                ("Missy Elliott", "artist"),
-                ("Work It", "title"),
-                ("USEE10240944", "isrc"),
-                ("apple-music", "originSourceID"),
-            ],
+            [(artist, "artist"), (title, "title")] + history_extra_fields,
         )
-        conn.execute(
-            "INSERT INTO database2 (collection, key, data) VALUES (?, ?, ?)",
-            ("historySessionItems", "test-key", blob),
-        )
-        conn.commit()
-        conn.close()
+        collections: dict = {"historySessionItems": [history_blob]}
+        if location_fields is not None:
+            location_blob = _build_tsaf_blob("ADCMediaItemLocation", location_fields)
+            collections["localMediaItemLocations"] = [("loc-uuid", location_blob)]
+        _make_db_with_collections(dbfile, collections)
 
         plugin._check_for_new_track()
 
-        assert plugin.metadata.get("artist") == "Missy Elliott"
-        assert plugin.metadata.get("isrc") == ["USEE10240944"]
-
-
-def test_check_for_new_track_no_isrc_omitted(bootstrap):
-    """_check_for_new_track omits isrc key when track has no ISRC."""
-    config = bootstrap
-    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        plugin.djaypro_dir = tmpdir
-        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
-
-        conn = sqlite3.connect(dbfile)
-        conn.execute(
-            "CREATE TABLE database2 (rowid INTEGER PRIMARY KEY, collection CHAR, "
-            "key CHAR, data BLOB, metadata BLOB)"
-        )
-        blob = _build_tsaf_blob(
-            "ADCHistorySessionItem",
-            [("Local Artist", "artist"), ("Local Track", "title")],
-        )
-        conn.execute(
-            "INSERT INTO database2 (collection, key, data) VALUES (?, ?, ?)",
-            ("historySessionItems", "test-key", blob),
-        )
-        conn.commit()
-        conn.close()
-
-        plugin._check_for_new_track()
-
-        assert plugin.metadata.get("artist") == "Local Artist"
-        assert "isrc" not in plugin.metadata
+        assert plugin.metadata.get("artist") == artist
+        if expected_isrc is None:
+            assert "isrc" not in plugin.metadata
+        else:
+            assert plugin.metadata.get("isrc") == expected_isrc
 
 
 def test_check_for_new_track_duplicate(bootstrap):
     """_check_for_new_track preserves metadata when the same track is polled twice."""
     config = bootstrap
+    config.cparser.setValue("djaypro/analyzed_data_delay", 0)
     plugin = nowplaying.inputs.djaypro.Plugin(config=config)
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -647,7 +647,7 @@ def test_check_for_new_track_with_data(bootstrap):
     ],
     ids=["history_isrc", "location_isrc", "history_wins", "no_isrc"],
 )
-def test_check_for_new_track_isrc_sources(
+def test_check_for_new_track_isrc_sources(  # pylint: disable=too-many-arguments
     bootstrap, artist, title, history_extra_fields, location_fields, expected_isrc
 ):
     """_check_for_new_track picks up ISRC from the correct source."""


### PR DESCRIPTION
## Summary by Sourcery

Improve djay Pro input plugin metadata resolution and configurability for analysis timing and ISRC/source handling.

New Features:
- Add configurable analysis delay setting to control how long to wait for djay Pro to commit BPM, key, and file path data before reporting a track.
- Expose additional metadata fields from djay Pro including source and deck, and enrich ISRC handling using both history and location data.

Enhancements:
- Refactor metadata lookup into shared helpers that retrieve filename, track UUID, BPM/key, ISRC, source, and deck more reliably using keyed database access instead of full-table scans.
- Unify new-track commit logic into a single helper to consistently assemble and log track metadata across both NowPlaying.txt and database-driven paths.
- Improve filename and analysis data matching by considering both local and global media item locations and handling tracks without artist tags.

Documentation:
- Update djay Pro input documentation to describe the new Analysis Delay setting, clarify artist query scope behavior, and list the metadata fields provided by the plugin.

Tests:
- Extend and adjust djay Pro input tests to cover UUID-based analyzed data lookups, ISRC precedence between history and location data, the new analysis delay behavior, and the richer database setup helper.