### PR TITLE
Mock out test_wikimedia_api_call_count

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,8 @@
 **What's Now Playing (WNP)** is a free, open-source DJ stream metadata bridge
 for Windows, macOS, and Linux that reads live track data from DJ software and
 sends it anywhere your audience can see it: overlays, chat bots, Discord, text
-files, and more.
+files, and more. It is used by everyone from hobby Twitch streamers to
+professional event DJs and internet radio stations.
 
 ## Setup
 
@@ -94,19 +95,24 @@ For tracks that are untagged or missing metadata:
 * **[MusicBrainz](recognition/musicbrainz.md)** — look up detailed track and artist metadata by fingerprint
   or ID
 
-## Artist Data Enrichment
+## Cover Art and Artist Enrichment
 
-WNP can automatically fetch additional artist information to enhance displays:
+WNP automatically downloads cover art and artist images as each track plays —
+no manual uploads or per-track tagging required.  Sources are queried in
+priority order; the first provider with usable data wins.  Multiple providers
+can be enabled together for fallback coverage.
 
-* **[Discogs](extras/discogs.md)** — artist biographies, images, and album cover art
-* **[TheAudioDB](extras/theaudiodb.md)** — artist biographies, images, and album art (free tier
-  available without API key)
-* **[FanArt.TV](extras/fanarttv.md)** — high-quality fan art, artist logos, background images,
-  and album cover art
-* **[Wikimedia / Wikipedia](extras/wikimedia.md)** — artist biographies and images
-* **[Last.fm](extras/lastfm.md)** — album art lookup
-* **[MusicBrainz](recognition/musicbrainz.md)** — artist website links, IDs, relationship data,
-  and album cover art via Cover Art Archive
+| Source                                              | Bio | Artist images | Cover art | API key  |
+| --------------------------------------------------- | --- | ------------- | --------- | -------- |
+| **[Cover Art Archive](recognition/musicbrainz.md)** |     |               | ✓         | none     |
+| **[Wikimedia / Wikipedia](extras/wikimedia.md)**    | ✓   | ✓             |           | none     |
+| **[TheAudioDB](extras/theaudiodb.md)**              | ✓   | ✓             | ✓         | bundled  |
+| **[Discogs](extras/discogs.md)**                    | ✓   | ✓             | ✓         | free\*   |
+| **[FanArt.TV](extras/fanarttv.md)**                 |     | ✓ (HD)        | ✓         | free\*   |
+| **[Last.fm](extras/lastfm.md)**                     |     |               | ✓         | free\*   |
+
+\* Free signup required for an API key.  Last.fm's free tier is
+non-commercial; commercial broadcasters should consult their licence.
 
 Artist biographies are deduplicated per session; the same bio will not be
 shown twice during a stream.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,9 +2,11 @@
 
 > What's Now Playing is a DJ stream metadata bridge: it displays the current
 > track from your DJ software on streams, in chat, and anywhere your audience
-> can see it. It connects to DJ software, reads live track data, and delivers
-> track titles, artists, album art, and other metadata to OBS browser overlays,
-> Twitch/Kick/Discord chat bots, text files, and APIs in real time.
+> can see it. It is used by everyone from hobby Twitch streamers to
+> professional event DJs and internet radio stations. It connects to DJ
+> software, reads live track data, and delivers track titles, artists, album
+> art, and other metadata to OBS browser overlays, Twitch/Kick/Discord chat
+> bots, text files, and APIs in real time.
 >
 > Free, open-source, with pre-built binaries for Windows, macOS (Intel and
 > Apple Silicon), and Linux. No Python installation required.

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -787,16 +787,24 @@ async def test_wikimedia_api_call_count(bootstrap, isolated_api_cache):  # pylin
             "artistwebsites": ["https://www.wikidata.org/wiki/Q11647"],
         }
 
-        # Mock the actual Wikipedia API call to count calls
+        # Mock the actual Wikipedia API call to count calls.  This test
+        # verifies that the apicache layer short-circuits the second
+        # download_async; it is not testing Wikipedia's response.  Using a
+        # synthetic WikiPage (instead of delegating to the real network call)
+        # keeps the test deterministic when Wikipedia is rate-limiting CI.
         original_get_page = nowplaying.wikiclient.get_page_async
         api_call_count = 0
 
-        async def mock_get_page_async(*args, **kwargs):
+        async def mock_get_page_async(*args, **kwargs):  # pylint: disable=unused-argument
             nonlocal api_call_count
             api_call_count += 1
             logging.debug("Mock Wikipedia API call #%d", api_call_count)
-            # Call the original method to get real data
-            return await original_get_page(*args, **kwargs)
+            page = nowplaying.wikiclient.WikiPage(entity="Q11647", lang="en")
+            page.data = {
+                "claims": {},
+                "description": "American industrial rock band",
+            }
+            return page
 
         # Replace the method with our mock
         nowplaying.wikiclient.get_page_async = mock_get_page_async


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update the Wikimedia API call count test to use a synthetic WikiPage instead of real network calls, making the test deterministic and independent of external rate limiting.