### PR TITLE
Pull popup windows to front via new focus_window helper

### DIFF
--- a/nowplaying/kick/settings.py
+++ b/nowplaying/kick/settings.py
@@ -13,6 +13,7 @@ import nowplaying.config
 import nowplaying.kick.oauth2
 import nowplaying.kick.utils
 import nowplaying.preview.textwindow
+import nowplaying.utils.qt
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.kick.constants import (
     ACCESS_TOKEN_KEY,
@@ -249,8 +250,7 @@ class KickChatSettings:
                 enable_select_button=True,
             )
             self._textpreview_window.template_selected.connect(self._on_announce_template_selected)
-        self._textpreview_window.show()
-        self._textpreview_window.raise_()
+        nowplaying.utils.qt.focus_window(self._textpreview_window)
 
     @Slot(str)
     def _on_announce_template_selected(self, template_name: str) -> None:

--- a/nowplaying/obs/exportdialog.py
+++ b/nowplaying/obs/exportdialog.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
 
 import nowplaying.obs.scenebuilder
 import nowplaying.preview.window
+import nowplaying.utils.qt
 
 logger = logging.getLogger(__name__)
 
@@ -167,9 +168,7 @@ class OBSExportDialog(QDialog):  # pylint: disable=too-few-public-methods,too-ma
                 if idx >= 0:
                     self._preview_window.template_combo.setCurrentIndex(idx)
 
-            self._preview_window.show()
-            self._preview_window.raise_()
-            self._preview_window.activateWindow()
+            nowplaying.utils.qt.focus_window(self._preview_window)
 
         return _handler
 

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -39,6 +39,7 @@ import nowplaying.hostmeta
 import nowplaying.musicbrainz.plugin
 import nowplaying.settings.categories
 import nowplaying.settings.tabs
+import nowplaying.utils.qt
 from nowplaying.exceptions import PluginVerifyError
 
 try:
@@ -1069,8 +1070,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             )
             window.template_selected.connect(on_selected)
             setattr(self, attr, window)
-        window.show()
-        window.raise_()
+        nowplaying.utils.qt.focus_window(window)
 
     @Slot()
     def on_discordbot_template_preview_button(self):
@@ -1124,9 +1124,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
                 config=self.config, enable_select_button=True
             )
             self._webpreview_window.template_selected.connect(self._on_webserver_template_selected)
-        self._webpreview_window.show()
-        self._webpreview_window.raise_()
-        self._webpreview_window.activateWindow()
+        nowplaying.utils.qt.focus_window(self._webpreview_window)
 
     @Slot(str)
     def _on_webserver_template_selected(self, template_name: str) -> None:
@@ -1453,8 +1451,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         if self.tray:
             self.tray.settings_action.setEnabled(False)
         if self.qtui:
-            self.qtui.show()
-            self.qtui.setFocus()
+            nowplaying.utils.qt.focus_window(self.qtui)
         # UI is already populated during initialization, no need to update on show
         # Only update if UI hasn't been populated yet (fallback)
         if not self.ui_populated:

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -1450,8 +1450,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         """show the system tray"""
         if self.tray:
             self.tray.settings_action.setEnabled(False)
-        if self.qtui:
-            nowplaying.utils.qt.focus_window(self.qtui)
+        nowplaying.utils.qt.focus_window(self.qtui)
         # UI is already populated during initialization, no need to update on show
         # Only update if UI hasn't been populated yet (fallback)
         if not self.ui_populated:

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -35,6 +35,7 @@ import nowplaying.subprocesses
 import nowplaying.trackrequests
 import nowplaying.twitch.chat
 import nowplaying.utils.charts_api
+import nowplaying.utils.qt
 
 LASTANNOUNCED: dict[str, str | None] = {"artist": None, "title": None}
 
@@ -183,9 +184,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             self._obs_export_dialog = nowplaying.obs.exportdialog.OBSExportDialog(
                 config=self.config
             )
-        self._obs_export_dialog.show()
-        self._obs_export_dialog.raise_()
-        self._obs_export_dialog.activateWindow()
+        nowplaying.utils.qt.focus_window(self._obs_export_dialog)
 
     def _show_settings(self) -> None:
         """Show settings window and bring it to the front."""
@@ -193,11 +192,8 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             return
         self.config.get()
         self.settingswindow.update_all_oauth_status()
+        # The wrapper's show() runs focus_window on qtui internally.
         self.settingswindow.show()
-        if self.settingswindow.qtui:
-            self.settingswindow.qtui.raise_()
-            self.settingswindow.qtui.activateWindow()
-            self.settingswindow.qtui.setFocus()
 
     @staticmethod
     def _open_documentation() -> None:
@@ -446,7 +442,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             f"Critical error: Failed to load {ui_file}. "
             "Installation appears corrupt. Please reinstall the application."
         )
-        msgbox.show()
+        nowplaying.utils.qt.focus_window(msgbox)
         msgbox.exec()
         if app := QApplication.instance():
             app.exit(1)
@@ -671,14 +667,14 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             self.config.cparser.remove("settings/input")
             msgbox = QErrorMessage()
             msgbox.showMessage(f"Configured source {plugin} is not supported. Reconfiguring.")
-            msgbox.show()
+            nowplaying.utils.qt.focus_window(msgbox)
             msgbox.exec()
         elif not plugin:
             msgbox = QMessageBox()
             msgbox.setText(
                 "New installation! Thanks! Determining setup. This operation may take a bit!"
             )
-            msgbox.show()
+            nowplaying.utils.qt.focus_window(msgbox)
             msgbox.exec()
         else:
             return
@@ -700,7 +696,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             " Please check the Source is correct for"
             " your DJ software."
         )
-        msgbox.show()
+        nowplaying.utils.qt.focus_window(msgbox)
         msgbox.exec()
 
         self._show_settings()

--- a/nowplaying/twitch/settings.py
+++ b/nowplaying/twitch/settings.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import QApplication, QMessageBox  # pylint: disable=no-na
 
 import nowplaying.preview.textwindow
 import nowplaying.twitch.oauth2
+import nowplaying.utils.qt
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.twitch.constants import (
     BROADCASTER_OAUTH_STATUS_KEY,
@@ -265,8 +266,7 @@ class TwitchSettings:
         current = pathlib.Path(self.widget.streamtitle_lineedit.text()).name
         if current:
             self._streamtitle_preview_window.select_template(current)
-        self._streamtitle_preview_window.show()
-        self._streamtitle_preview_window.raise_()
+        nowplaying.utils.qt.focus_window(self._streamtitle_preview_window)
 
     @Slot(str)
     def _on_streamtitle_template_selected(self, template_name: str) -> None:

--- a/nowplaying/upgrades/config.py
+++ b/nowplaying/upgrades/config.py
@@ -19,6 +19,7 @@ import nowplaying.apicache
 import nowplaying.artistextras.theaudiodb
 import nowplaying.trackrequests
 import nowplaying.utils.config_json
+import nowplaying.utils.qt
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
 
 from . import Version
@@ -77,6 +78,7 @@ class UpgradeConfig:
                 "Your old directory will remain as a backup."
             )
             msgbox.setStandardButtons(QMessageBox.Ok)
+            nowplaying.utils.qt.focus_window(msgbox)
             msgbox.exec()
 
             try:
@@ -597,7 +599,7 @@ class UpgradeConfig:
             if not self.testdir:
                 msgbox = QMessageBox()
                 msgbox.setText("M3U has been converted to VirtualDJ.")
-                msgbox.show()
+                nowplaying.utils.qt.focus_window(msgbox)
                 msgbox.exec()
 
     @staticmethod

--- a/nowplaying/upgrades/templates.py
+++ b/nowplaying/upgrades/templates.py
@@ -12,6 +12,8 @@ from PySide6.QtCore import (  # pylint: disable=no-name-in-module
 )
 from PySide6.QtWidgets import QMessageBox  # pylint: disable=no-name-in-module
 
+import nowplaying.utils.qt
+
 # Import unified checksum function and exclusion list
 from nowplaying.utils.checksum import EXCLUDED_FILES, checksum
 
@@ -48,7 +50,7 @@ class UpgradeTemplates:
             msgbox.setText("Updated templates have been placed.")
             msgbox.setModal(True)
             msgbox.setWindowTitle("What's Now Playing Templates")
-            msgbox.show()
+            nowplaying.utils.qt.focus_window(msgbox)
             msgbox.exec()
 
     def preload(self) -> None:

--- a/nowplaying/utils/qt.py
+++ b/nowplaying/utils/qt.py
@@ -4,7 +4,7 @@
 from PySide6.QtWidgets import QWidget
 
 
-def focus_window(widget: QWidget) -> None:
+def focus_window(widget: QWidget | None) -> None:
     """Show widget, raise it to the front, and grab keyboard focus.
 
     `QWidget.show()` alone makes a widget visible but does not bring it
@@ -21,10 +21,15 @@ def focus_window(widget: QWidget) -> None:
     `activateWindow()` alone activates the window but does not give any
     specific child widget input focus; `setFocus()` closes that gap.
 
+    Passing `None` is a no-op.  Callers can drop their defensive `if
+    widget:` guards and pass the optional reference directly.
+
     Note: on macOS the OS prevents apps from stealing focus from another
     app entirely; in that case a higher-level activation (via PyObjC) is
     needed in addition to this helper.
     """
+    if widget is None:
+        return
     widget.show()
     widget.raise_()
     widget.activateWindow()

--- a/nowplaying/utils/qt.py
+++ b/nowplaying/utils/qt.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Qt UI helpers."""
+
+from PySide6.QtWidgets import QWidget
+
+
+def focus_window(widget: QWidget) -> None:
+    """Show widget, raise it to the front, and grab keyboard focus.
+
+    `QWidget.show()` alone makes a widget visible but does not bring it
+    to the foreground or take keyboard focus when the user is interacting
+    with another application.  The full incantation is:
+
+    * `show()` — make the widget visible
+    * `raise_()` — move it to the top of the stacking order
+    * `activateWindow()` — request that this window become the active
+      window (so the OS directs keyboard input to it)
+    * `setFocus()` — make this widget the keyboard-focus target within
+      the now-active window so input has somewhere concrete to land
+
+    `activateWindow()` alone activates the window but does not give any
+    specific child widget input focus; `setFocus()` closes that gap.
+
+    Note: on macOS the OS prevents apps from stealing focus from another
+    app entirely; in that case a higher-level activation (via PyObjC) is
+    needed in addition to this helper.
+    """
+    widget.show()
+    widget.raise_()
+    widget.activateWindow()
+    widget.setFocus()

--- a/nowplaying/utils/qt.py
+++ b/nowplaying/utils/qt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Qt UI helpers."""
 
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QWidget  # pylint: disable=no-name-in-module
 
 
 def focus_window(widget: QWidget | None) -> None:


### PR DESCRIPTION
QWidget.show() alone makes a widget visible but does not bring it to the foreground or grab keyboard focus when the user is interacting with another application — windows would appear behind other apps. The full incantation is show() + raise_() + activateWindow() + setFocus(); the new nowplaying.utils.qt.focus_window() bundles it.

Applied to template-preview windows in Kick, Twitch, Discord, and the web preview; to the OBS export dialog and its preview; to the main settings window; and to seven startup/error msgboxes that were using the redundant msgbox.show() + msgbox.exec() pattern (template-update notice, M3U-to-VirtualDJ notice, directory-migration notice, etc.).

Shell-launched dev builds on macOS will still hide because macOS prevents non-LaunchServices-blessed processes from foregrounding themselves; the helper works correctly for the shipped .app bundle.

## Summary by Sourcery

Centralize and standardize window focusing behavior so dialogs and previews reliably appear in the foreground with keyboard focus.

New Features:
- Introduce a nowplaying.utils.qt.focus_window helper to show a QWidget, raise it, and give it keyboard focus in one call.

Bug Fixes:
- Ensure various dialogs, previews, and message boxes open in the foreground with proper keyboard focus instead of appearing behind other applications.

Enhancements:
- Refactor existing window and message box code paths to reuse the new focus_window helper, simplifying popup handling across the app.