### PR TITLE
CI: auto-upload release zips on tag + signed-bundle verification

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -29,6 +29,10 @@ jobs:
       contents: read
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      # Hoisted to job level so `env.RELEASE_TOKEN` is visible in
+      # step-level `if:` conditions (step-local env isn't always
+      # available to the if-expression evaluator).
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
       - name: cpu diagnostics
         run: |
@@ -93,6 +97,10 @@ jobs:
       # Catching this here means a bad zip never becomes a workflow
       # artifact or a release asset.
       - name: verify signed bundle survives zip round-trip
+        # Only run when the build entered a signing environment.  On a
+        # plain branch push (no environment, no MACOS_SIGN_IDENTITY) the
+        # bundle was never signed, so this check would fail spuriously.
+        if: ${{ inputs.environment != '' }}
         run: |
           # GitHub Actions runs bash -e; we have to be careful not to let
           # codesign/spctl non-zero exits kill the assignment before we get
@@ -152,8 +160,7 @@ jobs:
       - name: upload zip to GitHub Release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -84,8 +84,85 @@ jobs:
         run: |
           BINARY=$(find WhatsNowPlaying-* -path "*/Contents/MacOS/WhatsNowPlaying" -type f | head -1)
           "${BINARY}" --smoke-test
+
+      # Re-extract the zip into a fresh location and verify the bundle
+      # there.  codesign on the runner's in-place dist/ has been seen
+      # to silently accept bundles that fail verification once they
+      # round-trip through zip+unzip (e.g. PySide6 6.11.1 ships .cpp.o
+      # build artifacts that aren't in the signature manifest).
+      # Catching this here means a bad zip never becomes a workflow
+      # artifact or a release asset.
+      - name: verify signed bundle survives zip round-trip
+        run: |
+          # GitHub Actions runs bash -e; we have to be careful not to let
+          # codesign/spctl non-zero exits kill the assignment before we get
+          # a chance to print the diagnostic output.
+          ZIP=$(ls WhatsNowPlaying-*.zip | head -1)
+          if [[ -z "$ZIP" ]]; then
+            echo "ERROR: no zip found to verify"
+            exit 1
+          fi
+          EXTRACT=$(mktemp -d)
+          ditto -xk "$ZIP" "$EXTRACT"
+          APP=$(find "$EXTRACT" -name "WhatsNowPlaying.app" -type d | head -1)
+          if [[ -z "$APP" ]]; then
+            echo "ERROR: WhatsNowPlaying.app not found inside $ZIP"
+            exit 1
+          fi
+
+          echo "=== codesign --verify --deep --strict on extracted bundle ==="
+          set +e
+          VERIFY_OUT=$(codesign --verify --deep --strict --verbose=2 "$APP" 2>&1)
+          CODESIGN_EXIT=$?
+          set -e
+          echo "$VERIFY_OUT"
+          echo "codesign exit code: $CODESIGN_EXIT"
+          if [[ $CODESIGN_EXIT -ne 0 ]] || \
+             echo "$VERIFY_OUT" | grep -qE "not signed at all|invalid signature|failed"; then
+            echo "ERROR: codesign --verify reports failure on extracted bundle"
+            exit 1
+          fi
+
+          echo "=== spctl --assess on extracted bundle ==="
+          set +e
+          SPCTL_OUT=$(spctl --assess --type execute --verbose "$APP" 2>&1)
+          SPCTL_EXIT=$?
+          set -e
+          echo "$SPCTL_OUT"
+          echo "spctl exit code: $SPCTL_EXIT"
+          if [[ $SPCTL_EXIT -ne 0 ]] || echo "$SPCTL_OUT" | grep -q "rejected"; then
+            echo "ERROR: spctl rejected extracted bundle"
+            exit 1
+          fi
+
+          rm -rf "$EXTRACT"
+
       - name: artifact dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: ${{ inputs.artifact-name }}
           path: "*.zip"
+
+      # Release upload runs only when the build is inside a signing
+      # environment that has RELEASE_TOKEN configured.  RELEASE_TOKEN
+      # is a fine-scoped PAT with permission to write releases on this
+      # repo only.  Outside a signing environment the secret is empty
+      # and this step is skipped — no path for unsigned binaries to
+      # land on the public Releases page.
+      - name: upload zip to GitHub Release
+        if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$TAG" \
+                 --repo "$GITHUB_REPOSITORY" \
+                 --draft \
+                 --title "$TAG" \
+                 --generate-notes
+          gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            WhatsNowPlaying-*.zip

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -39,6 +39,8 @@ jobs:
 
   pyinstaller-linux:
     runs-on: ubuntu-latest
+    environment: >-
+      ${{ startsWith(github.ref, 'refs/tags/') && 'linux-signing' || '' }}
     permissions:
       contents: read
     steps:
@@ -55,6 +57,27 @@ jobs:
         with:
           name: linux-dist
           path: "*.zip"
+
+      # Release upload runs only inside the linux-signing environment
+      # (active on tag pushes), which provides the RELEASE_TOKEN PAT
+      # scoped to release-write on this repo only.
+      - name: upload zip to GitHub Release
+        if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$TAG" \
+                 --repo "$GITHUB_REPOSITORY" \
+                 --draft \
+                 --title "$TAG" \
+                 --generate-notes
+          gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            WhatsNowPlaying-*.zip
 
   pyinstaller-linux-smoke:
     needs: pyinstaller-linux
@@ -165,3 +188,77 @@ jobs:
           name: windows-dist
           # Windows builds create a directory, not a zip (see builder.sh line 146)
           path: "WhatsNowPlaying*windows"
+
+      # Windows zip is produced here (post-signing) rather than in
+      # builder.sh because the signing step has to run against the
+      # unpacked directory.
+      - name: zip windows dist for release
+        if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        shell: bash
+        run: |
+          DIR=$(find . -maxdepth 1 -type d -name "WhatsNowPlaying-*-Windows" | head -1)
+          if [[ -z "$DIR" ]]; then
+            echo "Windows dist directory not found" >&2
+            exit 1
+          fi
+          # Strip leading ./ so the archive doesn't contain it.
+          DIR="${DIR#./}"
+          7z a -tzip "${DIR}.zip" "${DIR}"
+
+      # Mirror the macOS zip-roundtrip verification: extract the zip
+      # we just made into a fresh location and check the Authenticode
+      # signature on the main exe.  The runner's in-place verification
+      # earlier in the job has been shown to mask issues that only
+      # appear after the zip+extract path users actually exercise.
+      - name: verify signed bundle survives zip round-trip
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        shell: powershell
+        run: |
+          $zip = Get-ChildItem -Filter "WhatsNowPlaying-*-Windows.zip" | Select-Object -First 1
+          if (-not $zip) {
+            Write-Error "No Windows zip found to verify"
+            exit 1
+          }
+          $extract = Join-Path $env:RUNNER_TEMP "verify-extract"
+          if (Test-Path $extract) { Remove-Item -Recurse -Force $extract }
+          New-Item -ItemType Directory -Path $extract | Out-Null
+          Expand-Archive -Path $zip.FullName -DestinationPath $extract -Force
+          $exe = Get-ChildItem -Recurse -Path $extract -Filter "WhatsNowPlaying.exe" | Select-Object -First 1
+          if (-not $exe) {
+            Write-Error "WhatsNowPlaying.exe not found inside $($zip.Name)"
+            exit 1
+          }
+          $sig = Get-AuthenticodeSignature -FilePath $exe.FullName
+          Write-Output "Status:  $($sig.Status)"
+          Write-Output "Subject: $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne 'Valid') {
+            Write-Error "Extracted bundle's WhatsNowPlaying.exe has signature status: $($sig.Status)"
+            exit 1
+          }
+          Remove-Item -Recurse -Force $extract
+
+      # Release upload runs only inside the windows-signing environment
+      # (active on tag pushes), which provides the RELEASE_TOKEN PAT
+      # scoped to release-write on this repo only.
+      - name: upload zip to GitHub Release
+        if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$TAG" \
+                 --repo "$GITHUB_REPOSITORY" \
+                 --draft \
+                 --title "$TAG" \
+                 --generate-notes
+          gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            WhatsNowPlaying-*-Windows.zip

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -43,6 +43,10 @@ jobs:
       ${{ startsWith(github.ref, 'refs/tags/') && 'linux-signing' || '' }}
     permissions:
       contents: read
+    env:
+      # Hoisted to job level so env.RELEASE_TOKEN is visible to the
+      # step-level if: condition below.
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -64,8 +68,7 @@ jobs:
       - name: upload zip to GitHub Release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
@@ -133,6 +136,9 @@ jobs:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      # Hoisted to job level so env.RELEASE_TOKEN is visible to step-level
+      # if: conditions on the zip + verify + upload steps below.
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -194,8 +200,6 @@ jobs:
       # unpacked directory.
       - name: zip windows dist for release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         shell: bash
         run: |
           DIR=$(find . -maxdepth 1 -type d -name "WhatsNowPlaying-*-Windows" | head -1)
@@ -212,10 +216,12 @@ jobs:
       # signature on the main exe.  The runner's in-place verification
       # earlier in the job has been shown to mask issues that only
       # appear after the zip+extract path users actually exercise.
+      # Gated only on RELEASE_TOKEN (signing-env active + tag push) —
+      # AZURE_CLIENT_ID gates the actual signing earlier; if we got
+      # here in the signing env, the binary should be signed and the
+      # verification should run.
       - name: verify signed bundle survives zip round-trip
-        if: ${{ env.AZURE_CLIENT_ID != '' && env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
         shell: powershell
         run: |
           $zip = Get-ChildItem -Filter "WhatsNowPlaying-*-Windows.zip" | Select-Object -First 1
@@ -247,8 +253,7 @@ jobs:
       - name: upload zip to GitHub Release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
           TAG: ${{ github.ref_name }}
         shell: bash
         run: |

--- a/bincomponents/osxcodesign.sh
+++ b/bincomponents/osxcodesign.sh
@@ -19,7 +19,16 @@ if [[ -z "${MACOS_SIGN_IDENTITY:-}" ]]; then
 fi
 
 echo "=== Verifying signature ==="
-codesign --verify --deep --strict --verbose=2 "${APP}"
+# codesign --verify --deep --strict exits 0 even when it reports
+# "code object is not signed at all" for a subcomponent.  Parse the
+# output and fail explicitly so CI catches unsigned bundle parts
+# (e.g. .cpp.o build artifacts shipped by PySide6 wheels).
+VERIFY_OUT=$(codesign --verify --deep --strict --verbose=2 "${APP}" 2>&1)
+echo "${VERIFY_OUT}"
+if echo "${VERIFY_OUT}" | grep -qE "not signed at all|invalid signature|failed"; then
+  echo "ERROR: codesign verification reported failure in ${APP}"
+  exit 1
+fi
 
 # Notarize only if all three Apple credentials are present
 if [[ -n "${APPLE_ID:-}" && -n "${APPLE_ID_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
@@ -56,7 +65,15 @@ if [[ -n "${APPLE_ID:-}" && -n "${APPLE_ID_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-
   xcrun stapler staple "${APP}"
 
   echo "=== Verifying notarization ==="
-  spctl --assess --type execute --verbose "${APP}"
+  # spctl --assess can exit 0 while printing "rejected"; parse the
+  # output to fail explicitly.  This is the Gatekeeper-equivalent
+  # check users hit at first launch.
+  SPCTL_OUT=$(spctl --assess --type execute --verbose "${APP}" 2>&1)
+  echo "${SPCTL_OUT}"
+  if echo "${SPCTL_OUT}" | grep -q "rejected"; then
+    echo "ERROR: spctl rejected ${APP}"
+    exit 1
+  fi
 else
   echo "=== Skipping notarization (APPLE_ID/APPLE_ID_PASSWORD/APPLE_TEAM_ID not set) ==="
 fi

--- a/bincomponents/osxcodesign.sh
+++ b/bincomponents/osxcodesign.sh
@@ -20,12 +20,18 @@ fi
 
 echo "=== Verifying signature ==="
 # codesign --verify --deep --strict exits 0 even when it reports
-# "code object is not signed at all" for a subcomponent.  Parse the
-# output and fail explicitly so CI catches unsigned bundle parts
-# (e.g. .cpp.o build artifacts shipped by PySide6 wheels).
+# "code object is not signed at all" for a subcomponent — so parse
+# the output too.  Also catch any non-zero exit (internal error,
+# missing file, etc.) that wouldn't match the grep.
+# `set -e` is active so wrap the assignment to capture exit code.
+set +e
 VERIFY_OUT=$(codesign --verify --deep --strict --verbose=2 "${APP}" 2>&1)
+CODESIGN_EXIT=$?
+set -e
 echo "${VERIFY_OUT}"
-if echo "${VERIFY_OUT}" | grep -qE "not signed at all|invalid signature|failed"; then
+echo "codesign exit code: ${CODESIGN_EXIT}"
+if [[ ${CODESIGN_EXIT} -ne 0 ]] \
+   || echo "${VERIFY_OUT}" | grep -qE "not signed at all|invalid signature|failed"; then
   echo "ERROR: codesign verification reported failure in ${APP}"
   exit 1
 fi
@@ -66,12 +72,16 @@ if [[ -n "${APPLE_ID:-}" && -n "${APPLE_ID_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-
 
   echo "=== Verifying notarization ==="
   # spctl --assess can exit 0 while printing "rejected"; parse the
-  # output to fail explicitly.  This is the Gatekeeper-equivalent
-  # check users hit at first launch.
+  # output to fail explicitly.  Also catch any non-zero exit that
+  # wouldn't match the grep.
+  set +e
   SPCTL_OUT=$(spctl --assess --type execute --verbose "${APP}" 2>&1)
+  SPCTL_EXIT=$?
+  set -e
   echo "${SPCTL_OUT}"
-  if echo "${SPCTL_OUT}" | grep -q "rejected"; then
-    echo "ERROR: spctl rejected ${APP}"
+  echo "spctl exit code: ${SPCTL_EXIT}"
+  if [[ ${SPCTL_EXIT} -ne 0 ]] || echo "${SPCTL_OUT}" | grep -q "rejected"; then
+    echo "ERROR: spctl rejected ${APP} (exit=${SPCTL_EXIT})"
     exit 1
   fi
 else

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -19,7 +19,9 @@ puremagic==2.2.0; python_version >= "3.12"
 pyacoustid==1.3.1
 pypresence==4.6.1
 # 6.5.0-6.5.3's rcc is broken on macOS; 6.5+ required for Qt.ColorScheme / colorSchemeChanged
-pyside6>=6.5.4,<6.12.0
+# 6.11.1 ships unsigned .cpp.o build artifacts in qml/Qt/labs/assetdownloader/ that break
+# macOS Gatekeeper at runtime; skip until upstream cleans up the wheel.
+pyside6>=6.5.4,!=6.11.1,<6.12.0
 rapidfuzz==3.14.5
 requests-cache==1.3.2
 requests==2.34.0


### PR DESCRIPTION
Release uploads
---------------
Adds a "release upload" step to each of the four platform build jobs (macos-arm, macos-intel, windows, linux) that calls `gh release` to attach the produced zip to a draft GitHub Release.

The capability is gated by RELEASE_TOKEN, a fine-grained PAT scoped to Contents: Read and write on this repo only.  RELEASE_TOKEN is configured as a secret inside the four *-signing environments and the steps if-check for its presence, so:

  - Push to a feature branch: env is empty, secret is empty, step skipped — no path for unsigned binaries to land on Releases.
  - Push to a tag: signing env is active, RELEASE_TOKEN is present, upload runs.

The first platform to upload creates a draft release with auto-generated notes; subsequent platforms attach their zips with --clobber.  Maintainer reviews and publishes when ready.

Windows requires a 7z step inside the workflow because the post-signing directory has to be zipped after the signature is applied (builder.sh leaves Windows as a directory, on purpose).

Workflow-level GITHUB_TOKEN stays contents: read.  Write capability is delegated to the environment-scoped PAT.

Signed-bundle verification
--------------------------
codesign --verify --deep --strict and spctl --assess both exit 0 in some failure modes (e.g. unsigned subcomponents) while still printing "not signed at all" or "rejected".  osxcodesign.sh now captures the output and greps for those strings to fail explicitly.

The in-place check on the runner can also silently accept bundles that fail once they round-trip through zip+unzip.  Each platform's job now extracts the just-built zip into a fresh location and re-runs the signing checks against that, mimicking the user-side state.  A bundle that codesign accepts in-place but fails after extraction (which is exactly what PySide6 6.11.1's unsigned .cpp.o build artifacts cause) is now caught before the zip becomes a workflow artifact or a release asset.

requirements-run.txt
--------------------
Excludes pyside6 6.11.1 — that release ships unsigned .cpp.o build outputs in qml/Qt/labs/assetdownloader/ that break macOS Gatekeeper at runtime.  Remove the !=6.11.1 once upstream fixes the wheel.

## Summary by Sourcery

Automate tagged release packaging and strengthen macOS/Windows bundle signature verification in CI.

Enhancements:
- Adjust runtime dependencies to avoid a problematic PySide6 release that ships unsigned artifacts until upstream is fixed.

CI:
- Add environment-scoped release upload steps for macOS, Windows, and Linux builds that attach signed zips to draft GitHub Releases on tag pushes using a fine-scoped PAT.
- Introduce a post-signing Windows packaging step that zips the signed distribution directory before uploading as a release asset.
- Add macOS and Windows CI checks that re-extract built zips and verify code signatures/Authenticode signatures to ensure bundles remain valid after a zip round-trip.
- Tighten macOS signing verification in the shared signing script by parsing codesign and spctl output and failing explicitly on unsigned or rejected components.