### PR TITLE
Add missing Qt/WebEngine libs to AlmaLinux 8 Docker build

### DIFF
--- a/bincomponents/Dockerfile
+++ b/bincomponents/Dockerfile
@@ -30,18 +30,32 @@ RUN dnf install -y \
 # them under the right SONAMEs automatically.
 RUN dnf install -y \
     alsa-lib \
+    atk \
+    cairo \
+    cups-libs \
+    fontconfig \
+    freetype \
+    gdk-pixbuf2 \
+    gtk3 \
+    libatomic \
     libdrm \
+    libX11-xcb \
+    libXcomposite \
+    libXdamage \
+    libXrandr \
+    libXrender \
+    libxcb \
+    libxkbfile \
     mesa-libEGL \
     mesa-libGL \
     nss \
     nspr \
+    pango \
     pulseaudio-libs \
     libwayland-client \
     libwayland-cursor \
     libwayland-egl \
     libwayland-server \
-    libX11-xcb \
-    libxcb \
     xcb-util \
     xcb-util-cursor \
     xcb-util-image \

--- a/builder.sh
+++ b/builder.sh
@@ -256,6 +256,12 @@ mv dist "${DISTDIR}"
 #   DISTDIR/WhatsNowPlaying      (Linux)
 if [[ "${SYSTEM}" == "macosx" ]]; then
   rm -rf "${DISTDIR}"/WhatsNowPlaying || true
+elif [[ "${SYSTEM}" == "linux" ]]; then
+  # Rename COLLECT dir aside first — the Linux binary is also named
+  # "WhatsNowPlaying", so mv would refuse to overwrite the directory.
+  mv "${DISTDIR}"/WhatsNowPlaying "${DISTDIR}"/.collect
+  mv "${DISTDIR}"/.collect/* "${DISTDIR}"/
+  rmdir "${DISTDIR}"/.collect || true
 else
   mv "${DISTDIR}"/WhatsNowPlaying/* "${DISTDIR}"/
   rmdir "${DISTDIR}"/WhatsNowPlaying || true


### PR DESCRIPTION
fontconfig, freetype, libatomic, cups-libs, X11 damage/randr/ composite/render/xkbfile, and GTK3 stack were missing from the dnf install block; PyInstaller could not bundle them at analysis time.