### PR TITLE
Add tufup-publish workflow + helper for release-time signing

### DIFF
--- a/.github/workflows/tufup-publish.yaml
+++ b/.github/workflows/tufup-publish.yaml
@@ -98,19 +98,43 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.meta.outputs.tag }}
         run: |
+          set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/release-assets"
-          # Pull only the 4 platform zips.  Other assets (tar.gz from
-          # prior runs, source archives, etc.) are skipped.
           cd "${RUNNER_TEMP}/release-assets"
-          for pattern in \
-              "WhatsNowPlaying-*-Linux-x86_64.zip" \
-              "WhatsNowPlaying-*-macOS15-AppleSilicon.zip" \
-              "WhatsNowPlaying-*-macOS15-Intel.zip" \
-              "WhatsNowPlaying-*-Windows.zip"; do
+
+          patterns=(
+              "WhatsNowPlaying-*-Linux-x86_64.zip"
+              "WhatsNowPlaying-*-macOS15-AppleSilicon.zip"
+              "WhatsNowPlaying-*-macOS15-Intel.zip"
+              "WhatsNowPlaying-*-Windows.zip"
+          )
+
+          # Pull only the 4 platform zips.  Other assets (tar.gz from
+          # prior runs, source archives, etc.) are skipped by pattern.
+          for pattern in "${patterns[@]}"; do
             gh release download "$TAG" \
                 --repo "${GITHUB_REPOSITORY}" \
                 --pattern "$pattern"
           done
+
+          # Explicit post-download validation.  `gh release download`
+          # errors on a missing pattern, but the underlying error can
+          # be noisy; collect every missing pattern and report them
+          # together to make misconfigured releases obvious.
+          missing=()
+          for pattern in "${patterns[@]}"; do
+            if ! compgen -G "$pattern" > /dev/null; then
+              missing+=("$pattern")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Missing expected release assets:"
+            for pattern in "${missing[@]}"; do
+              echo "  - $pattern"
+            done
+            exit 1
+          fi
+
           ls -la
 
       - name: Extract each zip into its bundle dir

--- a/.github/workflows/tufup-publish.yaml
+++ b/.github/workflows/tufup-publish.yaml
@@ -1,0 +1,214 @@
+---
+name: tufup publish on release
+
+# Triggered when a draft release is published.  Downloads the 4
+# platform zip assets, repackages each into a tufup-format tar.gz,
+# signs metadata referencing the new targets with secrets.TUFUP_KEY,
+# uploads the tarballs back to the release, and pushes refreshed
+# metadata to gh-pages:tufup/metadata/.
+#
+# Companion to .github/workflows/tufup-resign.yaml (daily re-sign
+# cron) -- both share the same concurrency group and signing key.
+#
+# See docs/dev/tufup-hosting.md for the proxy + hosting context,
+# and docs/dev/tufup-key-management.md for the key plan.
+
+on:  # yamllint disable-line rule:truthy
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to bundle (e.g. 5.3.0-preview1)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Sign into the _prerelease channel variants'
+        required: false
+        type: boolean
+        default: false
+
+# Serialize with the daily re-sign cron so we don't race on
+# gh-pages pushes.
+concurrency:
+  group: tufup-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+
+      - name: Install tufup
+        run: pip install -r requirements-tufup.txt
+
+      - name: Resolve tag + prerelease flag
+        id: meta
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          EVENT_PRERELEASE: ${{ github.event.release.prerelease }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          DISPATCH_PRERELEASE: ${{ github.event.inputs.prerelease }}
+        run: |
+          # On release: published, use event payload.  On
+          # workflow_dispatch, use the manual inputs.
+          if [[ -n "$EVENT_TAG" ]]; then
+            tag="$EVENT_TAG"
+            prerelease="$EVENT_PRERELEASE"
+          else
+            tag="$DISPATCH_TAG"
+            prerelease="$DISPATCH_PRERELEASE"
+          fi
+          if [[ -z "$tag" ]]; then
+            echo "::error::No tag resolved from event or dispatch inputs"
+            exit 1
+          fi
+          # Strip any leading "refs/tags/" defensively.
+          tag="${tag#refs/tags/}"
+          # Version excludes any leading "v" so it matches tufup
+          # filename conventions (we tag X.Y.Z, not vX.Y.Z, but be
+          # defensive).
+          version="${tag#v}"
+          # Prerelease channel suffix.  See tufup_channel routing in
+          # docs/dev/charts-server-spec.md.
+          if [[ "$prerelease" == "true" ]]; then
+            suffix="_prerelease"
+          else
+            suffix=""
+          fi
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "channel_suffix=$suffix"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: tag=$tag version=$version suffix='$suffix'"
+
+      - name: Download release zips
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release-assets"
+          # Pull only the 4 platform zips.  Other assets (tar.gz from
+          # prior runs, source archives, etc.) are skipped.
+          cd "${RUNNER_TEMP}/release-assets"
+          for pattern in \
+              "WhatsNowPlaying-*-Linux-x86_64.zip" \
+              "WhatsNowPlaying-*-macOS15-AppleSilicon.zip" \
+              "WhatsNowPlaying-*-macOS15-Intel.zip" \
+              "WhatsNowPlaying-*-Windows.zip"; do
+            gh release download "$TAG" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --pattern "$pattern"
+          done
+          ls -la
+
+      - name: Extract each zip into its bundle dir
+        env:
+          SUFFIX: ${{ steps.meta.outputs.channel_suffix }}
+        run: |
+          bash bincomponents/extract_release_zips.sh \
+              "${RUNNER_TEMP}/release-assets" \
+              "${RUNNER_TEMP}/extracted" \
+              "$SUFFIX"
+
+      - name: Restore signing key
+        env:
+          TUFUP_KEY: ${{ secrets.TUFUP_KEY }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/keystore"
+          chmod 700 "${RUNNER_TEMP}/keystore"
+          printf '%s' "$TUFUP_KEY" > "${RUNNER_TEMP}/keystore/wnp_prod_key"
+          chmod 600 "${RUNNER_TEMP}/keystore/wnp_prod_key"
+          cp bincomponents/wnp_prod_key.pub \
+             "${RUNNER_TEMP}/keystore/"
+
+      - name: Clone gh-pages metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          git clone --depth 1 --branch gh-pages \
+              "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+              "${RUNNER_TEMP}/ghpages"
+
+          metadata_dir="${RUNNER_TEMP}/ghpages/tufup/metadata"
+          if [[ ! -d "$metadata_dir" ]]; then
+            echo "::error::gh-pages is missing tufup/metadata/."
+            echo "Hosting must be initialized first."
+            echo "See docs/dev/tufup-hosting.md."
+            exit 1
+          fi
+          for f in root.json targets.json snapshot.json timestamp.json; do
+            if [[ ! -f "$metadata_dir/$f" ]]; then
+              echo "::error::Required metadata file missing on gh-pages:"
+              echo "  tufup/metadata/$f"
+              exit 1
+            fi
+          done
+
+          mkdir -p "${RUNNER_TEMP}/tufup-repo/metadata"
+          mkdir -p "${RUNNER_TEMP}/tufup-repo/targets"
+          cp "$metadata_dir/"*.json "${RUNNER_TEMP}/tufup-repo/metadata/"
+
+      - name: Run tufup_publish.py
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          SUFFIX: ${{ steps.meta.outputs.channel_suffix }}
+        run: |
+          # Build --bundle args from the channel list so each line stays
+          # under yamllint's 80-char limit.  Channel dirs match what
+          # extract_release_zips.sh produced.
+          bundle_args=()
+          for ch in WhatsNowPlaying_macos15_arm \
+                    WhatsNowPlaying_macos15_intel \
+                    WhatsNowPlaying_windows_x86_64 \
+                    WhatsNowPlaying_linux_x86_64; do
+            full="${ch}${SUFFIX}"
+            bundle_args+=(--bundle "${full}:${RUNNER_TEMP}/extracted/${full}")
+          done
+          python tools/tufup_publish.py \
+              --version "$VERSION" \
+              --keystore "${RUNNER_TEMP}/keystore" \
+              --repo-dir "${RUNNER_TEMP}/tufup-repo" \
+              "${bundle_args[@]}"
+
+      - name: Upload tarballs to GH Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          cd "${RUNNER_TEMP}/tufup-repo/targets"
+          ls -la *.tar.gz
+          gh release upload "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber \
+              *.tar.gz
+
+      - name: Push refreshed metadata to gh-pages
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          cp "${RUNNER_TEMP}/tufup-repo/metadata/"*.json \
+             "${RUNNER_TEMP}/ghpages/tufup/metadata/"
+          cd "${RUNNER_TEMP}/ghpages"
+          git config user.name 'github-actions[bot]'
+          git config user.email \
+              '41898282+github-actions[bot]@users.noreply.github.com'
+          git add tufup/metadata
+          if git diff --cached --quiet; then
+            echo "No metadata change; skipping push"
+            exit 0
+          fi
+          git commit -m "tufup: publish $TAG metadata"
+          git push origin gh-pages

--- a/bincomponents/extract_release_zips.sh
+++ b/bincomponents/extract_release_zips.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Extract the 4 platform zips downloaded from a GH Release into
+# channel-named bundle directories.
+#
+# Used by .github/workflows/tufup-publish.yaml to prepare unpacked
+# binaries for tufup_publish.py to archive.
+#
+# Usage:
+#   extract_release_zips.sh <zip_source_dir> <dest_dir> [<channel_suffix>]
+#
+# Each zip contains a single top-level wrapper dir; this script
+# flattens that so the per-channel dest dirs contain the bundle
+# contents directly (matching what tufup's make_gztar_archive
+# expects).
+#
+# Channel naming follows the spec in docs/dev/charts-server-spec.md:
+#   WhatsNowPlaying_<os><version>_<arch>[_<channel_suffix>]
+# The optional suffix is "_prerelease" for prerelease channels.
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    echo "usage: $0 <zip_source_dir> <dest_dir> [<channel_suffix>]" >&2
+    exit 64  # EX_USAGE
+fi
+
+ZIP_SRC="$1"
+DEST="$2"
+SUFFIX="${3:-}"
+
+if [[ ! -d "$ZIP_SRC" ]]; then
+    echo "error: zip source dir does not exist: $ZIP_SRC" >&2
+    exit 1
+fi
+
+mkdir -p "$DEST"
+
+# Filename-pattern -> channel-name mapping.  The pattern is matched
+# against the zip filename suffix (with a wildcard prefix).
+declare -A channel_for
+channel_for[Linux-x86_64]="WhatsNowPlaying_linux_x86_64${SUFFIX}"
+channel_for[macOS15-AppleSilicon]="WhatsNowPlaying_macos15_arm${SUFFIX}"
+channel_for[macOS15-Intel]="WhatsNowPlaying_macos15_intel${SUFFIX}"
+channel_for[Windows]="WhatsNowPlaying_windows_x86_64${SUFFIX}"
+
+for key in "${!channel_for[@]}"; do
+    channel="${channel_for[$key]}"
+    zip=$(find "$ZIP_SRC" -maxdepth 1 -name "*${key}.zip" | head -n 1)
+    if [[ -z "$zip" ]]; then
+        echo "::error::No zip found matching *${key}.zip in ${ZIP_SRC}"
+        exit 1
+    fi
+    out="${DEST}/${channel}"
+    mkdir -p "$out"
+    unzip -q "$zip" -d "$out"
+    # Each zip contains a single top-level wrapper directory; tufup
+    # wants the directory contents, not the wrapper.  Flatten one
+    # level if present.
+    inner=$(find "$out" -mindepth 1 -maxdepth 1 -type d)
+    if [[ -n "$inner" ]]; then
+        # shellcheck disable=SC2086  # globbing intentional
+        mv "$inner"/* "$inner"/.[!.]* "$out"/ 2>/dev/null || true
+        rmdir "$inner" 2>/dev/null || true
+    fi
+    echo "extracted $(basename "$zip") -> $out (channel: $channel)"
+done

--- a/bincomponents/extract_release_zips.sh
+++ b/bincomponents/extract_release_zips.sh
@@ -45,22 +45,58 @@ channel_for[Windows]="WhatsNowPlaying_windows_x86_64${SUFFIX}"
 
 for key in "${!channel_for[@]}"; do
     channel="${channel_for[$key]}"
-    zip=$(find "$ZIP_SRC" -maxdepth 1 -name "*${key}.zip" | head -n 1)
-    if [[ -z "$zip" ]]; then
-        echo "::error::No zip found matching *${key}.zip in ${ZIP_SRC}"
-        exit 1
-    fi
+
+    # Collect matching zips into an array so we can detect both
+    # the no-match and multi-match cases explicitly.  Silently
+    # picking the first of several would let an accidental
+    # duplicate asset slip through unnoticed.
+    mapfile -t matches < <(
+        find "$ZIP_SRC" -maxdepth 1 -name "*${key}.zip"
+    )
+    case ${#matches[@]} in
+        0)
+            echo "::error::No zip matching *${key}.zip in ${ZIP_SRC}"
+            exit 1
+            ;;
+        1)
+            zip="${matches[0]}"
+            ;;
+        *)
+            echo "::error::Multiple zips matching *${key}.zip in ${ZIP_SRC}:" >&2
+            printf '  %s\n' "${matches[@]}" >&2
+            exit 1
+            ;;
+    esac
+
     out="${DEST}/${channel}"
     mkdir -p "$out"
     unzip -q "$zip" -d "$out"
-    # Each zip contains a single top-level wrapper directory; tufup
-    # wants the directory contents, not the wrapper.  Flatten one
-    # level if present.
-    inner=$(find "$out" -mindepth 1 -maxdepth 1 -type d)
-    if [[ -n "$inner" ]]; then
-        # shellcheck disable=SC2086  # globbing intentional
-        mv "$inner"/* "$inner"/.[!.]* "$out"/ 2>/dev/null || true
-        rmdir "$inner" 2>/dev/null || true
-    fi
+
+    # PyInstaller zips contain a single top-level wrapper directory;
+    # tufup wants the directory contents, not the wrapper.  Detect
+    # exactly-one-wrapper-dir before flattening: zero dirs means the
+    # zip is already flat (nothing to do), multiple dirs means
+    # something is wrong with the asset and we should fail rather
+    # than guess which one to flatten.
+    mapfile -t inners < <(
+        find "$out" -mindepth 1 -maxdepth 1 -type d
+    )
+    case ${#inners[@]} in
+        0)
+            # Already flat; nothing to flatten.
+            ;;
+        1)
+            inner="${inners[0]}"
+            # shellcheck disable=SC2086  # globbing intentional
+            mv "$inner"/* "$inner"/.[!.]* "$out"/ 2>/dev/null || true
+            rmdir "$inner" 2>/dev/null || true
+            ;;
+        *)
+            echo "::error::Expected one wrapper dir in $(basename "$zip"), found ${#inners[@]}:" >&2
+            printf '  %s\n' "${inners[@]}" >&2
+            exit 1
+            ;;
+    esac
+
     echo "extracted $(basename "$zip") -> $out (channel: $channel)"
 done

--- a/tools/tufup_publish.py
+++ b/tools/tufup_publish.py
@@ -41,7 +41,7 @@ import os
 import pathlib
 import sys
 
-from tufup.repo import Repository, make_gztar_archive
+from tufup.repo import Repository, make_gztar_archive  # pylint: disable=import-error
 
 
 KEY_NAME = "wnp_prod_key"
@@ -89,6 +89,7 @@ def _write_config(repo_dir: pathlib.Path, keys_dir: pathlib.Path) -> pathlib.Pat
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse args, archive each bundle, register targets, and re-sign."""
     parser = argparse.ArgumentParser(
         description="Register platform bundles as tufup targets and re-sign metadata.",
     )
@@ -161,9 +162,10 @@ def main(argv: list[str] | None = None) -> int:
         # custom typing in tufup is JsonDict-recursive; pyright is too
         # strict about the nested {"required": False} shape, but the
         # runtime accepts it (same pattern as backfill scripts).
+        custom = {"user": None, "tufup": {"required": False}}
         repo.roles.add_or_update_target(
             local_path=archive_path,
-            custom=dict(user=None, tufup={"required": False}),  # type: ignore[arg-type]
+            custom=custom,  # type: ignore[arg-type]
         )
 
     print("publishing changes...")

--- a/tools/tufup_publish.py
+++ b/tools/tufup_publish.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate signed TUF metadata for one or more platform bundles in the
+prod tufup repo.
+
+Called by .github/workflows/tufup-publish.yaml at release time to
+register each platform's signed PyInstaller output as a TUF target,
+then sign + publish updated metadata.  Can also be run manually for
+one-off re-signs.
+
+Bypasses ``tufup targets add`` because that CLI assumes one channel
+per repo (its ``get_latest_archive()`` doesn't filter by app_name;
+adding a second channel at the same version trips the version check).
+We use the lower-level roles API instead.  See
+``feedback_tufup_multichannel`` for the full context.
+
+Usage:
+    tufup_publish.py \\
+        --version 5.3.0 \\
+        --keystore /tmp/keystore \\
+        --repo-dir /tmp/tufup-repo \\
+        --bundle WhatsNowPlaying_macos15_arm:/tmp/extracted/mac-arm \\
+        --bundle WhatsNowPlaying_macos15_intel:/tmp/extracted/mac-intel \\
+        --bundle WhatsNowPlaying_windows_x86_64:/tmp/extracted/win \\
+        --bundle WhatsNowPlaying_linux_x86_64:/tmp/extracted/linux
+
+Inputs:
+    --repo-dir: must contain a metadata/ subdir seeded from the current
+                gh-pages state.  The script writes new tar.gz files to
+                repo-dir/targets/ and refreshed metadata to
+                repo-dir/metadata/.
+    --keystore: directory containing wnp_prod_key and wnp_prod_key.pub.
+    --bundle:   repeat per channel.  The dir is the unpacked, signed
+                application bundle (PyInstaller output, already
+                notarized + stapled on macOS, Authenticode-signed on
+                Windows).
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+from tufup.repo import Repository, make_gztar_archive
+
+
+KEY_NAME = "wnp_prod_key"
+
+
+def _parse_bundle(value: str) -> tuple[str, pathlib.Path]:
+    """Parse a --bundle CHANNEL:DIR argument."""
+    channel, _, bundle_dir = value.partition(":")
+    if not channel or not bundle_dir:
+        raise argparse.ArgumentTypeError(f'invalid --bundle (expected "CHANNEL:DIR"): {value!r}')
+    path = pathlib.Path(bundle_dir)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError(f"bundle dir does not exist: {path}")
+    return channel, path
+
+
+def _write_config(repo_dir: pathlib.Path, keys_dir: pathlib.Path) -> pathlib.Path:
+    """Write a .tufup-repo-config in repo_dir's parent.
+
+    Returns the directory the config is in (the script chdirs there
+    before invoking tufup's config loader).
+    """
+    config_cwd = repo_dir.parent
+    config_cwd.mkdir(parents=True, exist_ok=True)
+    roles = ("root", "snapshot", "targets", "timestamp")
+    config = {
+        "app_name": "WhatsNowPlaying",
+        "app_version_attr": "nowplaying.version.__VERSION__",
+        "binary_diff": None,
+        "encrypted_keys": [],
+        "expiration_days": {
+            "root": 365,
+            "snapshot": 7,
+            "targets": 30,
+            "timestamp": 1,
+        },
+        "key_map": {role: [KEY_NAME] for role in roles},
+        "keys_dir": str(keys_dir),
+        "repo_dir": str(repo_dir),
+        "thresholds": {role: 1 for role in roles},
+    }
+    config_path = config_cwd / ".tufup-repo-config"
+    config_path.write_text(json.dumps(config, indent=4))
+    return config_cwd
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Register platform bundles as tufup targets and re-sign metadata.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Release version (PEP440), e.g. 5.3.0 or 5.3.0-preview1",
+    )
+    parser.add_argument(
+        "--keystore",
+        required=True,
+        type=pathlib.Path,
+        help="Directory containing private + public key files",
+    )
+    parser.add_argument(
+        "--repo-dir",
+        required=True,
+        type=pathlib.Path,
+        help="Tufup repo dir; must contain a metadata/ subdir seeded from gh-pages",
+    )
+    parser.add_argument(
+        "--bundle",
+        action="append",
+        required=True,
+        type=_parse_bundle,
+        metavar="CHANNEL:DIR",
+        help="Channel + bundle dir pair, e.g. "
+        "WhatsNowPlaying_macos15_arm:/tmp/extracted/mac-arm. "
+        "Repeat once per channel.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_dir: pathlib.Path = args.repo_dir.resolve()
+    keystore: pathlib.Path = args.keystore.resolve()
+
+    targets_dir = repo_dir / "targets"
+    metadata_dir = repo_dir / "metadata"
+    targets_dir.mkdir(parents=True, exist_ok=True)
+    if not metadata_dir.is_dir():
+        print(
+            f"error: metadata_dir {metadata_dir} not found.  "
+            "Seed it from gh-pages:tufup/metadata/ before running this script.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Repository.from_config() reads the config from CWD only, so write a
+    # fresh config and chdir to its parent before instantiating.
+    config_cwd = _write_config(repo_dir=repo_dir, keys_dir=keystore)
+    os.chdir(config_cwd)
+
+    repo = Repository.from_config()
+    # from_config() always populates repo.roles; the Optional is for the
+    # pre-initialize state we don't hit here.
+    assert repo.roles is not None
+    for channel, bundle_dir in args.bundle:
+        archive_filename = f"{channel}-{args.version}.tar.gz"
+        archive_path = targets_dir / archive_filename
+        if archive_path.exists():
+            print(f"archive already exists, reusing: {archive_filename}")
+        else:
+            print(f"creating archive for {channel} from {bundle_dir}")
+            make_gztar_archive(
+                src_dir=bundle_dir,
+                dst_dir=targets_dir,
+                app_name=channel,
+                version=args.version,
+            )
+        print(f"registering target: {archive_filename}")
+        # custom typing in tufup is JsonDict-recursive; pyright is too
+        # strict about the nested {"required": False} shape, but the
+        # runtime accepts it (same pattern as backfill scripts).
+        repo.roles.add_or_update_target(
+            local_path=archive_path,
+            custom=dict(user=None, tufup={"required": False}),  # type: ignore[arg-type]
+        )
+
+    print("publishing changes...")
+    repo.publish_changes(private_key_dirs=[keystore])
+    print("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Companion to the daily re-sign cron (tufup-resign.yaml).  Triggers on release: published and runs the multi-channel publish in one job: downloads platform zips from the release, extracts each, generates tufup-format tar.gz per channel, re-signs metadata with secrets.TUFUP_KEY, uploads the tarballs back to the release, and pushes refreshed metadata to gh-pages.

Files:
  * .github/workflows/tufup-publish.yaml - Triggers: release: published, workflow_dispatch (manual rerun with tag + prerelease inputs) - Concurrency group "tufup-publish" matches the cron so the two serialize on gh-pages pushes. - When release.prerelease is true, channel names get the "_prerelease" suffix per the charts-server channel spec.
  * tools/tufup_publish.py
      - Standalone CLI: takes --version, --keystore, --repo-dir, repeated --bundle CHANNEL:DIR.  Calls the lower-level roles API instead of `tufup targets add` to work around the multi-channel-per-repo version-check bug (see feedback_tufup_multichannel memory).
  * bincomponents/extract_release_zips.sh - Extracts the 4 release zips into channel-named bundle dirs and flattens the wrapper directory each PyInstaller zip contains.  Lives in bincomponents/ for shellcheck coverage via Apache Yetus in CI (shell-in-YAML escapes the linter).

## Summary by Sourcery

Introduce an automated workflow and helper tooling to package release artifacts into tufup tarballs, sign them, and publish updated TUF metadata on gh-pages when a GitHub release is published.

New Features:
- Add a GitHub Actions workflow that triggers on release publication or manual dispatch to repackage platform-specific release zips into tufup-compatible tarballs, upload them to the release, and push refreshed metadata to gh-pages.
- Provide a tufup_publish.py CLI helper to archive per-channel bundles, register them as TUF targets via the tufup repository API, and publish updated signed metadata.
- Add a shell helper script to extract platform release zip assets into channel-named bundle directories with optional prerelease suffixes for use in tufup publishing.

CI:
- Configure tufup-publish workflow concurrency to serialize with the existing tufup-resign cron job and ensure safe gh-pages updates.