### PR TITLE
Bump wnpmb to 0.3.0; purge stale MusicBrainz apicache on upgrade

### DIFF
--- a/nowplaying/apicache.py
+++ b/nowplaying/apicache.py
@@ -597,6 +597,49 @@ class APIResponseCache:
         except (sqlite3.Error, OSError) as error:
             logging.error("Database error during vacuum: %s", error, exc_info=True)
 
+    @staticmethod
+    def purge_providers(providers: list[str], db_file: pathlib.Path | None = None) -> int:
+        """Synchronously delete all cached rows for the given providers.
+
+        Used by version-upgrade hooks to evict cache entries produced by an
+        older library whose output format or scoring has since changed.
+        Reclaiming the disk pages is left to the vacuum pass that runs
+        right after.
+
+        Returns the number of rows removed.
+        """
+        if not providers:
+            return 0
+
+        if db_file is None:
+            cache_dir = pathlib.Path(
+                QStandardPaths.standardLocations(QStandardPaths.StandardLocation.CacheLocation)[0]
+            ).joinpath("api_cache")
+            db_file = cache_dir / "api_responses.db"
+
+        if not db_file.exists():
+            return 0
+
+        placeholders = ",".join("?" * len(providers))
+        try:
+            with nowplaying.utils.sqlite.sqlite_connection(db_file) as connection:
+                cursor = connection.execute(
+                    f"DELETE FROM api_responses WHERE provider IN ({placeholders})",
+                    providers,
+                )
+                connection.commit()
+                removed = cursor.rowcount or 0
+                if removed:
+                    logging.info(
+                        "Purged %d cached row(s) for provider(s): %s",
+                        removed,
+                        ", ".join(providers),
+                    )
+                return removed
+        except (sqlite3.Error, OSError) as error:
+            logging.error("Database error during provider purge: %s", error, exc_info=True)
+            return 0
+
 
 # Global cache instance for use across the application
 _global_cache_instance: APIResponseCache | None = None  # pylint: disable=invalid-name

--- a/nowplaying/apicache.py
+++ b/nowplaying/apicache.py
@@ -76,6 +76,13 @@ class APIResponseCache:
             self.__lock = asyncio.Lock()
         return self.__lock
 
+    @staticmethod
+    def _default_db_path() -> pathlib.Path:
+        """Return the default api_responses.db path under Qt's cache location."""
+        return pathlib.Path(
+            QStandardPaths.standardLocations(QStandardPaths.StandardLocation.CacheLocation)[0]
+        ).joinpath("api_cache", "api_responses.db")
+
     def __init__(self, cache_dir: pathlib.Path | None = None):
         """Initialize the API cache.
 
@@ -84,13 +91,12 @@ class APIResponseCache:
         """
         if cache_dir:
             self.cache_dir = pathlib.Path(cache_dir)
+            self.db_file = self.cache_dir / "api_responses.db"
         else:
-            self.cache_dir = pathlib.Path(
-                QStandardPaths.standardLocations(QStandardPaths.StandardLocation.CacheLocation)[0]
-            ).joinpath("api_cache")
+            self.db_file = self._default_db_path()
+            self.cache_dir = self.db_file.parent
 
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        self.db_file = self.cache_dir / "api_responses.db"
         self.__lock: asyncio.Lock | None = None
         self.__lock_loop: asyncio.AbstractEventLoop | None = None
         self._initialized = False
@@ -577,11 +583,7 @@ class APIResponseCache:
             db_file: Path to database file. If None, uses default cache location.
         """
         if db_file is None:
-            # Use same path construction as APIResponseCache.__init__
-            cache_dir = pathlib.Path(
-                QStandardPaths.standardLocations(QStandardPaths.StandardLocation.CacheLocation)[0]
-            ).joinpath("api_cache")
-            db_file = cache_dir / "api_responses.db"
+            db_file = APIResponseCache._default_db_path()
 
         logging.debug("Checking API cache database at: %s", db_file)
         logging.debug("Cache directory exists: %s", db_file.parent.exists())
@@ -612,30 +614,29 @@ class APIResponseCache:
             return 0
 
         if db_file is None:
-            cache_dir = pathlib.Path(
-                QStandardPaths.standardLocations(QStandardPaths.StandardLocation.CacheLocation)[0]
-            ).joinpath("api_cache")
-            db_file = cache_dir / "api_responses.db"
+            db_file = APIResponseCache._default_db_path()
 
         if not db_file.exists():
             return 0
 
-        placeholders = ",".join("?" * len(providers))
         try:
+            removed = 0
             with nowplaying.utils.sqlite.sqlite_connection(db_file) as connection:
-                cursor = connection.execute(
-                    f"DELETE FROM api_responses WHERE provider IN ({placeholders})",
-                    providers,
-                )
-                connection.commit()
-                removed = cursor.rowcount or 0
-                if removed:
-                    logging.info(
-                        "Purged %d cached row(s) for provider(s): %s",
-                        removed,
-                        ", ".join(providers),
+                # One literal statement per provider keeps the SQL fully static
+                # (no string interpolation) and the input bound as a parameter.
+                for provider in providers:
+                    cursor = connection.execute(
+                        "DELETE FROM api_responses WHERE provider = ?", (provider,)
                     )
-                return removed
+                    removed += cursor.rowcount or 0
+                connection.commit()
+            if removed:
+                logging.info(
+                    "Purged %d cached row(s) for provider(s): %s",
+                    removed,
+                    ", ".join(providers),
+                )
+            return removed
         except (sqlite3.Error, OSError) as error:
             logging.error("Database error during provider purge: %s", error, exc_info=True)
             return 0

--- a/nowplaying/upgrades/config.py
+++ b/nowplaying/upgrades/config.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import (  # pylint: disable=no-name-in-module
 )
 from PySide6.QtWidgets import QMessageBox  # pylint: disable=no-name-in-module
 
+import nowplaying.apicache
 import nowplaying.artistextras.theaudiodb
 import nowplaying.trackrequests
 import nowplaying.utils.config_json
@@ -294,6 +295,9 @@ class UpgradeConfig:
         if oldversion < Version("5.2.0"):
             self._upgrade_to_5_2_0(config)
 
+        if oldversion < Version("5.2.1"):
+            self._upgrade_to_5_2_1()
+
         self._oldkey_to_newkey(rawconfig, config, mapping)
 
         config.setValue("settings/configversion", thisverstr)
@@ -506,6 +510,18 @@ class UpgradeConfig:
             config.setValue("discord/bot_enabled", enabled)
             config.setValue("discord/richpresence_enabled", enabled)
             config.remove("discord/enabled")
+
+    @staticmethod
+    def _upgrade_to_5_2_1() -> None:
+        """Upgrade to 5.2.1 — purge MusicBrainz apicache entries.
+
+        wnpmb 0.3.0 changed release scoring (better handling of singles, reissues,
+        and compilations with missing secondary-types).  Entries cached by older
+        wnpmb versions can still return wrong albums even after the upgrade, so
+        we invalidate them once on first 5.2.1 launch.  The vacuum pass that
+        follows on startup reclaims the freed disk pages.
+        """
+        nowplaying.apicache.APIResponseCache.purge_providers(["musicbrainz", "musicbrainz_caa"])
 
     @staticmethod
     def _upgrade_to_5_2_0(config: QSettings) -> None:

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -28,7 +28,7 @@ truststore==0.10.4
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.2.3/wnpmb-0.2.3-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.3.0/wnpmb-0.3.0-py3-none-any.whl
 zeroconf==0.148.0
 
 #

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -263,7 +263,13 @@ async def test_fallback_klfvsent(getmusicbrainz):  # pylint: disable=redefined-o
         "8092b8b7-235e-4844-9f72-95a9d5a73dbf",
         "709af0d0-dcb6-4858-b76d-05a13fc9a0a6",
     ]
-    assert newdata["album"] == "Solid State Logik 1"
+    # MB has this recording on multiple releases; which one wins depends on
+    # wnpmb's release scoring.  Both are legitimate matches for the Radio
+    # Freedom edit.
+    assert newdata["album"] in {
+        "Solid State Logik 1",
+        "3 A.M. Eternal (Christmas Top of the Pops 1991)",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
wnpmb 0.3.0 improves release scoring (Single/EP base bonuses, compilation-title safety net, reissue penalty) so ISRC-only lookups no longer surface compilations when a canonical Single exists.

Add APIResponseCache.purge_providers() and call it from a new _upgrade_to_5_2_1() hook so cached results produced by older wnpmb versions are evicted on first 5.2.1 launch.  The vacuum pass that already runs on startup reclaims the freed pages.

Loosen test_fallback_klfvsent to accept either of the two legitimately-correct albums; wnpmb release-scoring tiebreaker may pick either depending on MB data drift.

## Summary by Sourcery

Purge stale MusicBrainz API cache entries on upgrade to avoid outdated release scoring results and align tests with updated wnpmb 0.3.0 behavior.

Bug Fixes:
- Invalidate old MusicBrainz API cache entries on upgrade to prevent incorrect album matches caused by changed release scoring.

Enhancements:
- Add a cache helper to bulk-delete API response entries for specific providers.
- Relax a MusicBrainz fallback test to accept multiple valid album matches based on current release scoring.

Tests:
- Adjust the MusicBrainz fallback test to allow either of the two valid releases for the targeted recording.