### PR TITLE
Upgrade wnpmb to fix false CAA rate limits

### DIFF
--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -28,7 +28,7 @@ truststore==0.10.4
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.2.2/wnpmb-0.2.2-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.2.3/wnpmb-0.2.3-py3-none-any.whl
 zeroconf==0.148.0
 
 #

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -506,7 +506,7 @@ async def test_discogs_from_mb(bootstrap):  # pylint: disable=redefined-outer-na
     metadatain = {"artist": "TR/ST", "title": "Iris"}
     mdp = nowplaying.metadata.MetadataProcessors(config=config)
     metadataout = await mdp.getmoremetadata(metadata=metadatain)
-    del metadataout["coverimageraw"]
+    metadataout.pop("coverimageraw", None)
     assert metadataout["album"] in ["Iris", "The Destroyer — 2", "Destroyer Vol 1 & 2"]
     assert metadataout["artistwebsites"] == ["https://www.discogs.com/artist/2028711"]
     assert metadataout["artist"] == "TR/ST"


### PR DESCRIPTION
## Summary by Sourcery

No code or configuration changes are present in this pull request based on the provided diff.