### PR TITLE
Fix the changelog date for 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 5.2.1 - 2026-05-05
+## Version 5.2.1 - 2026-05-20
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the 5.2.1 changelog entry to use the correct release date.