### PR TITLE
Add O(1) location index and title_id fast path for djay Pro

### DIFF
--- a/nowplaying/djaypro/locationdb.py
+++ b/nowplaying/djaypro/locationdb.py
@@ -15,6 +15,7 @@ called, which is acceptable for a live-set workflow.
 import logging
 import pathlib
 import sqlite3
+import time
 
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
 
@@ -22,6 +23,7 @@ import nowplaying.djaypro.tsaf
 import nowplaying.utils.sqlite
 
 _LOCATION_COLLECTIONS = ("localMediaItemLocations", "globalMediaItemLocations")
+_LOCATION_PLACEHOLDERS = ",".join("?" * len(_LOCATION_COLLECTIONS))
 
 _SCHEMA = [
     """CREATE TABLE IF NOT EXISTS locations (
@@ -46,6 +48,7 @@ def default_db_path() -> pathlib.Path:
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode=WAL")
     for stmt in _SCHEMA:
         conn.execute(stmt)
     conn.commit()
@@ -63,14 +66,40 @@ def _set_stored_max_rowid(conn: sqlite3.Connection, rowid: int) -> None:
     )
 
 
+def _get_last_rebuild_time(conn: sqlite3.Connection) -> float:
+    row = conn.execute("SELECT value FROM sync_state WHERE key='last_rebuild'").fetchone()
+    return float(row[0]) if row else 0.0
+
+
+def _set_last_rebuild_time(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_state (key, value) VALUES ('last_rebuild', ?)",
+        (str(time.time()),),
+    )
+
+
+def get_last_rebuild_time(side_db: pathlib.Path) -> float:
+    """Return the timestamp of the last full rebuild, or 0.0 if never rebuilt."""
+    if not side_db.exists():
+        return 0.0
+
+    def query() -> float:
+        with nowplaying.utils.sqlite.sqlite_connection(str(side_db), timeout=1) as conn:
+            return _get_last_rebuild_time(conn)
+
+    try:
+        return nowplaying.utils.sqlite.retry_sqlite_operation(query)
+    except (sqlite3.OperationalError, FileNotFoundError):
+        return 0.0
+
+
 def _probe_djay_max_rowid(djay_dbfile: pathlib.Path) -> int | None:
     """Return MAX(rowid) for location collections in djay's DB, or None on error."""
-    placeholders = ",".join("?" * len(_LOCATION_COLLECTIONS))
 
     def query() -> int:
         with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
             row = conn.execute(
-                f"SELECT MAX(rowid) FROM database2 WHERE collection IN ({placeholders})",
+                f"SELECT MAX(rowid) FROM database2 WHERE collection IN ({_LOCATION_PLACEHOLDERS})",
                 _LOCATION_COLLECTIONS,
             ).fetchone()
             return row[0] if row and row[0] is not None else -1
@@ -84,19 +113,20 @@ def _probe_djay_max_rowid(djay_dbfile: pathlib.Path) -> int | None:
 
 def _fetch_new_rows(
     djay_dbfile: pathlib.Path, after_rowid: int
-) -> list[tuple[str, str, str, str | None, str | None]]:
-    """Return parsed rows with rowid > after_rowid.
+) -> list[tuple[str, str, str, str | None, str | None]] | None:
+    """Return parsed rows with rowid > after_rowid, or None on DB error.
 
-    Yields tuples of (uuid, title_lower, artist_lower, filename, isrc).
+    Returns None (not empty list) when the fetch fails so callers can
+    distinguish a DB error from a genuinely empty result and avoid
+    advancing the watermark incorrectly.
     """
-    placeholders = ",".join("?" * len(_LOCATION_COLLECTIONS))
 
     def query() -> list[tuple[str, str, str, str | None, str | None]]:
         results: list[tuple[str, str, str, str | None, str | None]] = []
         with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
             cursor = conn.execute(
                 f"SELECT key, data FROM database2"
-                f" WHERE collection IN ({placeholders}) AND rowid > ?",
+                f" WHERE collection IN ({_LOCATION_PLACEHOLDERS}) AND rowid > ?",
                 _LOCATION_COLLECTIONS + (after_rowid,),
             )
             for uuid, blob in cursor:
@@ -122,7 +152,7 @@ def _fetch_new_rows(
         return nowplaying.utils.sqlite.retry_sqlite_operation(query)
     except (sqlite3.OperationalError, FileNotFoundError) as err:
         logging.debug("djaypro locationdb: could not fetch new rows: %s", err)
-        return []
+        return None
 
 
 def sync(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
@@ -146,6 +176,10 @@ def sync(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
                 return
 
             new_rows = _fetch_new_rows(djay_dbfile, our_max)
+            if new_rows is None:
+                # DB was locked during fetch — don't advance watermark so
+                # these rows are retried on the next sync call.
+                return
             if new_rows:
                 conn.executemany(
                     "INSERT OR REPLACE INTO locations"
@@ -202,12 +236,12 @@ def lookup_direct(djay_dbfile: pathlib.Path, title_id: str) -> tuple[str | None,
     between historySessionItems and the location collections.  Falls back to
     (None, None) when the track is absent or on error.
     """
-    placeholders = ",".join("?" * len(_LOCATION_COLLECTIONS))
 
     def query() -> tuple[str | None, str | None]:
         with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
             row = conn.execute(
-                f"SELECT data FROM database2 WHERE collection IN ({placeholders}) AND key = ?",
+                "SELECT data FROM database2"
+                f" WHERE collection IN ({_LOCATION_PLACEHOLDERS}) AND key = ?",
                 _LOCATION_COLLECTIONS + (title_id,),
             ).fetchone()
             if not row:
@@ -230,8 +264,26 @@ def lookup_direct(djay_dbfile: pathlib.Path, title_id: str) -> tuple[str | None,
 def rebuild(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
     """Drop and fully rebuild the location index from djay's DB.
 
-    Use when the index may be stale (e.g. files were moved in djay Pro).
+    Writes to a temp file then renames atomically so the index is never
+    absent during the rebuild. Use when the index may be stale (e.g.
+    files were moved in djay Pro).
     """
-    if side_db.exists():
-        side_db.unlink()
-    sync(djay_dbfile, side_db)
+    tmp = side_db.with_suffix(".tmp")
+    if tmp.exists():
+        tmp.unlink()
+
+    sync(djay_dbfile, tmp)
+
+    if not tmp.exists():
+        # sync() bailed early (djay DB unreachable) — leave old index intact
+        return
+
+    # Record rebuild timestamp before promoting the file
+    try:
+        with nowplaying.utils.sqlite.sqlite_connection(str(tmp)) as conn:
+            _set_last_rebuild_time(conn)
+            conn.commit()
+    except (sqlite3.OperationalError, FileNotFoundError) as err:
+        logging.debug("djaypro locationdb: could not stamp rebuild time: %s", err)
+
+    tmp.replace(side_db)

--- a/nowplaying/djaypro/locationdb.py
+++ b/nowplaying/djaypro/locationdb.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Side SQLite index for djay Pro location data.
+
+djay Pro stores file paths inside TSAF binary blobs with no queryable text
+columns, forcing a full table scan to match by artist/title.  This module
+maintains a WNP-owned index so lookups are O(log n) rather than O(n)
+blob-decode scans.
+
+The index is append-only: sync() checks MAX(rowid) in djay's location
+collections and only processes rows that are newer than the last sync.
+In-place updates (e.g. a file move) are not reflected until rebuild() is
+called, which is acceptable for a live-set workflow.
+"""
+
+import logging
+import pathlib
+import sqlite3
+
+from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
+
+import nowplaying.djaypro.tsaf
+import nowplaying.utils.sqlite
+
+_LOCATION_COLLECTIONS = ("localMediaItemLocations", "globalMediaItemLocations")
+
+_SCHEMA = [
+    """CREATE TABLE IF NOT EXISTS locations (
+        uuid         TEXT PRIMARY KEY,
+        title_lower  TEXT NOT NULL,
+        artist_lower TEXT NOT NULL DEFAULT '',
+        filename     TEXT,
+        isrc         TEXT
+    )""",
+    "CREATE INDEX IF NOT EXISTS idx_title ON locations (title_lower)",
+    """CREATE TABLE IF NOT EXISTS sync_state (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )""",
+]
+
+
+def default_db_path() -> pathlib.Path:
+    """Return the default WNP-owned location index path under Qt's cache dir."""
+    cache = QStandardPaths.standardLocations(QStandardPaths.StandardLocation.CacheLocation)[0]
+    return pathlib.Path(cache).joinpath("djaypro", "djaypro-locations.db")
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    for stmt in _SCHEMA:
+        conn.execute(stmt)
+    conn.commit()
+
+
+def _get_stored_max_rowid(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT value FROM sync_state WHERE key='max_rowid'").fetchone()
+    return int(row[0]) if row else -1
+
+
+def _set_stored_max_rowid(conn: sqlite3.Connection, rowid: int) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_state (key, value) VALUES ('max_rowid', ?)",
+        (str(rowid),),
+    )
+
+
+def _probe_djay_max_rowid(djay_dbfile: pathlib.Path) -> int | None:
+    """Return MAX(rowid) for location collections in djay's DB, or None on error."""
+    placeholders = ",".join("?" * len(_LOCATION_COLLECTIONS))
+
+    def query() -> int:
+        with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
+            row = conn.execute(
+                f"SELECT MAX(rowid) FROM database2 WHERE collection IN ({placeholders})",
+                _LOCATION_COLLECTIONS,
+            ).fetchone()
+            return row[0] if row and row[0] is not None else -1
+
+    try:
+        return nowplaying.utils.sqlite.retry_sqlite_operation(query)
+    except (sqlite3.OperationalError, FileNotFoundError) as err:
+        logging.debug("djaypro locationdb: could not probe djay DB: %s", err)
+        return None
+
+
+def _fetch_new_rows(
+    djay_dbfile: pathlib.Path, after_rowid: int
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Return parsed rows with rowid > after_rowid.
+
+    Yields tuples of (uuid, title_lower, artist_lower, filename, isrc).
+    """
+    placeholders = ",".join("?" * len(_LOCATION_COLLECTIONS))
+
+    def query() -> list[tuple[str, str, str, str | None, str | None]]:
+        results: list[tuple[str, str, str, str | None, str | None]] = []
+        with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
+            cursor = conn.execute(
+                f"SELECT key, data FROM database2"
+                f" WHERE collection IN ({placeholders}) AND rowid > ?",
+                _LOCATION_COLLECTIONS + (after_rowid,),
+            )
+            for uuid, blob in cursor:
+                parsed = nowplaying.djaypro.tsaf.parse_blob(blob)
+                title = parsed.get("title")
+                if not isinstance(title, str) or not title.strip():
+                    continue
+                artist = parsed.get("artist")
+                isrc = parsed.get("isrc")
+                filename = parsed.get("filename")
+                results.append(
+                    (
+                        uuid,
+                        title.strip().lower(),
+                        artist.strip().lower() if isinstance(artist, str) else "",
+                        filename if isinstance(filename, str) else None,
+                        isrc if isinstance(isrc, str) else None,
+                    )
+                )
+        return results
+
+    try:
+        return nowplaying.utils.sqlite.retry_sqlite_operation(query)
+    except (sqlite3.OperationalError, FileNotFoundError) as err:
+        logging.debug("djaypro locationdb: could not fetch new rows: %s", err)
+        return []
+
+
+def sync(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
+    """Sync new location rows from djay Pro's DB into the WNP-owned index.
+
+    Only processes rows newer than the last sync, so the steady-state cost
+    is a single MAX(rowid) probe when the library has not changed.
+    """
+    djay_max = _probe_djay_max_rowid(djay_dbfile)
+    if djay_max is None:
+        return
+
+    side_db.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with nowplaying.utils.sqlite.sqlite_connection(str(side_db)) as conn:
+            _ensure_schema(conn)
+            our_max = _get_stored_max_rowid(conn)
+
+            if djay_max <= our_max:
+                return
+
+            new_rows = _fetch_new_rows(djay_dbfile, our_max)
+            if new_rows:
+                conn.executemany(
+                    "INSERT OR REPLACE INTO locations"
+                    " (uuid, title_lower, artist_lower, filename, isrc)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    new_rows,
+                )
+                logging.debug("djaypro locationdb: indexed %d new location rows", len(new_rows))
+
+            _set_stored_max_rowid(conn, djay_max)
+            conn.commit()
+
+    except (sqlite3.OperationalError, FileNotFoundError) as err:
+        logging.debug("djaypro locationdb: sync failed: %s", err)
+
+
+def lookup(
+    artist: str, title: str, side_db: pathlib.Path
+) -> tuple[str | None, str | None, str | None]:
+    """Return (filename, uuid, isrc) for a track, or (None, None, None) if not found.
+
+    Matches on title_lower; requires artist match when both sides are non-empty,
+    accepts a miss on either side (mirrors the original blob-scan logic).
+    """
+    if not side_db.exists():
+        return None, None, None
+
+    title_lower = title.strip().lower() if title else ""
+    artist_lower = artist.strip().lower() if artist else ""
+    if not title_lower:
+        return None, None, None
+
+    def query() -> tuple[str | None, str | None, str | None]:
+        with nowplaying.utils.sqlite.sqlite_connection(str(side_db), timeout=1) as conn:
+            row = conn.execute(
+                "SELECT filename, uuid, isrc FROM locations"
+                " WHERE title_lower = ?"
+                "   AND (artist_lower = ? OR artist_lower = '' OR ? = '')"
+                " LIMIT 1",
+                (title_lower, artist_lower, artist_lower),
+            ).fetchone()
+            return (row[0], row[1], row[2]) if row else (None, None, None)
+
+    try:
+        return nowplaying.utils.sqlite.retry_sqlite_operation(query)
+    except (sqlite3.OperationalError, FileNotFoundError):
+        return None, None, None
+
+
+def lookup_direct(djay_dbfile: pathlib.Path, title_id: str) -> tuple[str | None, str | None]:
+    """Return (filename, isrc) via O(1) key lookup in djay's DB.
+
+    Uses the ADCMediaItemTitleID UUID as the database2 key — the direct FK
+    between historySessionItems and the location collections.  Falls back to
+    (None, None) when the track is absent or on error.
+    """
+    placeholders = ",".join("?" * len(_LOCATION_COLLECTIONS))
+
+    def query() -> tuple[str | None, str | None]:
+        with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
+            row = conn.execute(
+                f"SELECT data FROM database2 WHERE collection IN ({placeholders}) AND key = ?",
+                _LOCATION_COLLECTIONS + (title_id,),
+            ).fetchone()
+            if not row:
+                return None, None
+            parsed = nowplaying.djaypro.tsaf.parse_blob(row[0])
+            filename = parsed.get("filename")
+            isrc = parsed.get("isrc")
+            return (
+                filename if isinstance(filename, str) else None,
+                isrc if isinstance(isrc, str) else None,
+            )
+
+    try:
+        return nowplaying.utils.sqlite.retry_sqlite_operation(query)
+    except (sqlite3.OperationalError, FileNotFoundError) as err:
+        logging.debug("djaypro locationdb: lookup_direct failed: %s", err)
+        return None, None
+
+
+def rebuild(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
+    """Drop and fully rebuild the location index from djay's DB.
+
+    Use when the index may be stale (e.g. files were moved in djay Pro).
+    """
+    if side_db.exists():
+        side_db.unlink()
+    sync(djay_dbfile, side_db)

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -173,10 +173,16 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             "djaypro/rebuild_location_db", type=bool, defaultValue=False
         )
         if not rebuild and self._location_db_path.exists():
-            max_age_days = self.config.cparser.value(
-                "djaypro/location_max_age_days", type=int, defaultValue=7
+            max_age_days = max(
+                1,
+                self.config.cparser.value(
+                    "djaypro/location_max_age_days", type=int, defaultValue=7
+                ),
             )
-            age_days = (time.time() - self._location_db_path.stat().st_mtime) / 86400
+            last_rebuild = nowplaying.djaypro.locationdb.get_last_rebuild_time(
+                self._location_db_path
+            )
+            age_days = (time.time() - last_rebuild) / 86400
             if age_days > max_age_days:
                 logging.info(
                     "djay Pro location index is %.1f days old (max %d); rebuilding",
@@ -213,8 +219,6 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             logging.error("djay Pro directory does not exist: %s", self.djaypro_dir)
             await asyncio.sleep(1)
             return
-
-        await self._maybe_rebuild_location_db()
 
         logging.info("Watching for changes on %s", self.djaypro_dir)
         # Watch for changes to NowPlaying.txt (macOS) or MediaLibrary.db-wal (Windows)
@@ -730,6 +734,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     async def start(self):
         """setup the watcher"""
+        await self._maybe_rebuild_location_db()
         await self.setup_watcher()
 
     async def getplayingtrack(self) -> TrackMetadata:
@@ -981,7 +986,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self.config.cparser.setValue("djaypro/deckskip", deckskip)
 
     def on_rebuild_location_button(self):
-        """user clicked Rebuild Now — schedule a full location index rebuild"""
+        """user clicked Rebuild Now — flag for rebuild on next poll cycle"""
         logging.info("Manual djay Pro location index rebuild requested")
         self.config.cparser.setValue("djaypro/rebuild_location_db", True)
 

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -53,6 +53,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
+import nowplaying.djaypro.locationdb
 import nowplaying.djaypro.tsaf
 import nowplaying.utils.sqlite
 from nowplaying.exceptions import PluginVerifyError
@@ -80,6 +81,7 @@ class _HistoryExtras:
     source: str | None = None
     deck: str | None = None
     starttime: float | None = None
+    title_id: str | None = None
 
 
 @dataclasses.dataclass
@@ -114,6 +116,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self._wal_timer: threading.Timer | None = None
         self._wal_timer_lock = threading.Lock()
         self._deck_tracks: dict[str, _DeckTrack] = {}
+        self._location_db_path: pathlib.Path = nowplaying.djaypro.locationdb.default_db_path()
         # Record launch time in Core Data epoch (seconds since 2001-01-01 UTC)
         # so we can skip tracks that were already playing when WNP started.
         self._launch_time: float = (
@@ -164,6 +167,32 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             "key": None,
         }
 
+    async def _maybe_rebuild_location_db(self) -> None:
+        """Rebuild the location index if the manual flag is set or it has aged out."""
+        rebuild = self.config.cparser.value(
+            "djaypro/rebuild_location_db", type=bool, defaultValue=False
+        )
+        if not rebuild and self._location_db_path.exists():
+            max_age_days = self.config.cparser.value(
+                "djaypro/location_max_age_days", type=int, defaultValue=7
+            )
+            age_days = (time.time() - self._location_db_path.stat().st_mtime) / 86400
+            if age_days > max_age_days:
+                logging.info(
+                    "djay Pro location index is %.1f days old (max %d); rebuilding",
+                    age_days,
+                    max_age_days,
+                )
+                rebuild = True
+
+        if rebuild:
+            dbfile = self._get_db_path()
+            if dbfile:
+                await asyncio.to_thread(
+                    nowplaying.djaypro.locationdb.rebuild, dbfile, self._location_db_path
+                )
+                self.config.cparser.setValue("djaypro/rebuild_location_db", False)
+
     async def setup_watcher(self, configkey: str = "djaypro/directory"):
         """set up a custom watch on the djay Pro directory"""
         djaypro_dir = self.config.cparser.value(configkey)
@@ -184,6 +213,8 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             logging.error("djay Pro directory does not exist: %s", self.djaypro_dir)
             await asyncio.sleep(1)
             return
+
+        await self._maybe_rebuild_location_db()
 
         logging.info("Watching for changes on %s", self.djaypro_dir)
         # Watch for changes to NowPlaying.txt (macOS) or MediaLibrary.db-wal (Windows)
@@ -247,6 +278,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         seed_bpm: str | None = None,
         seed_key: str | None = None,
         retry_filename: bool = False,
+        title_id: str | None = None,
     ) -> tuple[str | None, dict, str | None]:
         """Look up file path, analyzed data, and location ISRC from the database.
 
@@ -257,9 +289,12 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         retry_filename: retry the filename lookup on first miss (macOS path,
         where NowPlaying.txt fires before localMediaItemLocations is committed).
 
+        title_id: ADCMediaItemTitleID UUID from the history blob.  When present
+        a direct O(1) key lookup is tried before falling back to the side table.
+
         Returns (filename, analyzed, loc_isrc).
         """
-        filename, track_uuid, loc_isrc = self._get_filename_from_db(artist, title)
+        filename, track_uuid, loc_isrc = self._get_filename_from_db(artist, title, title_id)
 
         need_analyzed = not seed_bpm or not seed_key
         analyzed: dict = {}
@@ -277,7 +312,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             )
             time.sleep(delay)
             if retry_filename and filename is None:
-                filename, track_uuid, loc_isrc = self._get_filename_from_db(artist, title)
+                filename, track_uuid, loc_isrc = self._get_filename_from_db(
+                    artist, title, title_id
+                )
             if need_analyzed and (not analyzed.get("bpm") or not analyzed.get("key")):
                 analyzed = self._get_analyzed_data_by_uuid(track_uuid or "")
 
@@ -383,12 +420,14 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         # historySessionItems BPM/key with mediaItemAnalyzedData when missing.
         # retry_filename=True because localMediaItemLocations is written in the
         # same second transaction as analyzedData and may not yet be present.
+        t_title_id = track_data.get("title_id")
         filename, analyzed, loc_isrc = self._supplement_from_db(
             t_artist or "",
             t_title,
             seed_bpm=track_data.get("bpm"),
             seed_key=track_data.get("key"),
             retry_filename=True,
+            title_id=t_title_id if isinstance(t_title_id, str) else None,
         )
         if filename:
             track_data["filename"] = filename
@@ -513,7 +552,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
         # NowPlaying.txt fires before localMediaItemLocations and
         # mediaItemAnalyzedData are committed — retry once after the delay.
-        filename, analyzed, loc_isrc = self._supplement_from_db(artist, title, retry_filename=True)
+        filename, analyzed, loc_isrc = self._supplement_from_db(
+            artist, title, retry_filename=True, title_id=extras.title_id
+        )
 
         isrc = extras.isrc if extras.isrc is not None else loc_isrc
 
@@ -644,89 +685,36 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 source = parsed.get("source")
                 deck = parsed.get("deck")
                 starttime = parsed.get("starttime")
+                title_id = parsed.get("title_id")
                 return _HistoryExtras(
                     isrc=isrc if isinstance(isrc, str) else None,
                     source=source if isinstance(source, str) else None,
                     deck=deck if isinstance(deck, str) else None,
                     starttime=starttime if isinstance(starttime, float) else None,
+                    title_id=title_id if isinstance(title_id, str) else None,
                 )
         return _HistoryExtras()
 
     def _get_filename_from_db(
-        self, artist: str, title: str
+        self, artist: str, title: str, title_id: str | None = None
     ) -> tuple[str | None, str | None, str | None]:
-        """Get filename, track UUID, and ISRC from localMediaItemLocations.
+        """Get filename, track UUID, and ISRC for a track.
 
-        Returns (filename, track_uuid, isrc).  Any value may be None.
-        The track UUID is the shared key between localMediaItemLocations
-        and mediaItemAnalyzedData, used for O(1) BPM/key lookup.
-        ISRC is returned when djay Pro has stored it in the location blob
-        (e.g. for local files that carry an embedded ISRC tag).
+        When title_id is present, tries a direct O(1) key lookup in djay's DB
+        first (the ADCMediaItemTitleID UUID is the database2 key for location
+        collections).  Falls back to the WNP-owned side-table index on miss.
         """
         dbfile = self._get_db_path()
         if not dbfile:
             return None, None, None
 
-        def query_db() -> tuple[str | None, str | None, str | None]:
-            with nowplaying.utils.sqlite.sqlite_connection(
-                str(dbfile), timeout=1, row_factory=sqlite3.Row
-            ) as connection:
-                cursor = connection.cursor()
-                return self._get_filename_for_track(cursor, artist, title)
+        if title_id:
+            filename, loc_isrc = nowplaying.djaypro.locationdb.lookup_direct(dbfile, title_id)
+            if filename is not None or loc_isrc is not None:
+                return filename, title_id, loc_isrc
 
-        try:
-            return nowplaying.utils.sqlite.retry_sqlite_operation(query_db)
-        except (sqlite3.OperationalError, FileNotFoundError):
-            return None, None, None
-
-    @staticmethod
-    def _get_filename_for_track(
-        cursor, artist: str, title: str
-    ) -> tuple[str | None, str | None, str | None]:
-        """Query localMediaItemLocations for file path, track UUID, and ISRC.
-
-        Returns (filename, track_uuid, isrc).  Matches on title+artist when
-        both are present; falls back to title-only when artist is absent from
-        the caller or from the stored blob (common on Windows for files that
-        have no artist tag).
-        """
-        try:
-            cursor.execute(
-                "SELECT key, data FROM database2"
-                " WHERE collection IN"
-                " ('localMediaItemLocations', 'globalMediaItemLocations')"
-            )
-
-            artist_norm = artist.strip().lower() if artist else ""
-            title_norm = title.strip().lower() if title else ""
-            if not title_norm:
-                return None, None, None
-
-            # Iterate the cursor lazily — fetchall() would load the whole library
-            # into memory before we even start comparing.
-            for row in cursor:
-                track_uuid = row[0]
-                parsed = nowplaying.djaypro.tsaf.parse_blob(row[1])
-
-                p_title = parsed.get("title")
-                p_artist = parsed.get("artist")
-                if not isinstance(p_title, str):
-                    continue
-                if p_title.strip().lower() != title_norm:
-                    continue
-                # Accept when either side has no artist; require match when both do.
-                # Treat empty/whitespace-only stored artist as absent.
-                if artist_norm and isinstance(p_artist, str) and p_artist.strip():
-                    if p_artist.strip().lower() != artist_norm:
-                        continue
-
-                isrc = parsed.get("isrc")
-                return parsed.get("filename"), track_uuid, isrc if isinstance(isrc, str) else None
-
-        except (sqlite3.Error, ValueError, KeyError) as err:
-            logging.debug("Error searching localMediaItemLocations: %s", err)
-
-        return None, None, None
+        nowplaying.djaypro.locationdb.sync(dbfile, self._location_db_path)
+        return nowplaying.djaypro.locationdb.lookup(artist, title, self._location_db_path)
 
     async def stop(self):
         """stop the watcher"""
@@ -905,12 +893,15 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         qsettings.setValue("djaypro/selected_playlists", "")
         qsettings.setValue("djaypro/analyzed_data_delay", _ANALYZED_DATA_RETRY_DEFAULT)
         qsettings.setValue("djaypro/deckskip", None)
+        qsettings.setValue("djaypro/location_max_age_days", 7)
+        qsettings.setValue("djaypro/rebuild_location_db", False)
 
     def connect_settingsui(self, qwidget: "QWidget", uihelp: "nowplaying.uihelp.UIHelp"):
         """connect djay Pro button to filename picker"""
         self.qwidget = qwidget
         self.uihelp = uihelp
         qwidget.dir_button.clicked.connect(self.on_djaypro_dir_button)
+        qwidget.djaypro_rebuild_location_button.clicked.connect(self.on_rebuild_location_button)
 
     def load_settingsui(self, qwidget: "QWidget"):
         """draw the plugin's settings page"""
@@ -936,6 +927,10 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     type=float,
                 )
             )
+        )
+
+        qwidget.djaypro_location_max_age_spinbox.setValue(
+            self.config.cparser.value("djaypro/location_max_age_days", type=int, defaultValue=7)
         )
 
         deckskip = self._get_deckskip()
@@ -969,6 +964,11 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         delay = max(0.0, min(delay, 10.0))
         self.config.cparser.setValue("djaypro/analyzed_data_delay", delay)
 
+        self.config.cparser.setValue(
+            "djaypro/location_max_age_days",
+            qwidget.djaypro_location_max_age_spinbox.value(),
+        )
+
         deckskip = []
         if qwidget.djaypro_deck1_skip_checkbox.isChecked():
             deckskip.append("1")
@@ -979,6 +979,11 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         if qwidget.djaypro_deck4_skip_checkbox.isChecked():
             deckskip.append("4")
         self.config.cparser.setValue("djaypro/deckskip", deckskip)
+
+    def on_rebuild_location_button(self):
+        """user clicked Rebuild Now — schedule a full location index rebuild"""
+        logging.info("Manual djay Pro location index rebuild requested")
+        self.config.cparser.setValue("djaypro/rebuild_location_db", True)
 
     def on_djaypro_dir_button(self):
         """open file browser to set djay Pro directory"""

--- a/nowplaying/djaypro/tsaf.py
+++ b/nowplaying/djaypro/tsaf.py
@@ -134,23 +134,28 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
         nonlocal pos
         result: dict = {}
 
-        # class name (discard)
+        # class name
         if pos >= len(blob) or blob[pos] != 0x08:
             return result
         pos += 1
-        read_string()
+        class_name = read_string()
 
         # Detect obj_id: a string immediately followed by 0x05 is an
         # object identity field, not a named field.
+        #
+        # ADCMediaItemTitleID uses its obj_id as the join key into the
+        # location / analysis tables.  Capture it instead of discarding it.
         local_max: int | None = None
         if pos < len(blob) and blob[pos] == 0x08:
             save_pos = pos
             pos += 1
-            read_string()  # candidate obj_id (discard)
+            obj_id = read_string()
             if pos < len(blob) and blob[pos] == 0x05:
                 pos += 1
                 local_max = blob[pos]
                 pos += 1
+                if class_name == "ADCMediaItemTitleID" and len(obj_id) == 32:
+                    result["titleID"] = obj_id
             else:
                 pos = save_pos  # not an obj_id – rewind
 
@@ -170,7 +175,8 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
                     if pos < len(blob) and blob[pos] == 0x08:
                         pos += 1
                         key = read_string()
-                        result[key] = value
+                        if key not in result:
+                            result[key] = value
                         fields_read += 1
                     continue
                 pos += 1  # end-of-object marker
@@ -275,7 +281,8 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
             if pos < len(blob) and blob[pos] == 0x08:
                 pos += 1
                 key = read_string()
-                result[key] = value
+                if value is not None or key not in result:
+                    result[key] = value
                 fields_read += 1
             elif isinstance(value, list):
                 # Array of objects with no following key: merge dict items
@@ -428,6 +435,11 @@ def parse_blob(blob_data: bytes) -> dict[str, str | int | float | None]:  # pyli
             float(starttime_raw) if isinstance(starttime_raw, (int, float)) else None
         )
 
+        title_id_raw = flat.get("titleID")
+        title_id: str | None = (
+            title_id_raw if isinstance(title_id_raw, str) and len(title_id_raw) == 32 else None
+        )
+
         return {
             "artist": flat.get("artist") or None,  # type: ignore[return-value]
             "title": flat.get("title") or None,  # type: ignore[return-value]
@@ -440,6 +452,7 @@ def parse_blob(blob_data: bytes) -> dict[str, str | int | float | None]:  # pyli
             "isrc": isrc,
             "key": key,
             "starttime": starttime,
+            "title_id": title_id,
         }
     except Exception as err:  # pylint: disable=broad-exception-caught
         logging.debug("Failed to parse blob: %s", err)

--- a/nowplaying/resources/ui/inputs_djaypro.ui
+++ b/nowplaying/resources/ui/inputs_djaypro.ui
@@ -142,6 +142,69 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="location_index_layout">
+     <item>
+      <widget class="QLabel" name="location_index_label">
+       <property name="text">
+        <string>Location Index</string>
+       </property>
+       <property name="toolTip">
+        <string>WNP-owned index of file paths from the djay Pro library. Auto-rebuilt on age; rebuild manually after moving or renaming files in djay Pro.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="djaypro_rebuild_location_button">
+       <property name="text">
+        <string>Rebuild Now</string>
+       </property>
+       <property name="toolTip">
+        <string>Drop and fully rebuild the file-path index from djay Pro's library. Use after moving or renaming tracks in djay Pro.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="location_max_age_label">
+       <property name="text">
+        <string>Rebuild after (days)</string>
+       </property>
+       <property name="toolTip">
+        <string>Automatically rebuild the location index when it is older than this many days.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="djaypro_location_max_age_spinbox">
+       <property name="toolTip">
+        <string>Automatically rebuild the location index when it is older than this many days.</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>365</number>
+       </property>
+       <property name="value">
+        <number>7</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="location_index_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QTextBrowser" name="help_label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -157,6 +220,7 @@ p, li { white-space: pre-wrap; }
 &lt;p&gt;djay Pro is professional DJ software by Algoriddim for macOS and Windows.&lt;/p&gt;
 &lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Artist Query Scope&lt;/span&gt; controls which tracks are searched for the !hasartist Twitch chat command and roulette playlist requests. Choose &lt;span style=&quot;font-weight:600;&quot;&gt;Entire Library&lt;/span&gt; to search all tracks, or &lt;span style=&quot;font-weight:600;&quot;&gt;Selected Playlists&lt;/span&gt; and enter comma-separated playlist names to limit the search. Note: Selected Playlists only finds playlists created natively in djay Pro.&lt;/p&gt;
 &lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Analysis Delay&lt;/span&gt; controls how long (in seconds) What&apos;s Now Playing waits after a new track starts before reading BPM, key, and file path data. djay Pro writes the track name first, then commits analysis data in a separate database transaction. The default of 0.5 seconds works for most systems. If BPM, key, or file path are consistently missing, increase this value.&lt;/p&gt;
+&lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Location Index&lt;/span&gt; — WNP maintains a fast index of file paths from your djay Pro library, updated automatically as you add tracks. &lt;span style=&quot;font-weight:600;&quot;&gt;Rebuild after (days)&lt;/span&gt; controls how often the index is rebuilt automatically. Click &lt;span style=&quot;font-weight:600;&quot;&gt;Rebuild Now&lt;/span&gt; to force an immediate rebuild after moving or renaming files in djay Pro.&lt;/p&gt;
 &lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Ignore Deck(s)&lt;/span&gt; — check any deck numbers that What&apos;s Now Playing should never report. Useful for preview decks or sampler decks that should not trigger now-playing updates.&lt;/p&gt;
 &lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -311,6 +311,41 @@ def test_parse_blob_key_out_of_range():
     assert result["key"] is None
 
 
+def test_parse_blob_title_id_from_nested_object():
+    """parse_blob extracts titleID from an ADCMediaItemTitleID nested object.
+
+    Real historySessionItems blobs have:
+      0x2b 0x08 'ADCMediaItemTitleID' 0x00  (nested class)
+      0x08 <32-hex-uuid> 0x00              (obj_id — the join key)
+      0x05 0x02                             (nested field count = 2)
+      <2 fields consumed by nested object>
+    followed by a 0x2e null-typed 'titleID' field that must NOT stomp the UUID.
+    """
+    uuid = "a1b2c3d4e5f6789012345678901234ab"
+    header = b"TSAF" + b"\x00" * 16
+    outer = bytearray()
+    outer += b"\x08ADCHistorySessionItem\x00"  # class name (no field count — reads to EOS)
+    # artist and title fields
+    outer += b"\x08Test Artist\x00\x08artist\x00"
+    outer += b"\x08Test Track\x00\x08title\x00"
+    # nested ADCMediaItemTitleID: obj_id=UUID, 0x05 0x02 = 2 fields for nested to consume
+    outer += b"\x2b"
+    outer += b"\x08ADCMediaItemTitleID\x00"
+    outer += b"\x08" + uuid.encode() + b"\x00"
+    outer += b"\x05\x02"
+    outer += b"\x08nested1\x00\x08nf1\x00"  # 2 fields consumed by nested obj
+    outer += b"\x08nested2\x00\x08nf2\x00"
+    # 0x2e null field named 'titleID' — must not overwrite the UUID
+    outer += b"\x2e\x08titleID\x00"
+
+    blob = header + b"\x2b" + bytes(outer)
+    result = nowplaying.djaypro.tsaf.parse_blob(blob)
+
+    assert result["title_id"] == uuid
+    assert result["artist"] == "Test Artist"
+    assert result["title"] == "Test Track"
+
+
 # ---------------------------------------------------------------------------
 # parse_tsaf primitive type smoke tests
 # ---------------------------------------------------------------------------
@@ -460,6 +495,7 @@ def test_check_for_new_track_uses_analyzed_bpm(bootstrap):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         plugin.djaypro_dir = tmpdir
+        plugin._location_db_path = pathlib.Path(tmpdir).joinpath("locations.db")
         dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
 
         track_uuid = "beat-artist-kick-drum-uuid"
@@ -618,6 +654,7 @@ def test_check_for_new_track_isrc_sources(  # pylint: disable=too-many-arguments
 
     with tempfile.TemporaryDirectory() as tmpdir:
         plugin.djaypro_dir = tmpdir
+        plugin._location_db_path = pathlib.Path(tmpdir).joinpath("locations.db")
         dbfile = pathlib.Path(tmpdir).joinpath("MediaLibrary.db")
 
         history_blob = _build_tsaf_blob(


### PR DESCRIPTION
Replace full O(n) TSAF blob scan with two lookup strategies:
- Fast path: extract ADCMediaItemTitleID UUID from history blobs via fixed TSAF parser, then do a single keyed DB lookup (O(1))
- Slow path: WNP-owned side SQLite index synced incrementally via MAX(rowid), with O(log n) artist/title lookup

Add age-based auto-rebuild (default 7 days) and a manual Rebuild Now button in settings UI. Verified against macOS and Windows DBs.

## Summary by Sourcery

Introduce a fast, indexed lookup path for djay Pro track locations and metadata to avoid full TSAF blob scans, with automatic and manual index maintenance.

New Features:
- Add a WNP-owned SQLite location index with incremental sync from djay Pro’s database and O(log n) artist/title lookups.
- Add an O(1) direct location lookup path using ADCMediaItemTitleID extracted from history blobs.
- Expose a configurable age limit and manual “Rebuild Now” control for the djay Pro location index in the settings UI.

Enhancements:
- Extend TSAF parsing to capture stable ADCMediaItemTitleID identifiers without being overwritten by null titleID fields and surface them as title_id in parsed results.
- Refactor djay Pro plugin filename/metadata resolution to consume title_id when available and to route lookups through the new location index module.
- Record and honor last-rebuild timestamps for the location index to trigger periodic automatic rebuilds.

Tests:
- Add unit coverage for nested ADCMediaItemTitleID parsing and title_id extraction from TSAF blobs.
- Update djay Pro plugin tests to exercise the new location index path and configuration defaults.