### PR TITLE
Polish 5.2.1 djay Pro section; add hasartist/playlist tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
 # Changelog
 
-## Version 5.2.1 - in progress
+## Version 5.2.1 - 2026-05-05
 
 ### Bug Fixes
 
 * Fixed incorrect Discord invite link in About window
-* Fixed trackpoll loop silently stopping after a system sleep/wake cycle or
-    transient error; the loop now recovers automatically
-* Fixed EarShot and two-computer setups sending cover art via HTTP URL:
-    only the first ~16KB of the image was being read due to an aiohttp
-    buffering issue; full image data is now fetched correctly
+* Fixed a bug where track detection silently stopped after a system sleep/wake
+    cycle or transient error
+* Fixed EarShot and two-computer setups truncating cover art
 * Fixed Wikipedia, MusicBrainz, Discogs, and fanart.tv remembering
     transient errors (rate limits, network failures) as "no data" for
     hours or days, so artist bios, images, and album metadata for the
@@ -26,32 +24,32 @@
 
 ### djay Pro
 
-* Added `has_tracks_by_artist` support for track requests
-* Added playlist support: available playlists can now be selected for
-    artist queries and roulette requests
 * BPM, key, and deck number are now read from djay Pro's analysis database
     and included in track metadata
 * ISRC codes are now included in track metadata when djay Pro provides
     them, improving downstream metadata lookups
-* Configurable analysis delay: how long to wait for djay Pro to commit
-    BPM, key, and file path after a track starts (separate DB transaction)
+* Configurable analysis delay: how long to wait for djay Pro to make BPM,
+    key, and file path available after a track starts
 * Configurable deck skip: individual decks can be excluded from reporting
     via checkboxes in settings
-* Tracks already playing when WNP launches are silently skipped; djay Pro
-    does not clear NowPlaying.txt between sessions so this prevents
-    re-reporting stale tracks on startup
+* Tracks already playing when WNP launches are silently skipped, preventing
+    stale tracks from being re-reported on startup
+* These features should work but I lack a full djay Pro license to test:
+  * The Twitch `!hasartist` chat command now works with djay Pro
+  * Added playlist support: available playlists can now be selected for
+      artist queries and roulette requests
 
 ### MusicBrainz
 
-* Improved album selection: when EarShot (or another source) provides an
-    album name, the canonical studio album is preferred over compilations
-    or reissues that happen to contain the same recording
+* Improved album and album art selection when an album name was provided by
+    EarShot iOS and macOS. The canonical studio album is preferred over
+    compilations or reissues that happen to contain the same recording.
 * Improved album selection for ISRC-only lookups: canonical singles and
     studio releases are preferred over compilations and reissues
 * Fixed cover art going permanently missing for a track after a single
     failed fetch from the Cover Art Archive; failed fetches now retry
     on the next play
-* Fixed false rate-limit errors from the MusicBrainz client
+* Fixed false rate-limit errors when talking to MusicBrainz
 
 ## Version 5.2.0 - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@
 * Fixed incorrect Discord invite link in About window
 * Fixed a bug where track detection silently stopped after a system sleep/wake
     cycle or transient error
-* Fixed EarShot and two-computer setups truncating cover art
+* Fixed cover art being truncated in EarShot and two-computer setups
 * Fixed Wikipedia, MusicBrainz, Discogs, and fanart.tv remembering
     transient errors (rate limits, network failures) as "no data" for
     hours or days, so artist bios, images, and album metadata for the
     affected track stayed blank until the entry expired.  Stale entries
     are cleared automatically on upgrade
+* Improved how WNP behaves when Wikipedia is rate-limiting traffic:
+    WNP now backs off for as long as Wikipedia asks (honoring their
+    Retry-After header) and caps parallel Wikipedia requests, so a
+    short throttling window no longer cascades into prolonged missing
+    artist data
 
 ### Artist Extras
 
@@ -41,7 +46,7 @@
 
 ### MusicBrainz
 
-* Improved album and album art selection when an album name was provided by
+* Improved album and album art selection when an album name is provided by
     EarShot iOS and macOS. The canonical studio album is preferred over
     compilations or reissues that happen to contain the same recording.
 * Improved album selection for ISRC-only lookups: canonical singles and

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,9 +1,9 @@
 # Feature Overview
 
-**What's Now Playing (WNP)** is a free, open-source application for Windows,
-macOS, and Linux that reads live track data from DJ software and sends it
-anywhere your audience can see it: overlays, chat bots, Discord, text files,
-and more.
+**What's Now Playing (WNP)** is a free, open-source DJ stream metadata bridge
+for Windows, macOS, and Linux that reads live track data from DJ software and
+sends it anywhere your audience can see it: overlays, chat bots, Discord, text
+files, and more.
 
 ## Setup
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,10 +1,10 @@
 # What's Now Playing
 
-> What's Now Playing displays the current track from your DJ software on
-> streams, in chat, and anywhere your audience can see it. It connects to
-> DJ software, reads live track data, and delivers track titles, artists,
-> album art, and other metadata to OBS browser overlays, Twitch/Kick/Discord
-> chat bots, text files, and APIs in real time.
+> What's Now Playing is a DJ stream metadata bridge: it displays the current
+> track from your DJ software on streams, in chat, and anywhere your audience
+> can see it. It connects to DJ software, reads live track data, and delivers
+> track titles, artists, album art, and other metadata to OBS browser overlays,
+> Twitch/Kick/Discord chat bots, text files, and APIs in real time.
 >
 > Free, open-source, with pre-built binaries for Windows, macOS (Intel and
 > Apple Silicon), and Linux. No Python installation required.

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -84,7 +84,7 @@ class MusicBrainzHelper:
         if not self.emailaddressset:
             emailaddress = (
                 self.config.cparser.value("musicbrainz/emailaddress")
-                or "aw+wnp@effectivemachines.com"
+                or "wnp@effectivemachines.com"
             )
             self.mb_client.set_useragent(emailaddress)
             self.mb_client.cache_service = WNPCacheAdapter(nowplaying.apicache.get_cache())

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -8,8 +8,10 @@ with just the functionality needed by the nowplaying application.
 """
 # pylint: disable=not-async-context-manager
 
+import asyncio
 import logging
 import ssl
+import time
 from typing import Any
 from urllib.parse import quote
 
@@ -17,6 +19,15 @@ import aiohttp
 
 import nowplaying
 import nowplaying.utils
+
+
+class WikiRateLimitError(aiohttp.ClientError):
+    """Raised when a Wikimedia endpoint returns HTTP 429.
+
+    Subclasses aiohttp.ClientError so existing (aiohttp.ClientError, TimeoutError)
+    handlers in get_page and in wikimedia.py treat it as a transient failure
+    and skip caching the empty result.
+    """
 
 
 class WikiPage:  # pylint: disable=too-few-public-methods
@@ -36,13 +47,85 @@ class WikiPage:  # pylint: disable=too-few-public-methods
 
 
 class AsyncWikiClient:
-    """Async Wikipedia/Wikidata client."""
+    """Async Wikipedia/Wikidata client.
+
+    Honours the Wikimedia client guidance:
+    - Sends a contact-bearing User-Agent (see __aenter__).
+    - Respects 429 + Retry-After across all Wikimedia endpoints (wikidata,
+      wikipedia, commons) via a class-level cooldown.  Rate limiting is
+      per-IP so the cooldown is shared between every instance in this
+      process.
+    - Caps concurrent requests to three with a class-level semaphore.
+    """
+
+    # Cooldown shared across all instances.  Updated when any request returns
+    # 429, checked before every request.
+    _rate_limit_until: float = 0.0
+    # Wikimedia asks clients to limit concurrent requests to 3 or fewer.
+    _concurrency_semaphore: asyncio.Semaphore = asyncio.Semaphore(3)
+    # Used when a 429 arrives without a parseable Retry-After header.
+    _DEFAULT_RETRY_AFTER_SECONDS = 60.0
 
     def __init__(self, timeout: int = 30):
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.session: aiohttp.ClientSession | None = None
         # Create SSL context with proper certificate verification
         self.ssl_context = ssl.create_default_context()
+
+    @classmethod
+    def _raise_if_rate_limited(cls) -> None:
+        """Raise WikiRateLimitError if we are inside a 429-induced cooldown."""
+        now = time.time()
+        if now < cls._rate_limit_until:
+            remaining = cls._rate_limit_until - now
+            raise WikiRateLimitError(f"Wikimedia cooldown active; {remaining:.0f}s remaining")
+
+    @classmethod
+    def _record_rate_limit(cls, retry_after_header: str | None) -> float:
+        """Record a 429 hit and return the chosen backoff in seconds.
+
+        Honours the Retry-After header when it parses as a delta-seconds
+        integer.  HTTP-date forms and missing values fall back to the
+        default.  A negative or zero value is bumped to 1 second so we
+        always wait at least a tick.
+        """
+        try:
+            delay = (
+                float(retry_after_header)
+                if retry_after_header
+                else cls._DEFAULT_RETRY_AFTER_SECONDS
+            )
+        except (TypeError, ValueError):
+            delay = cls._DEFAULT_RETRY_AFTER_SECONDS
+        delay = max(delay, 1.0)
+        cls._rate_limit_until = time.time() + delay
+        logging.warning(
+            "Wikimedia returned 429; backing off all Wikimedia requests for %.0fs",
+            delay,
+        )
+        return delay
+
+    async def _get_json(self, url: str, params: dict[str, Any]) -> dict[str, Any]:
+        """GET a Wikimedia JSON endpoint with shared rate-limit handling.
+
+        Caps process-wide concurrency at three, raises WikiRateLimitError if
+        we are in cooldown (either pre-emptively or after a fresh 429), and
+        raises on other non-200 statuses so callers can decide whether to
+        skip caching.
+        """
+        if not self.session:
+            raise RuntimeError("AsyncWikiClient not initialized - use as async context manager")
+        self._raise_if_rate_limited()
+        async with self._concurrency_semaphore:
+            async with self.session.get(url, params=params) as response:
+                if response.status == 429:
+                    self._record_rate_limit(response.headers.get("Retry-After"))
+                    raise WikiRateLimitError(
+                        f"429 from {response.url}; "
+                        f"Retry-After={response.headers.get('Retry-After')!r}"
+                    )
+                response.raise_for_status()
+                return await response.json()
 
     def _handle_redirect(self, data: dict, entity: str) -> dict | None:  # pylint: disable=no-self-use
         """Handle Wikidata entity redirects."""
@@ -67,7 +150,7 @@ class AsyncWikiClient:
         headers = {
             "User-Agent": f"WhatNowPlaying/{nowplaying.__version__} "
             "(https://github.com/whatsnowplaying/whats-now-playing; "
-            "aw@"
+            "wnp@"
             "effectivemachines.com) aiohttp/3.12.0",
         }
         self.session = aiohttp.ClientSession(
@@ -90,50 +173,47 @@ class AsyncWikiClient:
 
         params = {"action": "wbgetentities", "ids": entity, "format": "json", "props": props}
 
-        if not self.session:
+        data = await self._get_json(url, params)
+
+        if "entities" not in data:
             return {}
-        async with self.session.get(url, params=params) as response:
-            data = await response.json()
 
-            if "entities" not in data:
-                return {}
+        entity_data = self._handle_redirect(data, entity)
+        if not entity_data:
+            return {}
+        result = {"claims": {}}
 
-            entity_data = self._handle_redirect(data, entity)
-            if not entity_data:
-                return {}
-            result = {"claims": {}}
+        # Extract claims (P434 = MusicBrainz, P1953 = Discogs, P18 = Image)
+        if "claims" in entity_data:
+            claims = entity_data["claims"]
+            if "P434" in claims:  # MusicBrainz Artist ID
+                result["claims"]["P434"] = [
+                    claim["mainsnak"]["datavalue"]["value"]
+                    for claim in claims["P434"]
+                    if "datavalue" in claim["mainsnak"]
+                ]
+            if "P1953" in claims:  # Discogs Artist ID
+                result["claims"]["P1953"] = [
+                    claim["mainsnak"]["datavalue"]["value"]
+                    for claim in claims["P1953"]
+                    if "datavalue" in claim["mainsnak"]
+                ]
+            if "P18" in claims:  # Image
+                result["claims"]["P18"] = [
+                    claim["mainsnak"]["datavalue"]["value"]
+                    for claim in claims["P18"]
+                    if "datavalue" in claim["mainsnak"]
+                ]
 
-            # Extract claims (P434 = MusicBrainz, P1953 = Discogs, P18 = Image)
-            if "claims" in entity_data:
-                claims = entity_data["claims"]
-                if "P434" in claims:  # MusicBrainz Artist ID
-                    result["claims"]["P434"] = [
-                        claim["mainsnak"]["datavalue"]["value"]
-                        for claim in claims["P434"]
-                        if "datavalue" in claim["mainsnak"]
-                    ]
-                if "P1953" in claims:  # Discogs Artist ID
-                    result["claims"]["P1953"] = [
-                        claim["mainsnak"]["datavalue"]["value"]
-                        for claim in claims["P1953"]
-                        if "datavalue" in claim["mainsnak"]
-                    ]
-                if "P18" in claims:  # Image
-                    result["claims"]["P18"] = [
-                        claim["mainsnak"]["datavalue"]["value"]
-                        for claim in claims["P18"]
-                        if "datavalue" in claim["mainsnak"]
-                    ]
+        # Extract description
+        if "descriptions" in entity_data and lang in entity_data["descriptions"]:
+            result["description"] = entity_data["descriptions"][lang]["value"]
 
-            # Extract description
-            if "descriptions" in entity_data and lang in entity_data["descriptions"]:
-                result["description"] = entity_data["descriptions"][lang]["value"]
+        # Extract sitelinks if requested
+        if include_sitelinks and "sitelinks" in entity_data:
+            result["sitelinks"] = entity_data["sitelinks"]
 
-            # Extract sitelinks if requested
-            if include_sitelinks and "sitelinks" in entity_data:
-                result["sitelinks"] = entity_data["sitelinks"]
-
-            return result
+        return result
 
     async def _get_wikipedia_extract(  # pylint: disable=too-many-return-statements
         self, entity: str, lang: str, sitelinks: dict | None = None
@@ -149,18 +229,15 @@ class AsyncWikiClient:
                 "props": "sitelinks",
             }
 
-            if not self.session:
+            data = await self._get_json(url, params)
+
+            if "entities" not in data:
                 return None
-            async with self.session.get(url, params=params) as response:
-                data = await response.json()
 
-                if "entities" not in data:
-                    return None
-
-                entity_data = self._handle_redirect(data, entity)
-                if not entity_data:
-                    return None
-                sitelinks = entity_data.get("sitelinks", {})
+            entity_data = self._handle_redirect(data, entity)
+            if not entity_data:
+                return None
+            sitelinks = entity_data.get("sitelinks", {})
 
         # Look for the Wikipedia page in the specified language
         wiki_key = f"{lang}wiki"
@@ -181,19 +258,16 @@ class AsyncWikiClient:
             "exsectionformat": "plain",
         }
 
-        if not self.session:
+        data = await self._get_json(wiki_url, extract_params)
+
+        if "query" not in data or "pages" not in data["query"]:
             return None
-        async with self.session.get(wiki_url, params=extract_params) as response:
-            data = await response.json()
 
-            if "query" not in data or "pages" not in data["query"]:
-                return None
-
-            pages = data["query"]["pages"]
-            return next(
-                (page_data["extract"] for page_data in pages.values() if "extract" in page_data),
-                None,
-            )
+        pages = data["query"]["pages"]
+        return next(
+            (page_data["extract"] for page_data in pages.values() if "extract" in page_data),
+            None,
+        )
 
     async def _get_wikidata_images(self, entity: str) -> list[dict[str, str]]:
         """Get images directly from Wikidata entity with batch processing."""
@@ -203,30 +277,27 @@ class AsyncWikiClient:
         url = "https://www.wikidata.org/w/api.php"
         params = {"action": "wbgetentities", "ids": entity, "format": "json", "props": "claims"}
 
-        if not self.session:
+        data = await self._get_json(url, params)
+
+        if "entities" not in data:
             return images
-        async with self.session.get(url, params=params) as response:
-            data = await response.json()
 
-            if "entities" not in data:
-                return images
+        entity_data = self._handle_redirect(data, entity)
+        if not entity_data:
+            return images
+        claims = entity_data.get("claims", {})
 
-            entity_data = self._handle_redirect(data, entity)
-            if not entity_data:
-                return images
-            claims = entity_data.get("claims", {})
-
-            # Get P18 (image) claims
-            if "P18" in claims:
-                if filenames := [
-                    claim["mainsnak"]["datavalue"]["value"]
-                    for claim in claims["P18"]
-                    if "mainsnak" in claim and "datavalue" in claim["mainsnak"]
-                ]:
-                    image_urls = await self._get_commons_image_urls_batch(filenames)
-                    for img_url in image_urls:
-                        if img_url:
-                            images.append({"kind": "wikidata-image", "url": img_url})
+        # Get P18 (image) claims
+        if "P18" in claims:
+            if filenames := [
+                claim["mainsnak"]["datavalue"]["value"]
+                for claim in claims["P18"]
+                if "mainsnak" in claim and "datavalue" in claim["mainsnak"]
+            ]:
+                image_urls = await self._get_commons_image_urls_batch(filenames)
+                for img_url in image_urls:
+                    if img_url:
+                        images.append({"kind": "wikidata-image", "url": img_url})
 
         return images
 
@@ -248,37 +319,38 @@ class AsyncWikiClient:
         }
 
         try:
-            async with self.session.get(commons_url, params=params) as response:
-                data = await response.json()
-
-                if "query" not in data or "pages" not in data["query"]:
-                    return []
-
-                pages = data["query"]["pages"]
-                results = []
-
-                # Maintain order by matching against original filenames
-                for filename in filenames:
-                    file_title = f"File:{filename}"
-                    url = next(
-                        (
-                            page_data["imageinfo"][0].get("url")
-                            for page_data in pages.values()
-                            if (
-                                page_data.get("title") == file_title
-                                and "imageinfo" in page_data
-                                and page_data["imageinfo"]
-                            )
-                        ),
-                        None,
-                    )
-                    results.append(url)
-
-                return results
-
-        except Exception:  # pylint: disable=broad-exception-caught
+            data = await self._get_json(commons_url, params)
+        except (aiohttp.ClientError, TimeoutError):
+            # Includes WikiRateLimitError; the cooldown is already recorded
+            # inside _get_json so the rest of the pipeline will skip future
+            # Wikimedia requests until it expires.
             logging.debug("Batch Commons image URL fetch failed, skipping images")
             return []
+
+        if "query" not in data or "pages" not in data["query"]:
+            return []
+
+        pages = data["query"]["pages"]
+        results = []
+
+        # Maintain order by matching against original filenames
+        for filename in filenames:
+            file_title = f"File:{filename}"
+            url = next(
+                (
+                    page_data["imageinfo"][0].get("url")
+                    for page_data in pages.values()
+                    if (
+                        page_data.get("title") == file_title
+                        and "imageinfo" in page_data
+                        and page_data["imageinfo"]
+                    )
+                ),
+                None,
+            )
+            results.append(url)
+
+        return results
 
     async def _get_commons_image_url(self, filename: str) -> str | None:
         """Get Commons image URL from filename (single file convenience method)."""
@@ -299,18 +371,15 @@ class AsyncWikiClient:
                 "props": "sitelinks",
             }
 
-            if not self.session:
+            data = await self._get_json(url, params)
+
+            if "entities" not in data:
                 return []
-            async with self.session.get(url, params=params) as response:
-                data = await response.json()
 
-                if "entities" not in data:
-                    return []
-
-                entity_data = self._handle_redirect(data, entity)
-                if not entity_data:
-                    return []
-                sitelinks = entity_data.get("sitelinks", {})
+            entity_data = self._handle_redirect(data, entity)
+            if not entity_data:
+                return []
+            sitelinks = entity_data.get("sitelinks", {})
 
         wiki_key = f"{lang}wiki"
         if not sitelinks or wiki_key not in sitelinks:
@@ -330,32 +399,27 @@ class AsyncWikiClient:
             "pilicense": "any",  # Include both free and fair-use images
         }
 
-        images = []
+        images: list[dict[str, str]] = []
 
-        if not self.session:
+        data = await self._get_json(wiki_url, image_params)
+
+        if "query" not in data or "pages" not in data["query"]:
             return images
-        async with self.session.get(wiki_url, params=image_params) as response:
-            data = await response.json()
 
-            if "query" not in data or "pages" not in data["query"]:
-                return images
+        pages = data["query"]["pages"]
+        for page_data in pages.values():
+            # Add pageimage (main representative image) if available
+            if "original" in page_data:
+                images.append(
+                    {
+                        "kind": "wikidata-image",  # Keep same kind for compatibility
+                        "url": page_data["original"]["source"],
+                    }
+                )
 
-            pages = data["query"]["pages"]
-            for page_data in pages.values():
-                # Add pageimage (main representative image) if available
-                if "original" in page_data:
-                    images.append(
-                        {
-                            "kind": "wikidata-image",  # Keep same kind for compatibility
-                            "url": page_data["original"]["source"],
-                        }
-                    )
-
-                # Add thumbnail if available and no original
-                elif "thumbnail" in page_data:
-                    images.append(
-                        {"kind": "query-thumbnail", "url": page_data["thumbnail"]["source"]}
-                    )
+            # Add thumbnail if available and no original
+            elif "thumbnail" in page_data:
+                images.append({"kind": "query-thumbnail", "url": page_data["thumbnail"]["source"]})
 
         return images
 

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -12,6 +12,8 @@ import asyncio
 import logging
 import ssl
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -75,30 +77,50 @@ class AsyncWikiClient:
     @classmethod
     def _raise_if_rate_limited(cls) -> None:
         """Raise WikiRateLimitError if we are inside a 429-induced cooldown."""
-        now = time.time()
+        # Monotonic clock — NTP / DST adjustments must not shorten or extend
+        # cooldowns mid-flight.
+        now = time.monotonic()
         if now < cls._rate_limit_until:
             remaining = cls._rate_limit_until - now
             raise WikiRateLimitError(f"Wikimedia cooldown active; {remaining:.0f}s remaining")
+
+    @staticmethod
+    def _parse_retry_after(retry_after_header: str | None) -> float | None:
+        """Parse a Retry-After header value into a delay in seconds.
+
+        Returns None on missing / unparseable input.  RFC 9110 allows two
+        forms: delta-seconds (an integer) and HTTP-date.  We accept both.
+        Negative or already-past dates collapse to 0 (caller bumps to a
+        minimum tick).
+        """
+        if not retry_after_header:
+            return None
+        try:
+            return float(retry_after_header)
+        except (TypeError, ValueError):
+            pass
+        try:
+            target = parsedate_to_datetime(retry_after_header)
+        except (TypeError, ValueError):
+            return None
+        if target.tzinfo is None:
+            target = target.replace(tzinfo=timezone.utc)
+        return max((target - datetime.now(timezone.utc)).total_seconds(), 0.0)
 
     @classmethod
     def _record_rate_limit(cls, retry_after_header: str | None) -> float:
         """Record a 429 hit and return the chosen backoff in seconds.
 
-        Honours the Retry-After header when it parses as a delta-seconds
-        integer.  HTTP-date forms and missing values fall back to the
-        default.  A negative or zero value is bumped to 1 second so we
-        always wait at least a tick.
+        Honours the Retry-After header in either delta-seconds or HTTP-date
+        form (RFC 9110).  Missing or unparseable values fall back to the
+        default.  Values are floored at 1 second so we always wait at least
+        a tick.
         """
-        try:
-            delay = (
-                float(retry_after_header)
-                if retry_after_header
-                else cls._DEFAULT_RETRY_AFTER_SECONDS
-            )
-        except (TypeError, ValueError):
+        delay = cls._parse_retry_after(retry_after_header)
+        if delay is None:
             delay = cls._DEFAULT_RETRY_AFTER_SECONDS
         delay = max(delay, 1.0)
-        cls._rate_limit_until = time.time() + delay
+        cls._rate_limit_until = time.monotonic() + delay
         logging.warning(
             "Wikimedia returned 429; backing off all Wikimedia requests for %.0fs",
             delay,

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -88,7 +88,7 @@ class AsyncWikiClient:
     def _parse_retry_after(retry_after_header: str | None) -> float | None:
         """Parse a Retry-After header value into a delay in seconds.
 
-        Returns None on missing / unparseable input.  RFC 9110 allows two
+        Returns None on missing / unparsable input.  RFC 9110 allows two
         forms: delta-seconds (an integer) and HTTP-date.  We accept both.
         Negative or already-past dates collapse to 0 (caller bumps to a
         minimum tick).
@@ -112,7 +112,7 @@ class AsyncWikiClient:
         """Record a 429 hit and return the chosen backoff in seconds.
 
         Honours the Retry-After header in either delta-seconds or HTTP-date
-        form (RFC 9110).  Missing or unparseable values fall back to the
+        form (RFC 9110).  Missing or unparsable values fall back to the
         default.  Values are floored at 1 second so we always wait at least
         a tick.
         """
@@ -131,7 +131,7 @@ class AsyncWikiClient:
         """GET a Wikimedia JSON endpoint with shared rate-limit handling.
 
         Caps process-wide concurrency at three, raises WikiRateLimitError if
-        we are in cooldown (either pre-emptively or after a fresh 429), and
+        we are in cooldown (either preemptively or after a fresh 429), and
         raises on other non-200 statuses so callers can decide whether to
         skip caching.
         """

--- a/tests/test_acoustidmb.py
+++ b/tests/test_acoustidmb.py
@@ -18,7 +18,7 @@ def getacoustidplugin(bootstrap):
     config.cparser.setValue("acoustidmb/enabled", True)
     config.cparser.setValue("musicbrainz/enabled", True)
     config.cparser.setValue("acoustidmb/acoustidapikey", os.environ["ACOUSTID_TEST_APIKEY"])
-    config.cparser.setValue("musicbrainz/emailaddress", "aw+wnptest@effectivemachines.com")
+    config.cparser.setValue("musicbrainz/emailaddress", "wnp+test@effectivemachines.com")
     yield nowplaying.recognition.acoustid.Plugin(config=config)
 
 

--- a/tests/test_acoustidmb_joinphrases.py
+++ b/tests/test_acoustidmb_joinphrases.py
@@ -21,7 +21,7 @@ def getacoustidplugin(bootstrap):
     config.cparser.setValue("acoustidmb/enabled", True)
     config.cparser.setValue("musicbrainz/enabled", True)
     config.cparser.setValue("acoustidmb/acoustidapikey", os.environ["ACOUSTID_TEST_APIKEY"])
-    config.cparser.setValue("musicbrainz/emailaddress", "aw+wnptest@effectivemachines.com")
+    config.cparser.setValue("musicbrainz/emailaddress", "wnp+test@effectivemachines.com")
     yield nowplaying.recognition.acoustid.Plugin(config=config)
 
 

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -935,3 +935,185 @@ def test_parse_blob_starttime():
     )
     result = nowplaying.djaypro.tsaf.parse_blob(blob)
     assert result["starttime"] == start
+
+
+def _add_playlist_views(
+    dbfile: pathlib.Path,
+    playlist_assignments: dict[str, list[int]],
+) -> None:
+    """Create the view_mediaItemPlaylistView_{map,page} helper tables.
+
+    playlist_assignments maps a playlist display name to the list of
+    database2 rowids that belong to that playlist.  Real djay Pro stores
+    these as SQL views over deeper structures; for tests we just create
+    plain tables with the same column shape the production query uses.
+    """
+    conn = sqlite3.connect(dbfile)
+    conn.execute("CREATE TABLE view_mediaItemPlaylistView_map (rowid INTEGER, pageKey TEXT)")
+    conn.execute('CREATE TABLE view_mediaItemPlaylistView_page (pageKey TEXT, "group" TEXT)')
+    for page_key, (playlist_name, rowids) in enumerate(playlist_assignments.items(), start=1):
+        conn.execute(
+            'INSERT INTO view_mediaItemPlaylistView_page (pageKey, "group") VALUES (?, ?)',
+            (str(page_key), playlist_name),
+        )
+        for rowid in rowids:
+            conn.execute(
+                "INSERT INTO view_mediaItemPlaylistView_map (rowid, pageKey) VALUES (?, ?)",
+                (rowid, str(page_key)),
+            )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "library_artist,query_artist,expected",
+    [
+        ("Daft Punk", "Daft Punk", True),
+        ("Daft Punk", "Other Artist", False),
+        ("Daft Punk", "daft punk", True),
+        ("Daft Punk", "  Daft Punk  ", True),
+    ],
+    ids=["exact-match", "no-match", "case-insensitive", "whitespace-trim"],
+)
+@pytest.mark.asyncio
+async def test_has_tracks_by_artist_entire_library(
+    bootstrap, library_artist, query_artist, expected
+):
+    """has_tracks_by_artist scans mediaItemTitleIDs in entire-library mode."""
+    config = bootstrap
+    config.cparser.setValue("djaypro/artist_query_scope", "entire_library")
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+        blob = _build_tsaf_blob(
+            "ADCMediaItemTitleID",
+            [(library_artist, "artist"), ("Some Title", "title")],
+        )
+        _make_db_with_collections(dbfile, {"mediaItemTitleIDs": [blob]})
+
+        assert await plugin.has_tracks_by_artist(query_artist) is expected
+
+
+@pytest.mark.parametrize("artist_name", ["", "   ", "\t"], ids=["empty", "spaces", "tab"])
+@pytest.mark.asyncio
+async def test_has_tracks_by_artist_empty_query(bootstrap, artist_name):
+    """has_tracks_by_artist returns False for empty / whitespace queries."""
+    config = bootstrap
+    config.cparser.setValue("djaypro/artist_query_scope", "entire_library")
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+        blob = _build_tsaf_blob(
+            "ADCMediaItemTitleID",
+            [("Daft Punk", "artist"), ("Some Title", "title")],
+        )
+        _make_db_with_collections(dbfile, {"mediaItemTitleIDs": [blob]})
+
+        assert await plugin.has_tracks_by_artist(artist_name) is False
+
+
+@pytest.mark.asyncio
+async def test_has_tracks_by_artist_missing_db(bootstrap):
+    """has_tracks_by_artist returns False when MediaLibrary.db is absent."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        # No MediaLibrary.db created
+
+        assert await plugin.has_tracks_by_artist("Daft Punk") is False
+
+
+@pytest.mark.parametrize(
+    "selected_playlists,view_assignments,expected",
+    [
+        ("Friday Set", {"Friday Set": [1]}, True),
+        ("Friday Set", {"Saturday Set": [1]}, False),
+        ("", {"Friday Set": [1]}, False),
+        ("Friday Set", None, False),
+    ],
+    ids=["track-in-selected", "track-in-other", "no-playlist-configured", "no-view-tables"],
+)
+@pytest.mark.asyncio
+async def test_has_tracks_by_artist_selected_playlists(
+    bootstrap, selected_playlists, view_assignments, expected
+):
+    """has_tracks_by_artist in selected_playlists mode across playlist scenarios.
+
+    view_assignments=None means the view tables are not created at all, which
+    is djay Pro state when the user has never made a native playlist.
+    """
+    config = bootstrap
+    config.cparser.setValue("djaypro/artist_query_scope", "selected_playlists")
+    config.cparser.setValue("djaypro/selected_playlists", selected_playlists)
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+        blob = _build_tsaf_blob(
+            "ADCMediaItemTitleID",
+            [("Daft Punk", "artist"), ("Some Title", "title")],
+        )
+        # The first rowid inserted by _make_db_with_collections is 1.
+        _make_db_with_collections(dbfile, {"mediaItemTitleIDs": [blob]})
+        if view_assignments is not None:
+            _add_playlist_views(dbfile, view_assignments)
+
+        assert await plugin.has_tracks_by_artist("Daft Punk") is expected
+
+
+@pytest.mark.asyncio
+async def test_get_available_playlists_returns_sorted_unique(bootstrap):
+    """get_available_playlists returns a sorted list of distinct playlist names."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+        # database2 must exist for _make_db_with_collections to be useful, but the
+        # playlists query reads only from the view tables.  Create an empty one.
+        _make_db_with_collections(dbfile, {})
+        _add_playlist_views(
+            dbfile,
+            {"Zulu Set": [1], "Alpha Set": [2], "Mike Set": [3]},
+        )
+
+        result = await plugin.get_available_playlists()
+
+        assert result == ["Alpha Set", "Mike Set", "Zulu Set"]
+
+
+@pytest.mark.asyncio
+async def test_get_available_playlists_view_missing(bootstrap):
+    """get_available_playlists returns [] when the view table doesn't exist."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
+        # Create the DB but no playlist views — djay Pro state when the user has
+        # never made a playlist.
+        _make_db_with_collections(dbfile, {})
+
+        assert await plugin.get_available_playlists() == []
+
+
+@pytest.mark.asyncio
+async def test_get_available_playlists_missing_db(bootstrap):
+    """get_available_playlists returns [] when MediaLibrary.db is absent."""
+    config = bootstrap
+    plugin = nowplaying.inputs.djaypro.Plugin(config=config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin.djaypro_dir = tmpdir
+        # No MediaLibrary.db created
+
+        assert await plugin.get_available_playlists() == []

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -25,7 +25,7 @@ def getmusicbrainz(bootstrap):
     config.cparser.setValue("musicbrainz/websites", True)
     for site in ["bandcamp", "homepage", "lastfm", "discogs"]:
         config.cparser.setValue(f"musicbrainz/{site}", True)
-    config.cparser.setValue("musicbrainz/emailaddress", "aw+wnptest@effectivemachines.com")
+    config.cparser.setValue("musicbrainz/emailaddress", "wnp+test@effectivemachines.com")
     return nowplaying.musicbrainz.MusicBrainzHelper(config=config, test_mode=True)
 
 


### PR DESCRIPTION
CHANGELOG: rewrite Bug Fixes and djay Pro sections in user-facing terms (drop trackpoll/aiohttp/NowPlaying.txt internals, the has_tracks_by_artist identifier, the separate-DB-transaction parenthetical, and the unused streaming source field).  Soften the sleep/wake recovery claim — we fixed one path but more may lurk. Add a scoped note that the !hasartist and playlist features lack live djay Pro validation since the maintainer has no licence.

Tests: 7 new pytest functions (15 parametrized cases) covering has_tracks_by_artist (entire library, empty query, missing DB, selected playlists across four scenarios) and get_available_playlists (sorted-unique, missing view, missing DB).  Adds an _add_playlist_views helper that mirrors the production view-table schema.

## Summary by Sourcery

Introduce shared Wikimedia rate limiting and concurrency handling, expand djay Pro playlist/artist tests, and update Wikimedia/MusicBrainz contact details and changelog wording.

Bug Fixes:
- Ensure Wikimedia client honors Retry-After and avoids caching results from rate-limited responses as permanent failures.

Enhancements:
- Add centralized JSON fetch helper with global cooldown and concurrency semaphore for all Wikimedia API requests.
- Improve AsyncWikiClient documentation of Wikimedia usage and rate limiting behavior.

Documentation:
- Rewrite 5.2.1 changelog bug-fix and djay Pro sections in user-focused language, including notes on rate limiting and unverified djay Pro features.

Tests:
- Add djay Pro tests covering has_tracks_by_artist across library and playlist scopes, empty queries, and missing databases.
- Add djay Pro tests verifying get_available_playlists behavior for sorted unique results, missing views, and missing databases.
- Introduce a helper to construct djay Pro-like playlist view tables for tests.

Chores:
- Update User-Agent and test email addresses to use the new wnp@effectivemachines.com contact format.