### PR TITLE
Refresh template list each time preview window is raised

### DIFF
--- a/nowplaying/kick/settings.py
+++ b/nowplaying/kick/settings.py
@@ -250,6 +250,7 @@ class KickChatSettings:
                 enable_select_button=True,
             )
             self._textpreview_window.template_selected.connect(self._on_announce_template_selected)
+        self._textpreview_window.populate_templates()
         nowplaying.utils.qt.focus_window(self._textpreview_window)
 
     @Slot(str)

--- a/nowplaying/preview/textwindow.py
+++ b/nowplaying/preview/textwindow.py
@@ -61,7 +61,7 @@ class TextPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods
         self.setWindowTitle("Text Template Preview")
         self.resize(600, 300)
         self._setup_ui()
-        self._populate_templates()
+        self.populate_templates()
         self._render()
 
     # ------------------------------------------------------------------
@@ -102,7 +102,7 @@ class TextPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods
         self.text_edit.setReadOnly(True)
         layout.addWidget(self.text_edit)
 
-    def _populate_templates(self) -> None:
+    def populate_templates(self) -> None:
         """Fill the combobox with matching template files."""
         templatedir = pathlib.Path(self.config.templatedir)
         templates = sorted(templatedir.glob(self.glob_pattern))
@@ -111,11 +111,14 @@ class TextPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods
         configured_name = pathlib.Path(configured).name if configured else ""
 
         self.template_combo.blockSignals(True)
+        self.template_combo.clear()
         if not templates:
             self.template_combo.addItem("(no templates found)", userData=None)
             self.template_combo.setEnabled(False)
             self.text_edit.setEnabled(False)
         else:
+            self.template_combo.setEnabled(True)
+            self.text_edit.setEnabled(True)
             for tmpl in templates:
                 self.template_combo.addItem(tmpl.name, userData=tmpl.name)
 

--- a/nowplaying/preview/window.py
+++ b/nowplaying/preview/window.py
@@ -59,7 +59,7 @@ class WebPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods,too-m
         self.setWindowTitle("Template Preview")
         self.resize(900, 600)
         self._setup_ui()
-        self._populate_templates()
+        self.populate_templates()
         self._load_current()
 
     # ------------------------------------------------------------------
@@ -135,7 +135,7 @@ class WebPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods,too-m
         self._apply_bg(0)
         layout.addWidget(self.webview)
 
-    def _populate_templates(self) -> None:
+    def populate_templates(self) -> None:
         """Fill the combobox with .htm files from the bundled template directory."""
         templatedir = pathlib.Path(self.config.templatedir)
         templates = sorted(templatedir.glob("*.htm"))
@@ -144,11 +144,14 @@ class WebPreviewWindow(QWidget):  # pylint: disable=too-few-public-methods,too-m
         configured_name = pathlib.Path(configured).name if configured else ""
 
         self.template_combo.blockSignals(True)
+        self.template_combo.clear()
         if not templates:
             self.template_combo.addItem("(no templates found)", userData=None)
             self.template_combo.setEnabled(False)
             self.webview.setEnabled(False)
         else:
+            self.template_combo.setEnabled(True)
+            self.webview.setEnabled(True)
             for tmpl in templates:
                 self.template_combo.addItem(tmpl.name, userData=tmpl.name)
 

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -1078,6 +1078,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             )
             window.template_selected.connect(on_selected)
             setattr(self, attr, window)
+        window.populate_templates()
         nowplaying.utils.qt.focus_window(window)
 
     @Slot()
@@ -1132,6 +1133,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
                 config=self.config, enable_select_button=True
             )
             self._webpreview_window.template_selected.connect(self._on_webserver_template_selected)
+        self._webpreview_window.populate_templates()
         nowplaying.utils.qt.focus_window(self._webpreview_window)
 
     @Slot(str)

--- a/nowplaying/twitch/settings.py
+++ b/nowplaying/twitch/settings.py
@@ -263,6 +263,7 @@ class TwitchSettings:
             self._streamtitle_preview_window.template_selected.connect(
                 self._on_streamtitle_template_selected
             )
+        self._streamtitle_preview_window.populate_templates()
         current = pathlib.Path(self.widget.streamtitle_lineedit.text()).name
         if current:
             self._streamtitle_preview_window.select_template(current)


### PR DESCRIPTION
Make populate_templates() public and call it on every button click so newly added templates appear without restarting. Also clears and re-enables the combo/editor when switching from empty to non-empty.

## Summary by Sourcery

Refresh template preview windows to reload available templates each time they are opened and ensure controls are correctly enabled or disabled based on template availability.

New Features:
- Allow preview windows to repopulate the template list on each open so newly added templates appear without restarting.

Enhancements:
- Expose template population methods publicly for reuse when showing preview windows.
- Ensure template combo boxes and associated views/editors are cleared and re-enabled when templates become available after previously being empty.