### PR TITLE
Fix Version comparison: total ordering via sort key

### DIFF
--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -2,6 +2,7 @@
 """non-UI utility code for upgrade"""
 
 import copy
+import functools
 import logging
 import re
 import typing as t
@@ -43,6 +44,7 @@ VERSION_REGEX = re.compile(
 )
 
 
+@functools.total_ordering
 class Version:
     """process a version"""
 
@@ -61,22 +63,62 @@ class Version:
             if isinstance(value, str) and value.isdigit():
                 self.chunk[key] = int(value)
 
-        # Extract numeric part from commitnum for comparison (e.g., "16.g4b43e790" -> 16)
         if self.chunk.get("commitnum"):
             commit_str = str(self.chunk["commitnum"])
             leading = commit_str.split(".", maxsplit=1)[0]
-            if leading.isdigit():
-                self.chunk["commitnum_number"] = int(leading)
-            else:
-                self.chunk["commitnum_number"] = 0
+            self.chunk["commitnum_number"] = int(leading) if leading.isdigit() else 0
 
         if (
-            self.chunk.get("rc")
-            or self.chunk.get("preview")
-            or self.chunk.get("prerelease")
+            self.chunk.get("rc") is not None
+            or self.chunk.get("preview") is not None
+            or self.chunk.get("prerelease") is not None
             or self.chunk.get("commitnum")
         ):
             self.pre = True
+
+    def _sort_key(self) -> tuple[int, int, int, int, int]:
+        """Canonical sort key for total ordering.
+
+        Tiers (ascending):
+          0 — pre-release (rc, preview, or generic prerelease); rc and preview
+              are treated as equivalent — only the number distinguishes them.
+          1 — stable release
+          2 — dev build (commit on top of a release tag)
+        """
+        major = int(self.chunk.get("major") or 0)
+        minor = int(self.chunk.get("minor") or 0)
+        micro = int(self.chunk.get("micro") or 0)
+
+        if self.chunk.get("commitnum"):
+            return (major, minor, micro, 2, int(self.chunk.get("commitnum_number") or 0))
+        if not self.pre:
+            return (major, minor, micro, 1, 0)
+        # rc and preview share tier 0; the number is the sub-key.
+        # Use explicit None checks — rc0/preview0 are valid and int(0) is falsy.
+        rc = self.chunk.get("rc")
+        preview = self.chunk.get("preview")
+        if rc is not None:
+            pre_num = int(rc)
+        elif preview is not None:
+            pre_num = int(preview)
+        else:
+            pre_num = 0
+        return (major, minor, micro, 0, pre_num)
+
+    @property
+    def major(self) -> int:
+        """major version number"""
+        return int(self.chunk.get("major") or 0)
+
+    @property
+    def minor(self) -> int:
+        """minor version number"""
+        return int(self.chunk.get("minor") or 0)
+
+    @property
+    def micro(self) -> int:
+        """micro version number"""
+        return int(self.chunk.get("micro") or 0)
 
     def is_prerelease(self) -> bool:
         """if a pre-release, return True"""
@@ -85,109 +127,18 @@ class Version:
     def __str__(self) -> str:
         return self.textversion
 
-    def __lt__(  # pylint: disable=too-many-return-statements
-        self, other: t.Any
-    ) -> bool:
-        """version compare
-        do the easy stuff, major > minor > micro"""
-        for key in ["major", "minor", "micro"]:
-            if self.chunk.get(key) == other.chunk.get(key):
-                continue
-            return self.chunk.get(key) < other.chunk.get(key)
-
-        # rc/preview/prerelease < no rc/preview/prerelease
-        self_has_pre = (
-            self.chunk.get("rc") or self.chunk.get("preview") or self.chunk.get("prerelease")
-        )
-        other_has_pre = (
-            other.chunk.get("rc") or other.chunk.get("preview") or other.chunk.get("prerelease")
-        )
-
-        if self_has_pre:
-            if not other_has_pre:
-                return True
-
-            # Compare rc numbers if both have rc
-            if (
-                self.chunk.get("rc")
-                and other.chunk.get("rc")
-                and self.chunk.get("rc") != other.chunk.get("rc")
-            ):
-                return self.chunk.get("rc") < other.chunk.get("rc")
-            # Compare preview numbers if both have preview
-            if (
-                self.chunk.get("preview")
-                and other.chunk.get("preview")
-                and self.chunk.get("preview") != other.chunk.get("preview")
-            ):
-                return self.chunk.get("preview") < other.chunk.get("preview")
-            # Compare prerelease strings if both have prerelease
-            if (
-                self.chunk.get("prerelease")
-                and other.chunk.get("prerelease")
-                and self.chunk.get("prerelease") != other.chunk.get("prerelease")
-            ):
-                return self.chunk.get("prerelease") < other.chunk.get("prerelease")
-
-        # but commitnum > no commitnum at this point
-        if self.chunk.get("commitnum") and not other.chunk.get("commitnum"):
-            return False
-        if not self.chunk.get("commitnum") and other.chunk.get("commitnum"):
-            return True
-
-        if (
-            self.chunk.get("commitnum")
-            and other.chunk.get("commitnum")
-            and self.chunk.get("commitnum") != other.chunk.get("commitnum")
-        ):
-            # Compare numeric part of commitnum
-            return self.chunk.get("commitnum_number", 0) < other.chunk.get("commitnum_number", 0)
-
-        return False
-
-    def __le__(self, other: t.Any) -> bool:
-        """version less than or equal"""
-        return self == other or self < other
+    def __lt__(self, other: t.Any) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._sort_key() < other._sort_key()
 
     def __eq__(self, other: t.Any) -> bool:
-        """version equality"""
         if not isinstance(other, Version):
             return False
-        return (
-            self.chunk.get("major") == other.chunk.get("major")
-            and self.chunk.get("minor") == other.chunk.get("minor")
-            and self.chunk.get("micro") == other.chunk.get("micro")
-            and self.chunk.get("rc") == other.chunk.get("rc")
-            and self.chunk.get("preview") == other.chunk.get("preview")
-            and self.chunk.get("prerelease") == other.chunk.get("prerelease")
-            and self.chunk.get("commitnum") == other.chunk.get("commitnum")
-        )
-
-    def __ne__(self, other: t.Any) -> bool:
-        """version not equal"""
-        return not self == other
+        return self._sort_key() == other._sort_key()
 
     def __hash__(self) -> int:
-        """version hash"""
-        return hash(
-            (
-                self.chunk.get("major"),
-                self.chunk.get("minor"),
-                self.chunk.get("micro"),
-                self.chunk.get("rc"),
-                self.chunk.get("preview"),
-                self.chunk.get("prerelease"),
-                self.chunk.get("commitnum"),
-            )
-        )
-
-    def __gt__(self, other: t.Any) -> bool:
-        """version greater than"""
-        return not (self < other or self == other)
-
-    def __ge__(self, other: t.Any) -> bool:
-        """version greater than or equal"""
-        return not self < other
+        return hash(self._sort_key())
 
 
 def _is_prerelease(version: str) -> bool:
@@ -204,9 +155,9 @@ def _build_version_params(
     prefer_prerelease: opt-in flag from settings.  Sends `track=prerelease`
     even when the user is currently on a stable build, so stable users
     can subscribe to the prerelease track via the settings checkbox.
-    The auto-detection of `_is_prerelease(current_version)` still
-    applies: a user already running a prerelease keeps getting
-    prereleases regardless of the setting.
+    Auto-detection via Version.is_prerelease() still applies: a user
+    already running a prerelease keeps getting prereleases regardless
+    of the setting.
     """
     current_version = nowplaying.version.__VERSION__  # pylint: disable=no-member
 
@@ -219,7 +170,7 @@ def _build_version_params(
         params["chipset"] = chipset
     if macos_version := platform_info.get("macos_version"):
         params["macos_version"] = macos_version
-    if _is_prerelease(current_version) or prefer_prerelease:
+    if Version(current_version).is_prerelease() or prefer_prerelease:
         params["track"] = "prerelease"
 
     return params

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -85,16 +85,15 @@ class Version:
           1 — stable release
           2 — dev build (commit on top of a release tag)
         """
-        major = int(self.chunk.get("major") or 0)
-        minor = int(self.chunk.get("minor") or 0)
-        micro = int(self.chunk.get("micro") or 0)
-
         if self.chunk.get("commitnum"):
-            return (major, minor, micro, 2, int(self.chunk.get("commitnum_number") or 0))
+            commitnum = int(self.chunk.get("commitnum_number") or 0)
+            return (self.major, self.minor, self.micro, 2, commitnum)
         if not self.pre:
-            return (major, minor, micro, 1, 0)
+            return (self.major, self.minor, self.micro, 1, 0)
         # rc and preview share tier 0; the number is the sub-key.
         # Use explicit None checks — rc0/preview0 are valid and int(0) is falsy.
+        # Generic prerelease strings (e.g. "alpha") have no number and all sort equally at 0;
+        # WNP only uses rc/preview so this is intentional.
         rc = self.chunk.get("rc")
         preview = self.chunk.get("preview")
         if rc is not None:
@@ -103,7 +102,7 @@ class Version:
             pre_num = int(preview)
         else:
             pre_num = 0
-        return (major, minor, micro, 0, pre_num)
+        return (self.major, self.minor, self.micro, 0, pre_num)
 
     @property
     def major(self) -> int:

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -60,8 +60,9 @@ from nowplaying.upgrades import Version
     ],
 )
 def test_version_lt(lesser, greater):
+    """lesser is strictly less than greater, and not the reverse"""
     assert Version(lesser) < Version(greater)
-    assert not Version(greater) < Version(lesser)
+    assert Version(greater) >= Version(lesser)
 
 
 @pytest.mark.parametrize(
@@ -79,9 +80,10 @@ def test_version_lt(lesser, greater):
     ],
 )
 def test_version_eq(left, right):
+    """equal versions compare as equal and neither is less than the other"""
     assert Version(left) == Version(right)
-    assert not Version(left) < Version(right)
-    assert not Version(right) < Version(left)
+    assert Version(left) >= Version(right)
+    assert Version(right) >= Version(left)
 
 
 def test_version_hash_equal_versions_same_hash():
@@ -91,6 +93,7 @@ def test_version_hash_equal_versions_same_hash():
 
 
 def test_version_hash_unequal_versions_differ():
+    """unequal versions should have different hashes"""
     assert hash(Version("5.2.1")) != hash(Version("5.2.1-rc1"))
     assert hash(Version("5.2.1")) != hash(Version("5.2.1+10.gf95bd3f6"))
 

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -92,10 +92,10 @@ def test_version_hash_equal_versions_same_hash():
     assert hash(Version("5.2.1")) == hash(Version("5.2.1"))
 
 
-def test_version_hash_unequal_versions_differ():
-    """unequal versions should have different hashes"""
-    assert hash(Version("5.2.1")) != hash(Version("5.2.1-rc1"))
-    assert hash(Version("5.2.1")) != hash(Version("5.2.1+10.gf95bd3f6"))
+def test_version_hash_unequal_versions_coexist_in_set():
+    """unequal versions must be distinguishable as distinct set members"""
+    assert len({Version("5.2.1"), Version("5.2.1-rc1")}) == 2
+    assert len({Version("5.2.1"), Version("5.2.1+10.gf95bd3f6")}) == 2
 
 
 def test_version_sortable():

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -9,6 +9,115 @@ import requests
 
 import nowplaying.upgrades
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
+from nowplaying.upgrades import Version
+
+
+# ---------------------------------------------------------------------------
+# Version comparison
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "lesser,greater",
+    [
+        # major/minor/micro ordering
+        ("1.0.0", "2.0.0"),
+        ("1.0.0", "1.1.0"),
+        ("1.0.0", "1.0.1"),
+        ("5.2.0", "5.2.1"),
+        ("5.1.9", "5.2.0"),
+        ("4.9.9", "5.0.0"),
+        # pre-release < stable (same base)
+        ("5.2.1-rc1", "5.2.1"),
+        ("5.2.1-preview1", "5.2.1"),
+        # higher pre-release number (same type)
+        ("5.2.1-rc1", "5.2.1-rc2"),
+        ("5.2.1-preview1", "5.2.1-preview2"),
+        # rc and preview are the same tier — number still orders them
+        ("5.2.1-rc1", "5.2.1-preview2"),
+        ("5.2.1-preview1", "5.2.1-rc2"),
+        # stable < dev build (same base)
+        ("5.2.1", "5.2.1+10.gf95bd3f6"),
+        # pre-release < dev build (same base)
+        ("5.2.1-rc1", "5.2.1+10.gf95bd3f6"),
+        ("5.2.1-preview1", "5.2.1+10.gf95bd3f6"),
+        # dev build commit count ordering
+        ("5.2.1+5.gabcdef0", "5.2.1+10.gf95bd3f6"),
+        # cross-version: pre of next > stable of current
+        ("5.2.1", "5.2.2-preview1"),
+        # cross-version: same pre number, different base
+        ("5.2.1-preview1", "5.2.2-preview1"),
+        # cross-version: dev build of old < pre-release of next
+        ("5.2.0+10.gf95bd3f6", "5.2.1-preview1"),
+        # cross-version: dev build of old < stable of next
+        ("5.2.0+99.gabcdef0", "5.2.1"),
+        # rc0/preview0 are valid pre-releases, lower than rc1/preview1
+        ("5.2.1-rc0", "5.2.1-rc1"),
+        ("5.2.1-preview0", "5.2.1-preview1"),
+        # rc0/preview0 are pre-releases, lower than stable
+        ("5.2.1-rc0", "5.2.1"),
+        ("5.2.1-preview0", "5.2.1"),
+    ],
+)
+def test_version_lt(lesser, greater):
+    assert Version(lesser) < Version(greater)
+    assert not Version(greater) < Version(lesser)
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        # identical stable
+        ("5.2.1", "5.2.1"),
+        # rc == preview at same number
+        ("5.2.1-rc1", "5.2.1-preview1"),
+        ("5.2.1-rc2", "5.2.1-preview2"),
+        # identical dev builds
+        ("5.2.1+10.gf95bd3f6", "5.2.1+10.gf95bd3f6"),
+        # rc0 == preview0
+        ("5.2.1-rc0", "5.2.1-preview0"),
+    ],
+)
+def test_version_eq(left, right):
+    assert Version(left) == Version(right)
+    assert not Version(left) < Version(right)
+    assert not Version(right) < Version(left)
+
+
+def test_version_hash_equal_versions_same_hash():
+    """equal versions must have the same hash (set/dict contract)"""
+    assert hash(Version("5.2.1-rc1")) == hash(Version("5.2.1-preview1"))
+    assert hash(Version("5.2.1")) == hash(Version("5.2.1"))
+
+
+def test_version_hash_unequal_versions_differ():
+    assert hash(Version("5.2.1")) != hash(Version("5.2.1-rc1"))
+    assert hash(Version("5.2.1")) != hash(Version("5.2.1+10.gf95bd3f6"))
+
+
+def test_version_sortable():
+    """sorted() produces a consistent total ordering across all types"""
+    versions = [
+        "5.2.1+10.gf95bd3f6",
+        "5.2.1",
+        "5.2.1-preview2",
+        "5.2.1-rc1",
+        "5.2.0",
+    ]
+    result = [str(v) for v in sorted(Version(v) for v in versions)]
+    assert result == [
+        "5.2.0",
+        "5.2.1-rc1",
+        "5.2.1-preview2",
+        "5.2.1",
+        "5.2.1+10.gf95bd3f6",
+    ]
+
+
+def test_version_in_set():
+    """rc and preview at the same number are deduplicated in a set"""
+    s = {Version("5.2.1-rc1"), Version("5.2.1-preview1")}
+    assert len(s) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
Replace multi-branch __lt__ with _sort_key() tuple so comparison is transitive and consistent. rc and preview are treated as the same tier — only the number distinguishes them (rc1 == preview1, rc2 > preview1). Add @functools.total_ordering to derive __le__/__gt__/__ge__ from __lt__ + __eq__. __hash__ updated to match __eq__.

Add parametrized tests covering stable, rc, preview, cross-type, dev build, and set/sort behaviour.

## Summary by Sourcery

Establish a consistent total ordering for Version objects based on a canonical sort key and align prerelease detection with this logic.

New Features:
- Expose major, minor, and micro properties on Version for convenient access.

Bug Fixes:
- Fix Version comparison to be transitive and consistent across stable, prerelease, and dev build variants.
- Treat rc and preview versions at the same number as equivalent, ensuring correct equality and hashing behaviour.
- Ensure prerelease detection for upgrade track selection uses Version.is_prerelease() rather than a separate string helper.

Enhancements:
- Derive full ordering methods for Version via functools.total_ordering and a canonical sort key.
- Simplify commit number parsing and integrate commit count into version ordering tiers.

Tests:
- Add comprehensive parametrized tests covering Version ordering, equality, hashing, sorting, and set behaviour across stable, rc, preview, dev builds, and cross-version comparisons.