### PR TITLE
Docs: AI discoverability, multi-computer wording, 5.2.1 changelog

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -63,14 +63,18 @@ jobs:
             mike deploy --push -F properdocs.yml dev
           fi
 
-      - name: Update root 404 redirect page
+      - name: Update root-level files (404, robots.txt, llms.txt)
         run: |
           cp docs/404.html /tmp/404.html
+          cp docs/robots.txt /tmp/robots.txt
+          cp docs/llms.txt /tmp/llms.txt
           git fetch origin gh-pages
           git checkout -B gh-pages origin/gh-pages
           cp /tmp/404.html 404.html
-          git add 404.html
+          cp /tmp/robots.txt robots.txt
+          cp /tmp/llms.txt llms.txt
+          git add 404.html robots.txt llms.txt
           git diff --cached --quiet || \
-            git commit -m "ci: update root 404 redirect"
+            git commit -m "ci: update root-level files"
           git push origin gh-pages
           git checkout -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,23 @@
 
 * Added `has_tracks_by_artist` support for track requests
 * Added playlist support: available playlists can now be selected for
-    artist queries
+    artist queries and roulette requests
+* BPM, key, and deck number are now read from djay Pro's analysis database
+    and included in track metadata
+* Configurable analysis delay: how long to wait for djay Pro to commit
+    BPM, key, and file path after a track starts (separate DB transaction)
+* Configurable deck skip: individual decks can be excluded from reporting
+    via checkboxes in settings
+* Tracks already playing when WNP launches are silently skipped; djay Pro
+    does not clear NowPlaying.txt between sessions so this prevents
+    re-reporting stale tracks on startup
+
+### MusicBrainz
+
+* Fixed a Cover Art Archive cache poisoning issue where failed CAA fetches
+    were baked into the 7-day recording cache entry, preventing retries;
+    cover art is now cached independently so failures are always retried
+* Fixed false rate-limit errors from the MusicBrainz client
 
 ## Version 5.2.0 - 2026-05-04
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,19 +14,22 @@ Hardware-based sources (Denon StageLinQ) are detected from the network. The
 detected source is shown in **Core Settings → Source** and can be changed at
 any time.
 
-## Two-Computer Setup
+## Multi-Computer Setup
 
 Many DJs stream from a dedicated PC while running their DJ software on a
 separate laptop. WNP is built for this. The **Remote Output** feature
-automatically sends live track data from the DJ machine to the streaming
-machine over the local network.
+automatically sends live track data from 2 or more DJ machines to a central
+WNP instance over the local network, covering everything from a simple
+DJ-laptop/streaming-PC split to a full multi-DJ event where each performer's
+laptop feeds the same streaming machine.
 
 * No IP addresses to configure; uses Bonjour/Zeroconf auto-discovery
 * No port forwarding needed; works on any home or venue network
 * Works across platforms (DJ laptop on macOS, streaming PC on Windows, or
   any combination)
-* Install WNP on both machines, point the streaming machine at the DJ
-  machine, and it just works
+* 2 or more DJ machines can all send to a single central instance simultaneously
+* Install WNP on each machine, point the DJ machines at the central one,
+  and it just works
 
 See [Remote Output](input/remote.md) for setup details.
 
@@ -78,8 +81,9 @@ updates required.
 
 ### [Remote WNP Instance](input/remote.md)
 
-* One WNP instance can receive track data from another WNP instance over the
-  network, the standard solution for a two-computer DJ/streaming setup.
+* A central WNP instance can receive track data from two or more DJ machines
+  simultaneously over the network, covering everything from a simple
+  DJ-laptop/streaming-PC split to a full multi-DJ event.
   Supports auto-discovery via Bonjour/Zeroconf.
 
 ## Track Recognition

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,9 @@ required for most setups. Supports [Serato DJ](input/serato.md),
 [Traktor](input/traktor.md), [Virtual DJ](input/virtualdj.md),
 [Denon DJ](input/denon.md), [djay Pro](input/djaypro.md),
 [DJUCED](input/djuced.md), and [many more](features.md).
-[Two-computer DJ/streaming setups](input/remote.md) are supported via automatic
-network discovery with no IP addresses or port forwarding needed.
+Setups with 2 or more computers are supported: each DJ's machine sends to a
+single central WNP instance via [automatic network discovery](input/remote.md)
+with no IP addresses or port forwarding needed.
 
 Ships with **[42 ready-to-use OBS browser overlay templates](gallery/index.md)**
 including 7 WebGL animated effects. The **[OBS Scene Export](output/obs-export.md)**

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,11 +1,16 @@
 # What's Now Playing
 
-> Free, open-source application with pre-built binaries for Windows, macOS
-> (Intel and Apple Silicon), and Linux. No Python installation required.
-> Reads live track data from DJ software and delivers it to stream overlays,
-> chat bots, text files, and APIs, including artist images and bios from
-> Discogs, FanArt.TV, TheAudioDB, Last.fm, and Wikimedia, a chat-based
-> Guess Game, community charts, and viewer track requests.
+> What's Now Playing displays the current track from your DJ software on
+> streams, in chat, and anywhere your audience can see it. It connects to
+> DJ software, reads live track data, and delivers track titles, artists,
+> album art, and other metadata to OBS browser overlays, Twitch/Kick/Discord
+> chat bots, text files, and APIs in real time.
+>
+> Free, open-source, with pre-built binaries for Windows, macOS (Intel and
+> Apple Silicon), and Linux. No Python installation required.
+> Enriches tracks with artist images and bios from Discogs, FanArt.TV,
+> TheAudioDB, Last.fm, and Wikimedia, plus a chat-based Guess Game,
+> community charts, and viewer track requests.
 >
 > On first launch, WNP automatically detects which DJ software you are running
 > with no manual source selection required for most setups.

--- a/docs/output/guessgame.md
+++ b/docs/output/guessgame.md
@@ -253,7 +253,7 @@ The Guess Game uses Jinja2 templates for chat responses and OBS display:
 
 **twitchbot_guess.txt**: Response when a viewer makes a guess
 
-```jinja
+```jinja { title="twitchbot_guess.txt" data-download="blob" }
 {% raw %}
 {% if guess_error -%}
 {{ guess_error }}
@@ -277,7 +277,7 @@ The Guess Game uses Jinja2 templates for chat responses and OBS display:
 
 **twitchbot_mypoints.txt**: Response when a viewer checks their stats
 
-```jinja
+```jinja { title="twitchbot_mypoints.txt" data-download="blob" }
 {% raw %}
 {% if stats_none -%}
 @{{ stats_user }} You haven't played yet! Type !guess to start playing.
@@ -291,7 +291,7 @@ The Guess Game uses Jinja2 templates for chat responses and OBS display:
 
 **twitchbot_gamestart.txt**: Automatic announcement when a new game starts
 
-```jinja
+```jinja { title="twitchbot_gamestart.txt" data-download="blob" }
 {% raw %}
 🎮 New guessing game! Type !{{ guess_command }} <letter or word> to play | Track: {{ masked_track }} |
 Artist: {{ masked_artist }}

--- a/docs/output/kickbot.md
+++ b/docs/output/kickbot.md
@@ -67,7 +67,7 @@ Kick templates support powerful formatting features:
 
 Example announcement template:
 
-``` jinja
+``` jinja { title="kickbot_track.txt" data-download="blob" }
 {% raw %}
 {% if artist %}{{ artist }} - {% endif %}"{{ title }}"
 {% if album %} from {{ album }}{% endif %}

--- a/docs/output/twitchbot.md
+++ b/docs/output/twitchbot.md
@@ -247,7 +247,7 @@ the Twitchbot track announcement. You can pick and choose which websites
 are printed by taking the following code snippet and modifying as
 necessary:
 
-```jinja
+```jinja { title="twitchbot_websites_snippet.txt" data-download="blob" }
 {% raw %}
 {% if artistwebsites %}
 {% for website in artistwebsites %}

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://whatsnowplaying.com/sitemap.xml
+X-llms-txt: https://whatsnowplaying.com/llms.txt

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,5 +2,5 @@
 
 {% block extrahead %}
 {{ super() }}
-<link rel="alternate" type="text/plain" href="https://whatsnowplaying.com/llms.txt" />
+<link rel="llms-txt" type="text/plain" href="https://whatsnowplaying.com/llms.txt" />
 {% endblock %}

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -4,6 +4,7 @@ site_description: "A tool to retrieve current/last played song in DJ software"
 site_url: http://whatsnowplaying.github.io
 repo_url: https://github.com/whatsnowplaying/whats-now-playing
 repo_name: whatsnowplaying/whats-now-playing
+edit_uri: edit/main/docs/
 
 theme:
   name: materialx
@@ -34,6 +35,7 @@ theme:
     - search.share
     - search.suggest
     - content.code.copy
+    - content.action.agents
     - toc.follow
     - toc.integrate
 
@@ -69,6 +71,7 @@ markdown_extensions:
       alternate_style: true
   - attr_list
   - md_in_html
+  - material.extensions.code_download
   - toc:
       permalink: true
 


### PR DESCRIPTION
* CHANGELOG: add 5.2.1 djay Pro entries and MusicBrainz CAA fix
* index/features: reframe two-computer setup as 2-or-more computers
* llms.txt: lead with product purpose instead of packaging details
* properdocs.yml: enable content.action.agents, code download buttons, edit_uri for per-page markdown source links
* overrides/main.html: rel="llms-txt" for the llms.txt link
* robots.txt: new, with Sitemap and X-llms-txt directives
* docs-deploy workflow: copy robots.txt and llms.txt to gh-pages root
* guessgame/twitchbot/kickbot: download buttons on template snippets

## Summary by Sourcery

Document djay Pro and MusicBrainz changes in the changelog, expand documentation for multi-computer setups and AI/LLM consumption, and update the docs infrastructure and deployment workflow to support new metadata, robots/llms files, and downloadable code snippets.

New Features:
- Expose download buttons for example template snippets in guessgame, Twitchbot, and Kickbot documentation.

Bug Fixes:
- Record djay Pro analysis improvements and MusicBrainz Cover Art Archive caching and rate-limit fixes in the changelog.

Enhancements:
- Clarify documentation for multi-computer DJ/streaming setups and remote WNP instances.
- Reframe llms.txt to focus on product purpose and update the site head to reference it via a dedicated llms-txt link relation.
- Enable edit links, AI-related content actions, and code download support in the documentation configuration.

Build:
- Extend the docs deployment workflow to publish robots.txt and llms.txt alongside the root 404 page.

Deployment:
- Add a robots.txt file advertising the sitemap and llms.txt for AI/LLM crawlers.