### PR TITLE
Show cached status in upgrade dialog; move tufup tests

### DIFF
--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -471,10 +471,12 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         if not self.config.cparser.value(
             "upgrades/prefetch_enabled", defaultValue=True, type=bool
         ):
+            logging.debug("prefetch: disabled in settings")
             return
 
         install_dir = nowplaying.upgrade._writable_install_dir()  # pylint: disable=protected-access
         if not install_dir:
+            logging.debug("prefetch: skipped (not a packaged build or install dir not writable)")
             return
 
         prefer_prerelease = bool(

--- a/nowplaying/upgrade.py
+++ b/nowplaying/upgrade.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
 
 import nowplaying.upgrades
 import nowplaying.upgrades.autoinstall
+import nowplaying.upgrades.tufup_client
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
 from nowplaying.upgrades.config import UpgradeConfig
 from nowplaying.upgrades.platform import PlatformDetector
@@ -126,6 +127,7 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         platform_str: str | None = None,
         asset_name: str | None = None,
         asset_size_bytes: int | None = None,
+        cached: bool = False,
     ) -> None:
         """fill in the upgrade versions and message"""
         messages = [
@@ -136,11 +138,14 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         if platform_str:
             messages.append(f"Your platform: {platform_str}")
 
-        if asset_name and asset_size_bytes:
+        if asset_name:
             messages.append("")
             messages.append(f"Found: {asset_name}")
-            size_mb = asset_size_bytes / (1024 * 1024)
-            messages.append(f"Size: {size_mb:.1f} MB")
+            if cached:
+                messages.append("Ready to install — no download needed")
+            elif asset_size_bytes:
+                size_mb = asset_size_bytes / (1024 * 1024)
+                messages.append(f"Size: {size_mb:.1f} MB")
 
         for msg in messages:
             message = QLabel(msg)
@@ -168,8 +173,14 @@ def upgrade(bundledir: str | pathlib.Path | None = None) -> None:
         ):
             channel = data.get("tufup_channel")
             install_dir = _writable_install_dir()
+            offer_auto_install = bool(channel and install_dir)
+            cached = offer_auto_install and nowplaying.upgrades.tufup_client.has_cached_update(
+                data["latest_version"]
+            )
+            if cached:
+                logging.debug("upgrade: update archive is pre-cached — install will skip download")
             dialog = UpgradeDialog(
-                offer_auto_install=bool(channel and install_dir),
+                offer_auto_install=offer_auto_install,
             )
             dialog.fill_it_in(
                 nowplaying.version.__VERSION__,  # pylint: disable=no-member
@@ -177,6 +188,7 @@ def upgrade(bundledir: str | pathlib.Path | None = None) -> None:
                 platform_str=platform_str,
                 asset_name=data.get("asset_name"),
                 asset_size_bytes=data.get("asset_size_bytes"),
+                cached=cached,
             )
             # Use the PySide6 .exec_() alias here — semantically identical
             # to .exec() but avoids tripping security scanners that

--- a/nowplaying/upgrades/background.py
+++ b/nowplaying/upgrades/background.py
@@ -90,6 +90,7 @@ class PrefetchWorker(QThread):  # pylint: disable=too-few-public-methods
 
     def run(self) -> None:  # pylint: disable=missing-function-docstring
         try:
+            logger.info("prefetch: checking for update")
             platform_info = PlatformDetector.get_platform_info()
             data = nowplaying.upgrades.check_for_update(
                 platform_info, prefer_prerelease=self.prefer_prerelease
@@ -120,8 +121,10 @@ class PrefetchWorker(QThread):  # pylint: disable=too-few-public-methods
                 logger.debug("prefetch: throttling to %d KB/s", self.bandwidth_kbps)
                 client._fetcher = _ThrottledFetcher(self.bandwidth_kbps)  # pylint: disable=protected-access
 
+            logger.info("prefetch: downloading update on channel %s", channel)
             client._download_updates(progress_hook=None)  # pylint: disable=protected-access
             logger.info("prefetch: download complete for channel %s", channel)
+            nowplaying.upgrades.tufup_client.mark_prefetch_complete(data["latest_version"])
             self.prefetch_complete.emit()
         except Exception as error:  # pylint: disable=broad-except
             logger.exception("prefetch: download failed")

--- a/nowplaying/upgrades/tufup_client.py
+++ b/nowplaying/upgrades/tufup_client.py
@@ -57,6 +57,46 @@ def _default_state_dir() -> pathlib.Path:
     return pathlib.Path(locations[0]) / "tufup"
 
 
+# Sentinel filename written to the targets dir by mark_prefetch_complete().
+# Stores the version string that was successfully pre-fetched so that
+# has_cached_update() can confirm the cached archive is for the right version.
+_PREFETCH_SENTINEL = ".prefetch_version"
+
+
+def mark_prefetch_complete(version: str, state_dir: pathlib.Path | None = None) -> None:
+    """Write the prefetch sentinel so has_cached_update() can detect a warm cache.
+
+    Called by PrefetchWorker after _download_updates() succeeds.  Writes the
+    charts-API version string into targets/.prefetch_version; this exact string
+    is what upgrade() receives as data["latest_version"], so both sides agree.
+    """
+    if state_dir is None:
+        state_dir = _default_state_dir()
+    sentinel = state_dir / "targets" / _PREFETCH_SENTINEL
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text(version, encoding="utf-8")
+        logger.debug("prefetch: wrote sentinel %s for version %s", sentinel, version)
+    except OSError:
+        logger.warning("prefetch: could not write sentinel file %s", sentinel)
+
+
+def has_cached_update(version: str, state_dir: pathlib.Path | None = None) -> bool:
+    """Return True if the background prefetch completed for exactly `version`.
+
+    Reads targets/.prefetch_version (written by mark_prefetch_complete) and
+    compares it to the version string from the charts API.  No network calls.
+    A stale sentinel (wrong version or missing file) returns False cleanly.
+    """
+    if state_dir is None:
+        state_dir = _default_state_dir()
+    sentinel = state_dir / "targets" / _PREFETCH_SENTINEL
+    try:
+        return sentinel.read_text(encoding="utf-8").strip() == version
+    except OSError:
+        return False
+
+
 def _seed_trust_anchor(metadata_dir: pathlib.Path) -> None:
     """Copy the bundled root.json into metadata_dir if it isn't there yet.
 

--- a/tests-qt/test_background_prefetch.py
+++ b/tests-qt/test_background_prefetch.py
@@ -72,7 +72,7 @@ def test_prefetch_worker_emits_skipped_when_tufup_no_update(qtbot, install_dir):
 
 
 def test_prefetch_worker_emits_complete_on_success(qtbot, install_dir):
-    """Emits prefetch_complete after a successful download."""
+    """Emits prefetch_complete after a successful download and writes sentinel."""
     worker = background.PrefetchWorker(install_dir=install_dir)
 
     fake_client = mock.MagicMock()
@@ -84,12 +84,14 @@ def test_prefetch_worker_emits_complete_on_success(qtbot, install_dir):
             return_value={"tufup_channel": "WhatsNowPlaying_test", "latest_version": "9.9.9"},
         ),
         mock.patch("nowplaying.upgrades.tufup_client.build_client", return_value=fake_client),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete") as mock_mark,
     ):
         with qtbot.waitSignal(worker.prefetch_complete, timeout=5000):
             worker.start()
 
     worker.wait()
     fake_client._download_updates.assert_called_once_with(progress_hook=None)
+    mock_mark.assert_called_once_with("9.9.9")
 
 
 def test_prefetch_worker_emits_failed_on_exception(qtbot, install_dir):
@@ -120,6 +122,7 @@ def test_prefetch_worker_installs_throttled_fetcher(qtbot, install_dir):
             return_value={"tufup_channel": "WhatsNowPlaying_test", "latest_version": "9.9.9"},
         ),
         mock.patch("nowplaying.upgrades.tufup_client.build_client", return_value=fake_client),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete"),
     ):
         with qtbot.waitSignal(worker.prefetch_complete, timeout=5000):
             worker.start()
@@ -143,6 +146,7 @@ def test_prefetch_worker_no_throttled_fetcher_when_unlimited(qtbot, install_dir)
             return_value={"tufup_channel": "WhatsNowPlaying_test", "latest_version": "9.9.9"},
         ),
         mock.patch("nowplaying.upgrades.tufup_client.build_client", return_value=fake_client),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete"),
     ):
         with qtbot.waitSignal(worker.prefetch_complete, timeout=5000):
             worker.start()

--- a/tests/test_tufup_client.py
+++ b/tests/test_tufup_client.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
-"""Tests for nowplaying.upgrades.tufup_client."""
+"""Tests for nowplaying.upgrades.tufup_client.
+
+None of these tests use qtbot — they live in tests/ (not tests-qt/).
+QStandardPaths works because the root conftest.py calls set_qt_names()
+which creates a QCoreApplication before any test runs.
+"""
 
 import pathlib
 from unittest import mock
 
 # pylint: disable=protected-access
+
+import pytest
+
 from nowplaying.upgrades import tufup_client
 
 
@@ -111,6 +119,50 @@ def test_win_batch_template_format_substitution():
     assert "WhatsNowPlaying-5.1.0.exe" in result
     assert r"C:\install\WhatsNowPlaying.exe" in result
     assert "robocopy" in result
+
+
+# ---------------------------------------------------------------------------
+# mark_prefetch_complete / has_cached_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", ["5.2.1", "5.3.0-rc1", "6.0.0"])
+def test_has_cached_update_false_when_no_sentinel(tmp_path, version):
+    """Returns False when no sentinel file has been written."""
+    state_dir = tmp_path / "tufup"
+    assert not tufup_client.has_cached_update(version, state_dir)
+
+
+def test_has_cached_update_false_after_wrong_version_prefetched(tmp_path):
+    """Returns False when the sentinel records a different version."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("5.2.0", state_dir)
+    assert not tufup_client.has_cached_update("5.2.1", state_dir)
+
+
+def test_has_cached_update_true_after_correct_version_prefetched(tmp_path):
+    """Returns True when the sentinel matches the requested version."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("5.2.1", state_dir)
+    assert tufup_client.has_cached_update("5.2.1", state_dir)
+
+
+def test_mark_prefetch_complete_creates_sentinel_file(tmp_path):
+    """Sentinel file is created in state_dir/targets/.prefetch_version."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("9.9.9", state_dir)
+    sentinel = state_dir / "targets" / tufup_client._PREFETCH_SENTINEL
+    assert sentinel.exists()
+    assert sentinel.read_text(encoding="utf-8").strip() == "9.9.9"
+
+
+def test_mark_prefetch_complete_overwrites_stale_sentinel(tmp_path):
+    """A second prefetch for a new version updates the sentinel."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("5.2.0", state_dir)
+    tufup_client.mark_prefetch_complete("5.2.1", state_dir)
+    assert tufup_client.has_cached_update("5.2.1", state_dir)
+    assert not tufup_client.has_cached_update("5.2.0", state_dir)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Add mark_prefetch_complete()/has_cached_update() to tufup_client: writes a version sentinel to targets/.prefetch_version after a successful background download; upgrade() reads it to detect a warm cache without a second network call
- upgrade() shows "Ready to install — no download needed" instead of the file size when the sentinel matches the latest version
- Add prefetch logging to background.py and systemtray.py
- Move tests-qt/test_tufup_client.py → tests/test_tufup_client.py; none of those tests use qtbot, and QStandardPaths works fine via the QCoreApplication created by the root conftest
- Mock mark_prefetch_complete in background prefetch success tests to avoid writing to the real user state dir during test runs

## Summary by Sourcery

Detect and surface pre‑cached update archives so the upgrade dialog can show when no download is needed, and adjust tests and logging to support the new prefetch flow.

New Features:
- Add prefetch sentinel support in the TUF client to record completed background downloads and detect cached updates.
- Update the upgrade dialog to indicate when an update is already cached and can be installed without downloading.

Enhancements:
- Add logging around background prefetch checks, downloads, and system tray prefetch decisions for better observability.

Tests:
- Move tufup client tests into the main tests suite and add coverage for the prefetch sentinel behavior, mocking sentinel writes in background prefetch tests to avoid touching real user state.