### PR TITLE
Stop caching transient API errors; refresh 5.2.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 * Fixed EarShot and two-computer setups sending cover art via HTTP URL:
     only the first ~16KB of the image was being read due to an aiohttp
     buffering issue; full image data is now fetched correctly
+* Fixed Wikipedia, MusicBrainz, Discogs, and fanart.tv remembering
+    transient errors (rate limits, network failures) as "no data" for
+    hours or days, so artist bios, images, and album metadata for the
+    affected track stayed blank until the entry expired.  Stale entries
+    are cleared automatically on upgrade
 
 ### Artist Extras
 
@@ -26,6 +31,8 @@
     artist queries and roulette requests
 * BPM, key, and deck number are now read from djay Pro's analysis database
     and included in track metadata
+* ISRC codes are now included in track metadata when djay Pro provides
+    them, improving downstream metadata lookups
 * Configurable analysis delay: how long to wait for djay Pro to commit
     BPM, key, and file path after a track starts (separate DB transaction)
 * Configurable deck skip: individual decks can be excluded from reporting
@@ -36,9 +43,14 @@
 
 ### MusicBrainz
 
-* Fixed a Cover Art Archive cache poisoning issue where failed CAA fetches
-    were baked into the 7-day recording cache entry, preventing retries;
-    cover art is now cached independently so failures are always retried
+* Improved album selection: when EarShot (or another source) provides an
+    album name, the canonical studio album is preferred over compilations
+    or reissues that happen to contain the same recording
+* Improved album selection for ISRC-only lookups: canonical singles and
+    studio releases are preferred over compilations and reissues
+* Fixed cover art going permanently missing for a track after a single
+    failed fetch from the Cover Art Archive; failed fetches now retry
+    on the next play
 * Fixed false rate-limit errors from the MusicBrainz client
 
 ## Version 5.2.0 - 2026-05-04

--- a/docs/input/djaypro.md
+++ b/docs/input/djaypro.md
@@ -58,6 +58,7 @@ now-playing updates.
 * Album (macOS only)
 * BPM and musical key (from djay Pro's own analysis, when available)
 * Deck number
+* ISRC, when djay Pro has it
 * Filename / file path (local tracks only)
 
 ## Troubleshooting

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -53,6 +53,11 @@ class Plugin(ArtistExtrasPlugin):
             result = await self.client.search_async(
                 album_title, artist=artist_name, search_type=search_type
             )
+            # search_async returns None on transient errors (429, network);
+            # propagating None tells apicache to skip caching so the next
+            # call retries instead of serving a poisoned empty result.
+            if result is None:
+                return None
             # Convert to JSON-serializable format for caching
             if hasattr(result, "results"):
                 return {
@@ -257,7 +262,9 @@ class Plugin(ArtistExtrasPlugin):
             logging.error("discogs async hit %s", error)
             return None, None
 
-        for result in resultlist:
+        # _search_async_cached returns None on transient errors (so the empty
+        # result is not cached); treat that the same as "no match here".
+        for result in resultlist or []:
             if isinstance(result, nowplaying.discogsclient.Models.Release):
                 artist = result.artists[0] if result.artists else None
                 cover_url = result.data.get("cover_image") or result.data.get("thumb")

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -34,6 +34,19 @@ class Plugin(ArtistExtrasPlugin):
                 async with session.get(
                     f"{baseurl}?api_key={apikey}", timeout=aiohttp.ClientTimeout(total=delay)
                 ) as response:
+                    # Only 200 and 404 are cache-worthy.  A 404 means "artist
+                    # not in the database", which is a legitimate negative
+                    # result that should be remembered.  Everything else —
+                    # 429, 5xx, plus credential/config errors like 400/401/403
+                    # — should be retried on the next play rather than baked
+                    # into a 7-day cache entry.
+                    if response.status not in (200, 404):
+                        logging.warning(
+                            "fanart.tv HTTP %d for artistid %s; not caching",
+                            response.status,
+                            artistid,
+                        )
+                        return None
                     return await response.json()
         except TimeoutError:
             logging.error("fantart.tv async timeout getting artistid %s", artistid)

--- a/nowplaying/artistextras/wikimedia.py
+++ b/nowplaying/artistextras/wikimedia.py
@@ -40,14 +40,20 @@ class Plugin(ArtistExtrasPlugin):
         ) or self.config.cparser.value("wikimedia/thumbnails", type=bool)
 
         async def fetch_func():
-            page = await nowplaying.wikiclient.get_page_async(
-                entity=entity,
-                lang=lang,
-                timeout=5,
-                need_bio=need_bio,
-                need_images=need_images,
-                max_images=5,  # Limit for performance during live shows
-            )
+            try:
+                page = await nowplaying.wikiclient.get_page_async(
+                    entity=entity,
+                    lang=lang,
+                    timeout=5,
+                    need_bio=need_bio,
+                    need_images=need_images,
+                    max_images=5,  # Limit for performance during live shows
+                )
+            except Exception as err:  # pylint: disable=broad-except
+                # Returning None tells apicache to skip caching, so a transient
+                # wikidata failure (e.g. 429) does not poison the entry.
+                logging.debug("wikimedia fetch failed for %s/%s: %s", entity, lang, err)
+                return None
             # Convert to JSON-serializable format for caching
             if page:
                 return {

--- a/nowplaying/artistextras/wikimedia.py
+++ b/nowplaying/artistextras/wikimedia.py
@@ -3,6 +3,8 @@
 
 import logging
 
+import aiohttp
+
 import nowplaying.apicache
 import nowplaying.wikiclient
 from nowplaying.artistextras import ArtistExtrasPlugin
@@ -49,9 +51,12 @@ class Plugin(ArtistExtrasPlugin):
                     need_images=need_images,
                     max_images=5,  # Limit for performance during live shows
                 )
-            except Exception as err:  # pylint: disable=broad-except
+            except (aiohttp.ClientError, TimeoutError) as err:
                 # Returning None tells apicache to skip caching, so a transient
-                # wikidata failure (e.g. 429) does not poison the entry.
+                # wikidata failure (e.g. 429) does not poison the entry.  Only
+                # network/HTTP errors are caught here so genuine bugs in our
+                # own parsing logic still surface instead of being treated as
+                # transient.
                 logging.debug("wikimedia fetch failed for %s/%s: %s", entity, lang, err)
                 return None
             # Convert to JSON-serializable format for caching

--- a/nowplaying/discogsclient.py
+++ b/nowplaying/discogsclient.py
@@ -173,8 +173,14 @@ class AsyncDiscogsClient:
         per_page: int = 50,
         load_full_artists: bool = True,
         max_results: int | None = None,
-    ) -> DiscogsSearchResult:
-        """Search for releases, artists, etc."""
+    ) -> DiscogsSearchResult | None:
+        """Search for releases, artists, etc.
+
+        Returns None on transient errors (429, non-200 HTTP, network exceptions)
+        so callers can avoid caching a poisoned empty result for the 7-day TTL.
+        A successful response with zero matches still returns an empty
+        DiscogsSearchResult so legitimate negatives can be cached.
+        """
         if not self.session:
             raise RuntimeError("Client not initialized - use async context manager")
 
@@ -187,7 +193,7 @@ class AsyncDiscogsClient:
 
         try:
             if not self.session:
-                return DiscogsSearchResult([], self)
+                return None
             async with self.session.get(url, params=params) as response:  # pylint: disable=not-async-context-manager
                 self._log_rate_limit(response)
                 if response.status == 200:
@@ -210,10 +216,10 @@ class AsyncDiscogsClient:
                     logging.warning("Discogs search rate limited (429), skipping")
                 else:
                     logging.warning("Discogs search failed with status %d", response.status)
-                return DiscogsSearchResult([], self)
+                return None
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.debug("Discogs search error: %s", error)
-            return DiscogsSearchResult([], self)
+            return None
 
     async def artist(
         self, artist_id: int | str, limit_images: int | None = None, include_bio: bool = True
@@ -286,8 +292,12 @@ class AsyncDiscogsClientWrapper:
 
     async def search_async(
         self, query: str, artist: str | None = None, search_type: str = "release"
-    ) -> DiscogsSearchResult:
-        """Search for releases (async version)."""
+    ) -> DiscogsSearchResult | None:
+        """Search for releases (async version).
+
+        Returns None on transient errors so the cache layer does not store
+        a poisoned empty result.
+        """
         async with AsyncDiscogsClient(self.user_agent, self.user_token, self.timeout) as client:
             return await client.search(
                 query, artist, search_type, max_results=10, load_full_artists=True

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -326,11 +326,18 @@ class MusicBrainzHelper:
                 return art
         return None
 
-    async def _recordingid_uncached(self, recordingid, track_data: dict | None = None) -> dict:
+    async def _recordingid_uncached(
+        self, recordingid, track_data: dict | None = None
+    ) -> dict | None:
         """uncached version of recordingid lookup.
 
         track_data: optional original metadata (e.g. EarShot's Shazam result)
         whose 'album', 'year', 'date' fields wnpmb uses as release-scoring hints.
+
+        Returns None on rate-limit / MusicBrainzError so the caller does not
+        cache a poisoned empty result for the 7-day TTL.  Returns {} when the
+        lookup succeeded but MusicBrainz genuinely has no recording — caching
+        that negative result is desirable.
         """
         self._setemail()
 
@@ -363,7 +370,7 @@ class MusicBrainzHelper:
                     newdata["genre"] = "/".join(enriched["genres"])
                 return newdata
 
-        return await self._mb_op_with_retry(_fetch, "get_recording_by_id", {})
+        return await self._mb_op_with_retry(_fetch, "get_recording_by_id", None)
 
     async def artistids(self, idlist):
         """add data available via musicbrainz artist ids"""

--- a/nowplaying/upgrades/config.py
+++ b/nowplaying/upgrades/config.py
@@ -513,15 +513,26 @@ class UpgradeConfig:
 
     @staticmethod
     def _upgrade_to_5_2_1() -> None:
-        """Upgrade to 5.2.1 — purge MusicBrainz apicache entries.
+        """Upgrade to 5.2.1 — purge MusicBrainz, Wikimedia, and Discogs apicache.
 
         wnpmb 0.3.0 changed release scoring (better handling of singles, reissues,
         and compilations with missing secondary-types).  Entries cached by older
         wnpmb versions can still return wrong albums even after the upgrade, so
-        we invalidate them once on first 5.2.1 launch.  The vacuum pass that
-        follows on startup reclaims the freed disk pages.
+        we invalidate them once on first 5.2.1 launch.  This also clears any
+        MusicBrainz recording entries poisoned by a 5.2.0 rate-limit failure
+        (the recording lookup used to cache an empty dict for 7 days).
+
+        Wikimedia and Discogs entries are purged for the same shape of bug:
+        5.2.0 silently cached empty results when the upstream API returned a
+        transient error (HTTP 429, network failure), poisoning the entry for
+        24 hours (Wikimedia) or 7 days (Discogs).  5.2.1 no longer caches
+        transient failures, but existing 5.2.0 caches may still hold them.
+
+        The vacuum pass that follows on startup reclaims the freed disk pages.
         """
-        nowplaying.apicache.APIResponseCache.purge_providers(["musicbrainz", "musicbrainz_caa"])
+        nowplaying.apicache.APIResponseCache.purge_providers(
+            ["musicbrainz", "musicbrainz_caa", "wikimedia", "discogs"]
+        )
 
     @staticmethod
     def _upgrade_to_5_2_0(config: QSettings) -> None:

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -367,34 +367,46 @@ class AsyncWikiClient:
         fetch_images: bool = True,
         max_images: int = 10,
     ) -> WikiPage:
-        """Get a Wikipedia page by Wikidata entity ID with selective fetching."""
+        """Get a Wikipedia page by Wikidata entity ID with selective fetching.
+
+        Raises on transient failures of the primary Wikidata lookup (e.g.
+        HTTP 429 rate limits) so callers can avoid caching a poisoned empty
+        result. Secondary best-effort fetches (extract, images) swallow
+        their own errors and contribute whatever data they were able to
+        retrieve.
+        """
         wiki_page = WikiPage(entity, lang)
 
-        try:
-            # Get Wikidata info, including sitelinks if we need bio or images
-            include_sitelinks = fetch_bio or fetch_images
-            wikidata_info = await self._get_wikidata_info(entity, lang, include_sitelinks)
-            wiki_page.data.update(wikidata_info)
+        # Primary Wikidata lookup - if this fails, the page is unusable.
+        # Let the exception propagate so callers do not cache the empty result.
+        include_sitelinks = fetch_bio or fetch_images
+        wikidata_info = await self._get_wikidata_info(entity, lang, include_sitelinks)
+        wiki_page.data.update(wikidata_info)
 
-            # Extract sitelinks for reuse
-            sitelinks = wikidata_info.get("sitelinks") if include_sitelinks else None
+        # Extract sitelinks for reuse
+        sitelinks = wikidata_info.get("sitelinks") if include_sitelinks else None
 
-            # Only fetch bio if requested - reuse sitelinks to avoid extra API call
-            if fetch_bio:
+        # Secondary fetches are best-effort: a partial page is still cacheable.
+        # Catch only network/HTTP errors here so unexpected bugs in our parsers
+        # (KeyError, TypeError, etc.) still propagate and get noticed.  Log at
+        # warning so repeated upstream failures show up in normal logs.
+        if fetch_bio:
+            try:
                 extract = await self._get_wikipedia_extract(entity, lang, sitelinks)
                 if extract:
                     wiki_page.data["extext"] = extract
+            except (aiohttp.ClientError, TimeoutError) as error:
+                logging.warning("Wikipedia extract fetch failed for %s: %s", entity, error)
 
-            # Only fetch images if requested - reuse sitelinks to avoid extra API call
-            if fetch_images:
+        if fetch_images:
+            try:
                 wikidata_images = await self._get_wikidata_images(entity)
                 wikipedia_images = await self._get_wikipedia_images(entity, lang, sitelinks)
                 # Limit total images for performance
                 all_images = wikidata_images + wikipedia_images
                 wiki_page._images = all_images[:max_images]  # pylint: disable=protected-access
-
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.debug("Error fetching page data for %s: %s", entity, error)
+            except (aiohttp.ClientError, TimeoutError) as error:
+                logging.warning("Wikipedia image fetch failed for %s: %s", entity, error)
 
         return wiki_page
 


### PR DESCRIPTION
Wikipedia, MusicBrainz (recording), Discogs (search), and fanart.tv previously stored an empty result whenever the upstream returned a transient error (HTTP 429, network failure, 5xx).  That cached "no data" then served the next 24 hours (Wikimedia) or 7 days (the others), so a single rate-limit hit during a set could blank out artist bios, images, and album metadata for the rest of the day.

Each provider now signals transient failures by returning None so the cache layer skips writing.  Legitimate "found but empty" results still get cached.  The 5.2.1 upgrade hook purges existing 5.2.0 entries for these providers so users start clean.

Also fills the 5.2.1 changelog gap from the post-5.2.0 commits the last CHANGELOG update missed (djay Pro ISRC, MusicBrainz release scoring improvements, wnpmb 0.3.0 behaviour) and adds ISRC to the djay Pro "Metadata provided" list.

## Summary by Sourcery

Prevent transient upstream API failures from being cached as permanent empty results and refresh the 5.2.1 changelog and djay Pro docs.

New Features:
- Include ISRC codes from djay Pro in exported track metadata.

Bug Fixes:
- Treat transient errors from Discogs search, MusicBrainz recording lookups, Wikimedia/Wikipedia, and fanart.tv as non-cacheable so temporary rate limits or network failures no longer blank metadata for extended periods.
- Purge existing 5.2.0 API cache entries for MusicBrainz, Wikimedia, and Discogs on upgrade to 5.2.1 to clear previously poisoned results.

Enhancements:
- Improve Wikipedia page fetching to distinguish hard failures from best-effort secondary fetches while preserving cacheable partial results.
- Clarify and expand the 5.2.1 changelog entries around external metadata provider behavior and MusicBrainz album selection improvements.

Documentation:
- Document ISRC support and other djay Pro metadata details in the djay Pro integration guide.