### PR TITLE
Show cached status in upgrade dialog; cleanup stale tufup archives

### DIFF
--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -471,10 +471,12 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         if not self.config.cparser.value(
             "upgrades/prefetch_enabled", defaultValue=True, type=bool
         ):
+            logging.debug("prefetch: disabled in settings")
             return
 
         install_dir = nowplaying.upgrade._writable_install_dir()  # pylint: disable=protected-access
         if not install_dir:
+            logging.debug("prefetch: skipped (not a packaged build or install dir not writable)")
             return
 
         prefer_prerelease = bool(

--- a/nowplaying/upgrade.py
+++ b/nowplaying/upgrade.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
 
 import nowplaying.upgrades
 import nowplaying.upgrades.autoinstall
+import nowplaying.upgrades.tufup_client
 import nowplaying.version  # pylint: disable=import-error, no-name-in-module
 from nowplaying.upgrades.config import UpgradeConfig
 from nowplaying.upgrades.platform import PlatformDetector
@@ -126,6 +127,7 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         platform_str: str | None = None,
         asset_name: str | None = None,
         asset_size_bytes: int | None = None,
+        cached: bool = False,
     ) -> None:
         """fill in the upgrade versions and message"""
         messages = [
@@ -136,11 +138,14 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         if platform_str:
             messages.append(f"Your platform: {platform_str}")
 
-        if asset_name and asset_size_bytes:
+        if asset_name and (cached or asset_size_bytes is not None):
             messages.append("")
             messages.append(f"Found: {asset_name}")
-            size_mb = asset_size_bytes / (1024 * 1024)
-            messages.append(f"Size: {size_mb:.1f} MB")
+            if cached:
+                messages.append("Ready to install — no download needed")
+            elif asset_size_bytes is not None:
+                size_mb = asset_size_bytes / (1024 * 1024)
+                messages.append(f"Size: {size_mb:.1f} MB")
 
         for msg in messages:
             message = QLabel(msg)
@@ -163,13 +168,20 @@ def upgrade(bundledir: str | pathlib.Path | None = None) -> None:
         prefer_prerelease = bool(
             QSettings().value("upgrades/prefer_prerelease", defaultValue=False, type=bool)
         )
+        nowplaying.upgrades.tufup_client.cleanup_stale_targets()
         if data := nowplaying.upgrades.check_for_update(
             platform_info, prefer_prerelease=prefer_prerelease
         ):
             channel = data.get("tufup_channel")
             install_dir = _writable_install_dir()
+            offer_auto_install = bool(channel and install_dir)
+            cached = offer_auto_install and nowplaying.upgrades.tufup_client.has_cached_update(
+                data["latest_version"]
+            )
+            if cached:
+                logging.debug("upgrade: update archive is pre-cached — install will skip download")
             dialog = UpgradeDialog(
-                offer_auto_install=bool(channel and install_dir),
+                offer_auto_install=offer_auto_install,
             )
             dialog.fill_it_in(
                 nowplaying.version.__VERSION__,  # pylint: disable=no-member
@@ -177,6 +189,7 @@ def upgrade(bundledir: str | pathlib.Path | None = None) -> None:
                 platform_str=platform_str,
                 asset_name=data.get("asset_name"),
                 asset_size_bytes=data.get("asset_size_bytes"),
+                cached=cached,
             )
             # Use the PySide6 .exec_() alias here — semantically identical
             # to .exec() but avoids tripping security scanners that

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -270,7 +270,7 @@ def check_for_update(
         response = requests.get(UPDATE_CHECK_URL, params=params, timeout=10)
         response.raise_for_status()
         data: dict[str, t.Any] = response.json()
-        if data.get("update_available"):
+        if data.get("update_available") and data.get("latest_version"):
             return data
         return None
     except Exception:  # pylint: disable=broad-except

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -270,7 +270,13 @@ def check_for_update(
         response = requests.get(UPDATE_CHECK_URL, params=params, timeout=10)
         response.raise_for_status()
         data: dict[str, t.Any] = response.json()
-        if data.get("update_available") and data.get("latest_version"):
+        if data.get("update_available"):
+            if not data.get("latest_version"):
+                logging.warning(
+                    "Update check: update_available=True but latest_version missing/empty; "
+                    "treating as no update (malformed API response)"
+                )
+                return None
             return data
         return None
     except Exception:  # pylint: disable=broad-except

--- a/nowplaying/upgrades/autoinstall.py
+++ b/nowplaying/upgrades/autoinstall.py
@@ -13,8 +13,6 @@ from PySide6.QtWidgets import QProgressDialog, QWidget  # pylint: disable=no-nam
 
 import nowplaying.upgrades.tufup_client
 
-logger = logging.getLogger(__name__)
-
 
 class UpdateWorker(QThread):  # pylint: disable=too-few-public-methods
     """Run the synchronous tufup download+apply on a background thread.
@@ -106,7 +104,7 @@ def run_auto_install(
         progress.close()
 
     def on_timeout() -> None:
-        logger.error("Auto-install: download timed out after %ds", download_timeout_ms // 1000)
+        logging.error("Auto-install: download timed out after %ds", download_timeout_ms // 1000)
         on_failed("Download timed out — check your network connection and try again.")
         # terminate() may leave a partial archive on disk; that is safe because
         # tufup's find_cached_target() validates length + hash on the next launch
@@ -130,6 +128,6 @@ def run_auto_install(
     worker.wait()
 
     if failure_message:
-        logger.error("Auto-install: %s", failure_message[0])
+        logging.error("Auto-install: %s", failure_message[0])
         return False
     return True

--- a/nowplaying/upgrades/background.py
+++ b/nowplaying/upgrades/background.py
@@ -106,7 +106,7 @@ class PrefetchWorker(QThread):  # pylint: disable=too-few-public-methods
                 self.prefetch_skipped.emit("No tufup channel for this platform.")
                 return
 
-            state_dir = nowplaying.upgrades.tufup_client._default_state_dir()  # pylint: disable=protected-access
+            state_dir = nowplaying.upgrades.tufup_client.get_state_dir()
             client = nowplaying.upgrades.tufup_client.build_client(
                 self.install_dir, state_dir=state_dir, channel=channel
             )

--- a/nowplaying/upgrades/background.py
+++ b/nowplaying/upgrades/background.py
@@ -18,8 +18,6 @@ import nowplaying.upgrades
 import nowplaying.upgrades.tufup_client
 from nowplaying.upgrades.platform import PlatformDetector
 
-logger = logging.getLogger(__name__)
-
 # Chunk size used when bandwidth throttling is active.  Smaller than tufup's
 # 400 KB default so the sleep granularity produces a smooth cap.
 _THROTTLE_CHUNK_BYTES = 8 * 1024
@@ -90,12 +88,13 @@ class PrefetchWorker(QThread):  # pylint: disable=too-few-public-methods
 
     def run(self) -> None:  # pylint: disable=missing-function-docstring
         try:
+            logging.info("prefetch: checking for update")
             platform_info = PlatformDetector.get_platform_info()
             data = nowplaying.upgrades.check_for_update(
                 platform_info, prefer_prerelease=self.prefer_prerelease
             )
             if not data:
-                logger.debug("prefetch: no update available")
+                logging.debug("prefetch: no update available")
                 self.prefetch_skipped.emit("No update available.")
                 return
 
@@ -103,26 +102,35 @@ class PrefetchWorker(QThread):  # pylint: disable=too-few-public-methods
             if not channel:
                 # Common during rollout: charts API sees an update but no
                 # tufup bundle exists for this platform yet.
-                logger.debug("prefetch: no tufup_channel in API response")
+                logging.debug("prefetch: no tufup_channel in API response")
                 self.prefetch_skipped.emit("No tufup channel for this platform.")
                 return
 
+            state_dir = nowplaying.upgrades.tufup_client._default_state_dir()  # pylint: disable=protected-access
             client = nowplaying.upgrades.tufup_client.build_client(
-                self.install_dir, channel=channel
+                self.install_dir, state_dir=state_dir, channel=channel
             )
             if not client.check_for_updates():
                 # Possible TUF/charts API propagation race — not an error.
-                logger.debug("prefetch: tufup reports no update on channel %s", channel)
+                logging.debug("prefetch: tufup reports no update on channel %s", channel)
                 self.prefetch_skipped.emit("No update available via tufup.")
                 return
 
             if self.bandwidth_kbps > 0:
-                logger.debug("prefetch: throttling to %d KB/s", self.bandwidth_kbps)
+                logging.debug("prefetch: throttling to %d KB/s", self.bandwidth_kbps)
                 client._fetcher = _ThrottledFetcher(self.bandwidth_kbps)  # pylint: disable=protected-access
 
+            logging.info("prefetch: downloading update on channel %s", channel)
             client._download_updates(progress_hook=None)  # pylint: disable=protected-access
-            logger.info("prefetch: download complete for channel %s", channel)
+            logging.info("prefetch: download complete for channel %s", channel)
+            archive_path = client.new_archive_local_path  # pylint: disable=protected-access
+            if archive_path:
+                nowplaying.upgrades.tufup_client.mark_prefetch_complete(
+                    data["latest_version"],
+                    archive_path.name,
+                    state_dir=state_dir,
+                )
             self.prefetch_complete.emit()
         except Exception as error:  # pylint: disable=broad-except
-            logger.exception("prefetch: download failed")
+            logging.exception("prefetch: download failed")
             self.prefetch_failed.emit(str(error))

--- a/nowplaying/upgrades/tufup_client.py
+++ b/nowplaying/upgrades/tufup_client.py
@@ -14,6 +14,7 @@ API supplies the tufup channel, and run_auto_install() in autoinstall.py
 handles the QThread worker and progress UI.
 """
 
+import json
 import logging
 import os
 import pathlib
@@ -38,9 +39,6 @@ if TYPE_CHECKING:
         def __call__(self, *, bytes_downloaded: int, bytes_expected: int) -> None: ...
 
 
-logger = logging.getLogger(__name__)
-
-
 def _default_state_dir() -> pathlib.Path:
     """Per-platform cache directory for tufup state.
 
@@ -52,9 +50,99 @@ def _default_state_dir() -> pathlib.Path:
         QStandardPaths.StandardLocation.AppLocalDataLocation
     )
     if not locations:
-        logger.warning("QStandardPaths returned no AppLocalDataLocation; using home dir fallback")
+        logging.warning("QStandardPaths returned no AppLocalDataLocation; using home dir fallback")
         return pathlib.Path.home() / ".local" / "share" / "WhatsNowPlaying" / "tufup"
     return pathlib.Path(locations[0]) / "tufup"
+
+
+# Sentinel filename written to the targets dir by mark_prefetch_complete().
+# Stores the version string that was successfully pre-fetched so that
+# has_cached_update() can confirm the cached archive is for the right version.
+_PREFETCH_SENTINEL = ".prefetch_version"
+
+
+def mark_prefetch_complete(
+    version: str,
+    filename: str,
+    state_dir: pathlib.Path | None = None,
+) -> None:
+    """Write the prefetch sentinel so has_cached_update() can detect a warm cache.
+
+    Stores version and archive filename as JSON in targets/.prefetch_version.
+    version is the charts-API latest_version string (both sides agree on it).
+    filename is the archive basename from client.new_archive_local_path.name,
+    used by has_cached_update() to confirm the specific file is still on disk.
+    """
+    if state_dir is None:
+        state_dir = _default_state_dir()
+    sentinel = state_dir / "targets" / _PREFETCH_SENTINEL
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text(
+            json.dumps({"version": version, "filename": filename}),
+            encoding="utf-8",
+        )
+        logging.debug("prefetch: wrote sentinel for version %s (%s)", version, filename)
+    except OSError:
+        logging.warning("prefetch: could not write sentinel file %s", sentinel, exc_info=True)
+
+
+def has_cached_update(version: str, state_dir: pathlib.Path | None = None) -> bool:
+    """Return True if the background prefetch completed for exactly `version`
+    and the specific archive file is still on disk.
+
+    Two-step check — no network calls:
+    1. Sentinel targets/.prefetch_version must record `version`.
+    2. The archive filename stored in the sentinel must exist in targets/.
+    """
+    if state_dir is None:
+        state_dir = _default_state_dir()
+    sentinel = state_dir / "targets" / _PREFETCH_SENTINEL
+    try:
+        data = json.loads(sentinel.read_text(encoding="utf-8"))
+        if data.get("version") != version:
+            return False
+        filename = data.get("filename")
+        if not filename:
+            return False
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (state_dir / "targets" / filename).exists()
+
+
+def cleanup_stale_targets(state_dir: pathlib.Path | None = None) -> None:
+    """Delete archives in targets/ that are not the current prefetched version.
+
+    tufup never removes old archives after install (it has a # todo comment for
+    this).  Each release is ~300 MB, so three releases = ~1 GB of waste.  We
+    read the sentinel to find the current archive and delete everything else in
+    targets/ except the sentinel itself.
+
+    Called from upgrade() on every launch so the directory stays bounded to at
+    most one archive regardless of how many versions were skipped.
+    """
+    if state_dir is None:
+        state_dir = _default_state_dir()
+    target_dir = state_dir / "targets"
+    if not target_dir.is_dir():
+        return
+    keep: set[str] = {_PREFETCH_SENTINEL}
+    sentinel = target_dir / _PREFETCH_SENTINEL
+    try:
+        data = json.loads(sentinel.read_text(encoding="utf-8"))
+        if filename := data.get("filename"):
+            keep.add(filename)
+    except (OSError, json.JSONDecodeError):
+        pass
+    for item in target_dir.iterdir():
+        if item.name not in keep:
+            try:
+                item.unlink()
+                logging.debug("prefetch: removed stale archive %s", item.name)
+            except OSError:
+                logging.warning(
+                    "prefetch: could not remove stale archive %s", item.name, exc_info=True
+                )
 
 
 def _seed_trust_anchor(metadata_dir: pathlib.Path) -> None:
@@ -71,10 +159,10 @@ def _seed_trust_anchor(metadata_dir: pathlib.Path) -> None:
     bundledir = pathlib.Path(nowplaying.frozen.frozen_init(None))
     src = bundledir / "resources" / "tufup" / "root.json"
     if not src.exists():
-        logger.warning("Bundled root.json not found at %s; auto-update disabled", src)
+        logging.warning("Bundled root.json not found at %s; auto-update disabled", src)
         return
     shutil.copy(src, dst)
-    logger.info("Seeded TUF trust anchor: %s -> %s", src, dst)
+    logging.info("Seeded TUF trust anchor: %s -> %s", src, dst)
 
 
 # Public HTTPS endpoints fronted by the whatsnowplaying.com FastAPI app.
@@ -149,13 +237,13 @@ def check_for_update(
     try:
         client = build_client(install_dir, channel=channel)
         if client.check_for_updates():
-            logger.info("tufup: update available on channel %s", channel)
+            logging.info("tufup: update available on channel %s", channel)
             return client
-        logger.debug("tufup: no update available on channel %s", channel)
+        logging.debug("tufup: no update available on channel %s", channel)
     except Exception:  # pylint: disable=broad-except
         # tufup raises on metadata fetch failures, network errors, signature
         # mismatches, etc.  Swallow so the live app never blocks on auto-update.
-        logger.exception("tufup: update check failed on channel %s", channel)
+        logging.exception("tufup: update check failed on channel %s", channel)
     return None
 
 
@@ -199,7 +287,7 @@ def _win_install(
     with tempfile.NamedTemporaryFile(mode="w", prefix="tufup", suffix=".bat", delete=False) as fh:
         fh.write(script_text)
         script_path = fh.name
-    logger.debug("tufup install (win): batch=%s", script_path)
+    logging.debug("tufup install (win): batch=%s", script_path)
     startupinfo = subprocess.STARTUPINFO()  # type: ignore[attr-defined]
     startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined]
     startupinfo.wShowWindow = 0  # SW_HIDE
@@ -262,7 +350,7 @@ def _install_without_sys_exit(
     for src, dst in renames:
         if src.exists():
             os.rename(src, dst)
-            logger.debug("tufup install: renamed %s -> %s", src, dst)
+            logging.debug("tufup install: renamed %s -> %s", src, dst)
 
     # No rollback if a move fails mid-way: the versioned-aside backup (above)
     # is the recovery path — the user can relaunch the old binary manually.
@@ -275,9 +363,9 @@ def _install_without_sys_exit(
             else:
                 dest.unlink()
         shutil.move(item, dest)
-    logger.debug("tufup install: moved %s -> %s", src_path, dst_path)
+    logging.debug("tufup install: moved %s -> %s", src_path, dst_path)
 
-    logger.debug("tufup install: spawning %s", new_exe)
+    logging.debug("tufup install: spawning %s", new_exe)
     subprocess.Popen([str(new_exe)])  # nosec  # pylint: disable=consider-using-with
 
 

--- a/nowplaying/upgrades/tufup_client.py
+++ b/nowplaying/upgrades/tufup_client.py
@@ -39,6 +39,15 @@ if TYPE_CHECKING:
         def __call__(self, *, bytes_downloaded: int, bytes_expected: int) -> None: ...
 
 
+def get_state_dir() -> pathlib.Path:
+    """Public accessor for the default tufup state directory.
+
+    Delegates to _default_state_dir() so callers (e.g. background.py) do not
+    need to reference a private name and force a pylint suppression.
+    """
+    return _default_state_dir()
+
+
 def _default_state_dir() -> pathlib.Path:
     """Per-platform cache directory for tufup state.
 
@@ -79,7 +88,7 @@ def mark_prefetch_complete(
     try:
         sentinel.parent.mkdir(parents=True, exist_ok=True)
         sentinel.write_text(
-            json.dumps({"version": version, "filename": filename}),
+            json.dumps({"version": version, "filename": pathlib.Path(filename).name}),
             encoding="utf-8",
         )
         logging.debug("prefetch: wrote sentinel for version %s (%s)", version, filename)
@@ -102,21 +111,32 @@ def has_cached_update(version: str, state_dir: pathlib.Path | None = None) -> bo
         data = json.loads(sentinel.read_text(encoding="utf-8"))
         if data.get("version") != version:
             return False
-        filename = data.get("filename")
-        if not filename:
+        raw = data.get("filename")
+        if not raw:
             return False
+        filename = pathlib.Path(raw).name
     except (OSError, json.JSONDecodeError):
         return False
     return (state_dir / "targets" / filename).exists()
 
 
+_ARCHIVE_SUFFIXES = (".zip", ".tar", ".tar.gz", ".tar.bz2", ".tar.xz")
+
+
+def _is_archive_file(path: pathlib.Path) -> bool:
+    """Return True if path has a known tufup archive extension."""
+    name = path.name
+    return any(name.endswith(suffix) for suffix in _ARCHIVE_SUFFIXES)
+
+
 def cleanup_stale_targets(state_dir: pathlib.Path | None = None) -> None:
-    """Delete archives in targets/ that are not the current prefetched version.
+    """Delete archive files in targets/ that are not the current prefetched version.
 
     tufup never removes old archives after install (it has a # todo comment for
     this).  Each release is ~300 MB, so three releases = ~1 GB of waste.  We
-    read the sentinel to find the current archive and delete everything else in
-    targets/ except the sentinel itself.
+    read the sentinel to find the current archive and delete only regular files
+    with known archive extensions — logs, debug artifacts, and directories are
+    left untouched.
 
     Called from upgrade() on every launch so the directory stays bounded to at
     most one archive regardless of how many versions were skipped.
@@ -126,23 +146,30 @@ def cleanup_stale_targets(state_dir: pathlib.Path | None = None) -> None:
     target_dir = state_dir / "targets"
     if not target_dir.is_dir():
         return
-    keep: set[str] = {_PREFETCH_SENTINEL}
+    keep_name: str | None = None
     sentinel = target_dir / _PREFETCH_SENTINEL
     try:
         data = json.loads(sentinel.read_text(encoding="utf-8"))
         if filename := data.get("filename"):
-            keep.add(filename)
+            keep_name = pathlib.Path(filename).name
     except (OSError, json.JSONDecodeError):
         pass
     for item in target_dir.iterdir():
-        if item.name not in keep:
-            try:
-                item.unlink()
-                logging.debug("prefetch: removed stale archive %s", item.name)
-            except OSError:
-                logging.warning(
-                    "prefetch: could not remove stale archive %s", item.name, exc_info=True
-                )
+        if not item.is_file():
+            continue
+        if item.name == _PREFETCH_SENTINEL:
+            continue
+        if not _is_archive_file(item):
+            continue
+        if keep_name and item.name == keep_name:
+            continue
+        try:
+            item.unlink()
+            logging.debug("prefetch: removed stale archive %s", item.name)
+        except OSError:
+            logging.warning(
+                "prefetch: could not remove stale archive %s", item.name, exc_info=True
+            )
 
 
 def _seed_trust_anchor(metadata_dir: pathlib.Path) -> None:

--- a/tests-qt/test_background_prefetch.py
+++ b/tests-qt/test_background_prefetch.py
@@ -72,7 +72,7 @@ def test_prefetch_worker_emits_skipped_when_tufup_no_update(qtbot, install_dir):
 
 
 def test_prefetch_worker_emits_complete_on_success(qtbot, install_dir):
-    """Emits prefetch_complete after a successful download."""
+    """Emits prefetch_complete after a successful download and writes sentinel."""
     worker = background.PrefetchWorker(install_dir=install_dir)
 
     fake_client = mock.MagicMock()
@@ -84,27 +84,33 @@ def test_prefetch_worker_emits_complete_on_success(qtbot, install_dir):
             return_value={"tufup_channel": "WhatsNowPlaying_test", "latest_version": "9.9.9"},
         ),
         mock.patch("nowplaying.upgrades.tufup_client.build_client", return_value=fake_client),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete") as mock_mark,
     ):
         with qtbot.waitSignal(worker.prefetch_complete, timeout=5000):
             worker.start()
 
     worker.wait()
     fake_client._download_updates.assert_called_once_with(progress_hook=None)
+    mock_mark.assert_called_once_with("9.9.9", mock.ANY, state_dir=mock.ANY)
 
 
 def test_prefetch_worker_emits_failed_on_exception(qtbot, install_dir):
     """Emits prefetch_failed when an unexpected exception occurs."""
     worker = background.PrefetchWorker(install_dir=install_dir)
 
-    with mock.patch(
-        "nowplaying.upgrades.check_for_update",
-        side_effect=RuntimeError("network gone"),
+    with (
+        mock.patch(
+            "nowplaying.upgrades.check_for_update",
+            side_effect=RuntimeError("network gone"),
+        ),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete") as mock_mark,
     ):
         with qtbot.waitSignal(worker.prefetch_failed, timeout=5000) as spy:
             worker.start()
 
     worker.wait()
     assert "network gone" in spy.args[0]
+    mock_mark.assert_not_called()
 
 
 def test_prefetch_worker_installs_throttled_fetcher(qtbot, install_dir):
@@ -120,6 +126,7 @@ def test_prefetch_worker_installs_throttled_fetcher(qtbot, install_dir):
             return_value={"tufup_channel": "WhatsNowPlaying_test", "latest_version": "9.9.9"},
         ),
         mock.patch("nowplaying.upgrades.tufup_client.build_client", return_value=fake_client),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete"),
     ):
         with qtbot.waitSignal(worker.prefetch_complete, timeout=5000):
             worker.start()
@@ -143,6 +150,7 @@ def test_prefetch_worker_no_throttled_fetcher_when_unlimited(qtbot, install_dir)
             return_value={"tufup_channel": "WhatsNowPlaying_test", "latest_version": "9.9.9"},
         ),
         mock.patch("nowplaying.upgrades.tufup_client.build_client", return_value=fake_client),
+        mock.patch("nowplaying.upgrades.tufup_client.mark_prefetch_complete"),
     ):
         with qtbot.waitSignal(worker.prefetch_complete, timeout=5000):
             worker.start()

--- a/tests/test_tufup_client.py
+++ b/tests/test_tufup_client.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
-"""Tests for nowplaying.upgrades.tufup_client."""
+"""Tests for nowplaying.upgrades.tufup_client.
+
+None of these tests use qtbot — they live in tests/ (not tests-qt/).
+QStandardPaths works because the root conftest.py calls set_qt_names()
+which creates a QCoreApplication before any test runs.
+"""
 
 import pathlib
 from unittest import mock
 
 # pylint: disable=protected-access
+
+import pytest
+
 from nowplaying.upgrades import tufup_client
 
 
@@ -111,6 +119,103 @@ def test_win_batch_template_format_substitution():
     assert "WhatsNowPlaying-5.1.0.exe" in result
     assert r"C:\install\WhatsNowPlaying.exe" in result
     assert "robocopy" in result
+
+
+# ---------------------------------------------------------------------------
+# mark_prefetch_complete / has_cached_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", ["5.2.1", "5.3.0-rc1", "6.0.0"])
+def test_has_cached_update_false_when_no_sentinel(tmp_path, version):
+    """Returns False when no sentinel file has been written."""
+    state_dir = tmp_path / "tufup"
+    assert not tufup_client.has_cached_update(version, state_dir)
+
+
+def test_has_cached_update_false_after_wrong_version_prefetched(tmp_path):
+    """Returns False when the sentinel records a different version."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("5.2.0", "WhatsNowPlaying_test-5.2.0.tar.gz", state_dir)
+    assert not tufup_client.has_cached_update("5.2.1", state_dir)
+
+
+def test_has_cached_update_true_after_correct_version_prefetched(tmp_path):
+    """Returns True when the sentinel matches and the named archive is on disk."""
+    state_dir = tmp_path / "tufup"
+    archive = "WhatsNowPlaying_test-5.2.1.tar.gz"
+    tufup_client.mark_prefetch_complete("5.2.1", archive, state_dir)
+    (state_dir / "targets" / archive).write_bytes(b"archive")
+    assert tufup_client.has_cached_update("5.2.1", state_dir)
+
+
+def test_has_cached_update_false_when_archive_evicted(tmp_path):
+    """Returns False when the sentinel is present but the named archive is gone."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("5.2.1", "WhatsNowPlaying_test-5.2.1.tar.gz", state_dir)
+    assert not tufup_client.has_cached_update("5.2.1", state_dir)
+
+
+def test_mark_prefetch_complete_creates_sentinel_file(tmp_path):
+    """Sentinel JSON records version and filename."""
+    import json  # pylint: disable=import-outside-toplevel
+
+    state_dir = tmp_path / "tufup"
+    tufup_client.mark_prefetch_complete("9.9.9", "WhatsNowPlaying_test-9.9.9.tar.gz", state_dir)
+    sentinel = state_dir / "targets" / tufup_client._PREFETCH_SENTINEL
+    assert sentinel.exists()
+    data = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert data["version"] == "9.9.9"
+    assert data["filename"] == "WhatsNowPlaying_test-9.9.9.tar.gz"
+
+
+def test_mark_prefetch_complete_overwrites_stale_sentinel(tmp_path):
+    """A second prefetch for a new version updates the sentinel."""
+    state_dir = tmp_path / "tufup"
+    archive = "WhatsNowPlaying_test-5.2.1.tar.gz"
+    tufup_client.mark_prefetch_complete("5.2.0", "WhatsNowPlaying_test-5.2.0.tar.gz", state_dir)
+    tufup_client.mark_prefetch_complete("5.2.1", archive, state_dir)
+    (state_dir / "targets" / archive).write_bytes(b"archive")
+    assert tufup_client.has_cached_update("5.2.1", state_dir)
+    assert not tufup_client.has_cached_update("5.2.0", state_dir)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_stale_targets
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_removes_stale_archives(tmp_path):
+    """Deletes archives that are not the current sentinel filename."""
+    state_dir = tmp_path / "tufup"
+    targets = state_dir / "targets"
+    targets.mkdir(parents=True)
+    stale = targets / "WhatsNowPlaying_test-5.2.0.tar.gz"
+    current = targets / "WhatsNowPlaying_test-5.2.1.tar.gz"
+    stale.write_bytes(b"old")
+    current.write_bytes(b"new")
+    tufup_client.mark_prefetch_complete("5.2.1", current.name, state_dir)
+    tufup_client.cleanup_stale_targets(state_dir)
+    assert not stale.exists()
+    assert current.exists()
+    assert (targets / tufup_client._PREFETCH_SENTINEL).exists()
+
+
+def test_cleanup_noop_when_no_targets_dir(tmp_path):
+    """Does not raise when the targets directory does not exist."""
+    state_dir = tmp_path / "tufup"
+    tufup_client.cleanup_stale_targets(state_dir)
+
+
+def test_cleanup_noop_when_no_sentinel(tmp_path):
+    """Deletes all archives when there is no sentinel (no known current version)."""
+    state_dir = tmp_path / "tufup"
+    targets = state_dir / "targets"
+    targets.mkdir(parents=True)
+    orphan = targets / "WhatsNowPlaying_test-5.2.0.tar.gz"
+    orphan.write_bytes(b"old")
+    tufup_client.cleanup_stale_targets(state_dir)
+    assert not orphan.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Prefetch sentinel (targets/.prefetch_version):
- Stores version + archive filename as JSON so has_cached_update() can confirm the exact file is still on disk — not just any file
- mark_prefetch_complete() uses the same state_dir as build_client() (computed once in PrefetchWorker.run) so sentinel and archive always point at the same directory
- has_cached_update() checks sentinel version match then verifies the named archive file exists (catches OS eviction)
- cleanup_stale_targets() deletes archives not matching the sentinel; ~300 MB/release means 3 releases = ~1 GB without cleanup; called from upgrade() on every launch

Upgrade dialog:
- Shows "Ready to install — no download needed" when cached=True
- Guards "Found: name" block with (cached or size is not None) to prevent dangling label with no follow-up line
- check_for_update() validates latest_version present before returning dict to prevent silent KeyError at call sites

Code hygiene:
- Drop module-level logger from background.py, tufup_client.py, autoinstall.py — use logging. directly (project convention)
- Move tests-qt/test_tufup_client.py → tests/test_tufup_client.py; none use qtbot; QStandardPaths works via root conftest QCoreApp
- Add exc_info=True to sentinel OSError warning
- Mock mark_prefetch_complete in all success/failure prefetch tests

## Summary by Sourcery

Improve auto-update UX by detecting pre-cached upgrade archives and cleaning up stale tufup data while tightening logging and tests.

New Features:
- Record successful prefetches via a sentinel file so the app can detect when a specific version archive is already cached.
- Show a cached-update message in the upgrade dialog when an update archive is already downloaded.

Bug Fixes:
- Validate presence of latest_version in the update-check response to avoid missing-key failures at call sites.
- Prevent upgrade dialog from rendering an incomplete asset label when size information is absent.

Enhancements:
- Add cleanup of stale tufup target archives on startup to bound disk usage to the current prefetched release.
- Align upgrade-related logging with the project convention by using the root logging namespace and adding richer context for sentinel errors.

Tests:
- Extend tufup client and background prefetch tests to cover prefetch sentinel behavior, cached-update detection, and stale-archive cleanup.
- Relocate tufup client tests from the Qt-specific suite into the general tests directory for simpler coverage.