### PR TITLE
Fill missing QSettings defaults; add stealth-defaults test

### DIFF
--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -381,7 +381,7 @@ class Plugin(ArtistExtrasPlugin):
             self.config.cparser.setValue(f"discogs/{field}", func.isChecked())
 
     def defaults(self, qsettings):
-        for field in ["bio", "fanart", "thumbnails", "coverart"]:
+        for field in ["bio", "fanart", "thumbnails", "websites", "coverart"]:
             qsettings.setValue(f"discogs/{field}", False)
 
         qsettings.setValue("discogs/enabled", False)

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -21,6 +21,7 @@ from PySide6.QtCore import (  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QWidget  # pylint: disable=no-name-in-module
 
 import nowplaying.artistextras
+import nowplaying.discord.settings
 import nowplaying.guessgame.settings
 import nowplaying.inputs
 import nowplaying.notifications
@@ -166,9 +167,11 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         self._defaults_general_settings(settings)
         self._defaults_output(settings)
         self._defaults_chat_services(settings)
+        nowplaying.discord.settings.DiscordSettings.defaults(settings)
         self._defaults_upgrades(settings)
         nowplaying.guessgame.settings.GuessGameSettings.defaults(settings)
         self._defaults_quirks(settings)
+        self._defaults_trackskip(settings)
         self._defaults_requests(settings)
         self._defaults_plugins(settings)
 
@@ -215,6 +218,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         """default values for recognition"""
         settings.setValue("recognition/replacetitle", False)
         settings.setValue("recognition/replaceartist", False)
+        settings.setValue("recognition/replaceartistwebsites", False)
         settings.setValue("setlist/enabled", False)
 
     def _defaults_general_settings(self, settings: QSettings) -> None:
@@ -223,6 +227,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         settings.setValue("settings/initialized", False)
         settings.setValue("settings/loglevel", self.loglevel)
         settings.setValue("settings/notif", self.notif)
+        settings.setValue("settings/requests", False)
         settings.setValue("settings/stripextras", False)
         settings.setValue("tray/icontheme", "auto")
 
@@ -279,10 +284,25 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
     def _defaults_chat_services(self, settings: QSettings) -> None:
         """default values for chat services"""
         settings.setValue("twitchbot/enabled", False)
+        settings.setValue("twitchbot/channel", "")
+        settings.setValue("twitchbot/clientid", "")
+        settings.setValue("twitchbot/secret", "")
+        settings.setValue("twitchbot/streamtitle_enabled", False)
         settings.setValue(
             "twitchbot/streamtitle", str(self.templatedir.joinpath("twitchbot_streamtitle.txt"))
         )
+        settings.setValue("twitchbot/chat", False)
+        settings.setValue("twitchbot/announce", "")
+        settings.setValue("twitchbot/commandchar", "!")
+        settings.setValue("twitchbot/announcedelay", "5")
+        settings.setValue("twitchbot/helpkeyword", "help")
+        settings.setValue("twitchbot/usereplies", False)
+        settings.setValue("twitchbot/chatrequests", False)
+        settings.setValue("twitchbot/redemptions", False)
         settings.setValue("kick/enabled", False)
+        settings.setValue("kick/channel", "")
+        settings.setValue("kick/clientid", "")
+        settings.setValue("kick/secret", "")
         settings.setValue("kick/chat", False)
         settings.setValue("kick/announce", str(self.templatedir.joinpath("kickbot_track.txt")))
         settings.setValue("kick/announcedelay", 1.0)
@@ -293,11 +313,22 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         settings.setValue("quirks/pollingobserver", False)
         settings.setValue("quirks/pollinginterval", 5.0)
         settings.setValue("quirks/filesubst", False)
+        settings.setValue("quirks/filesubstin", "")
+        settings.setValue("quirks/filesubstout", "")
         settings.setValue("quirks/slashmode", "nochange")
+
+    @staticmethod
+    def _defaults_trackskip(settings: QSettings) -> None:
+        """default values for track skip filters"""
+        settings.setValue("trackskip/genre", "")
+        settings.setValue("trackskip/comment", "")
 
     @staticmethod
     def _defaults_requests(settings: QSettings) -> None:
         """default values for requests"""
+        settings.setValue("requests/fuzzythreshold", 85)
+        settings.setValue("gifwords/klipykey", "")
+
         settings.setValue("request-0/command", "request")
         settings.setValue("request-0/twitchtext", "")
         settings.setValue("request-0/type", "Generic")

--- a/nowplaying/denon/plugin.py
+++ b/nowplaying/denon/plugin.py
@@ -63,7 +63,7 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def defaults(self, qsettings: "QSettings | None"):
         """Set default configuration values"""
         qsettings.setValue("denon/discovery_timeout", 5.0)
-        qsettings.setValue("denon/deckskip", None)
+        qsettings.setValue("denon/deckskip", "")
 
     def connect_settingsui(self, qwidget: "QWidget", uihelp: "nowplaying.uihelp.UIHelp"):
         """Connect UI elements"""

--- a/nowplaying/discord/__init__.py
+++ b/nowplaying/discord/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+"""Discord integration for WNP"""

--- a/nowplaying/discord/settings.py
+++ b/nowplaying/discord/settings.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Discord settings UI class"""
+
+import pathlib
+from typing import TYPE_CHECKING, Any
+
+from PySide6.QtCore import Slot  # pylint: disable=no-name-in-module
+
+import nowplaying.preview.textwindow
+import nowplaying.utils.qt
+
+if TYPE_CHECKING:
+    import nowplaying.config
+
+
+class DiscordSettings:
+    """Settings UI handler for the Discord integration."""
+
+    def __init__(self) -> None:
+        self.config: nowplaying.config.ConfigFile | None = None
+        self._widget: Any = None
+        self._uihelp: Any = None
+        self._template_preview: nowplaying.preview.textwindow.TextPreviewWindow | None = None
+        self._channel_template_preview: nowplaying.preview.textwindow.TextPreviewWindow | None = (
+            None
+        )
+
+    def connect(self, uihelp: Any, widget: Any) -> None:
+        """Connect widget signals."""
+        self._uihelp = uihelp
+        self._widget = widget
+        widget.template_button.clicked.connect(self._on_template_button)
+        widget.template_preview_button.clicked.connect(self._on_template_preview_button)
+        widget.channel_template_button.clicked.connect(self._on_channel_template_button)
+        widget.channel_template_preview_button.clicked.connect(
+            self._on_channel_template_preview_button
+        )
+        widget.richpresence_enable_checkbox.toggled.connect(
+            lambda _: DiscordSettings._update_fields(widget)
+        )
+        widget.bot_enable_checkbox.toggled.connect(
+            lambda _: DiscordSettings._update_fields(widget)
+        )
+
+    def load(
+        self,
+        config: nowplaying.config.ConfigFile,
+        widget: Any,
+        _uihelp: Any,
+    ) -> None:
+        """Load config values into the Discord settings widget."""
+        self.config = config
+        self._widget = widget
+        widget.richpresence_enable_checkbox.setChecked(
+            config.cparser.value("discord/richpresence_enabled", type=bool)
+        )
+        widget.bot_enable_checkbox.setChecked(
+            config.cparser.value("discord/bot_enabled", type=bool)
+        )
+        widget.clientid_lineedit.setText(config.cparser.value("discord/clientid") or "")
+        widget.token_lineedit.setText(config.cparser.value("discord/token") or "")
+        widget.channel_id_lineedit.setText(config.cparser.value("discord/channel_id") or "")
+        widget.channel_attach_image_checkbox.setChecked(
+            config.cparser.value("discord/channel_attach_image", type=bool)
+        )
+        widget.channel_image_size_spinbox.setValue(
+            config.cparser.value("discord/channel_image_size", type=int) or 200
+        )
+        widget.channel_template_lineedit.setText(
+            config.cparser.value("discord/channel_template") or ""
+        )
+        widget.channel_strip_extra_lines_checkbox.setChecked(
+            config.cparser.value("discord/channel_strip_extra_lines", type=bool)
+        )
+        widget.template_lineedit.setText(config.cparser.value("discord/template") or "")
+        DiscordSettings._update_fields(widget)
+
+    @staticmethod
+    def save(
+        config: nowplaying.config.ConfigFile,
+        widget: Any,
+        subprocesses: Any,
+    ) -> None:
+        """Save Discord widget values to config."""
+        old_bot = config.cparser.value("discord/bot_enabled", type=bool)
+        old_rp = config.cparser.value("discord/richpresence_enabled", type=bool)
+        new_bot = widget.bot_enable_checkbox.isChecked()
+        new_rp = widget.richpresence_enable_checkbox.isChecked()
+
+        config.cparser.setValue("discord/richpresence_enabled", new_rp)
+        config.cparser.setValue("discord/bot_enabled", new_bot)
+        config.cparser.setValue("discord/clientid", widget.clientid_lineedit.text())
+        config.cparser.setValue("discord/token", widget.token_lineedit.text())
+        config.cparser.setValue("discord/channel_id", widget.channel_id_lineedit.text())
+        config.cparser.setValue(
+            "discord/channel_attach_image", widget.channel_attach_image_checkbox.isChecked()
+        )
+        config.cparser.setValue(
+            "discord/channel_image_size", widget.channel_image_size_spinbox.value()
+        )
+        config.cparser.setValue(
+            "discord/channel_template", widget.channel_template_lineedit.text()
+        )
+        config.cparser.setValue(
+            "discord/channel_strip_extra_lines",
+            widget.channel_strip_extra_lines_checkbox.isChecked(),
+        )
+        config.cparser.setValue("discord/template", widget.template_lineedit.text())
+
+        if old_bot != new_bot or old_rp != new_rp:
+            subprocesses.restart_discordbot()
+
+    @staticmethod
+    def defaults(settings: Any) -> None:
+        """Write default values for all discord/ keys."""
+        settings.setValue("discord/richpresence_enabled", False)
+        settings.setValue("discord/bot_enabled", False)
+        settings.setValue("discord/clientid", "")
+        settings.setValue("discord/token", "")
+        settings.setValue("discord/template", "")
+        settings.setValue("discord/channel_id", "")
+        settings.setValue("discord/channel_attach_image", False)
+        settings.setValue("discord/channel_image_size", 200)
+        settings.setValue("discord/channel_template", "")
+        settings.setValue("discord/channel_strip_extra_lines", False)
+        settings.setValue("discord/large_image_key", "")
+        settings.setValue("discord/small_image_key", "")
+
+    @staticmethod
+    def _update_fields(widget: Any) -> None:
+        """Enable/disable fields based on which Discord modes are active."""
+        rp_enabled = widget.richpresence_enable_checkbox.isChecked()
+        bot_enabled = widget.bot_enable_checkbox.isChecked()
+        either_enabled = rp_enabled or bot_enabled
+
+        widget.clientid_label.setEnabled(rp_enabled)
+        widget.clientid_lineedit.setEnabled(rp_enabled)
+
+        widget.token_label.setEnabled(bot_enabled)
+        widget.token_lineedit.setEnabled(bot_enabled)
+        widget.channel_id_label.setEnabled(bot_enabled)
+        widget.channel_id_lineedit.setEnabled(bot_enabled)
+        widget.channel_attach_image_checkbox.setEnabled(bot_enabled)
+        widget.channel_image_size_label.setEnabled(bot_enabled)
+        widget.channel_image_size_spinbox.setEnabled(bot_enabled)
+        widget.channel_template_label.setEnabled(bot_enabled)
+        widget.channel_template_lineedit.setEnabled(bot_enabled)
+        widget.channel_template_button.setEnabled(bot_enabled)
+        widget.channel_template_preview_button.setEnabled(bot_enabled)
+        widget.channel_strip_extra_lines_checkbox.setEnabled(bot_enabled)
+
+        widget.template_label.setEnabled(either_enabled)
+        widget.template_lineedit.setEnabled(either_enabled)
+        widget.template_button.setEnabled(either_enabled)
+        widget.template_preview_button.setEnabled(either_enabled)
+
+    def _show_preview(self, attr: str, config_key: str, on_selected: Any) -> None:
+        """Create (if needed) and raise a Discord text template preview window."""
+        window: nowplaying.preview.textwindow.TextPreviewWindow | None = getattr(self, attr)
+        if window is None:
+            window = nowplaying.preview.textwindow.TextPreviewWindow(
+                config=self.config,
+                config_key=config_key,
+                enable_select_button=True,
+            )
+            window.template_selected.connect(on_selected)
+            setattr(self, attr, window)
+        window.populate_templates()  # pyright: ignore[reportAttributeAccessIssue]
+        nowplaying.utils.qt.focus_window(window)
+
+    @Slot()
+    def _on_template_button(self) -> None:
+        if self._uihelp and self._widget:
+            self._uihelp.template_picker_lineedit(self._widget.template_lineedit)
+
+    @Slot()
+    def _on_channel_template_button(self) -> None:
+        if self._uihelp and self._widget:
+            self._uihelp.template_picker_lineedit(self._widget.channel_template_lineedit)
+
+    @Slot()
+    def _on_template_preview_button(self) -> None:
+        self._show_preview(
+            "_template_preview",
+            "discord/template",
+            self._on_template_selected,
+        )
+
+    @Slot(str)
+    def _on_template_selected(self, template_name: str) -> None:
+        if self._widget and self.config:
+            self._widget.template_lineedit.setText(
+                str(pathlib.Path(self.config.templatedir) / template_name)
+            )
+
+    @Slot()
+    def _on_channel_template_preview_button(self) -> None:
+        self._show_preview(
+            "_channel_template_preview",
+            "discord/channel_template",
+            self._on_channel_template_selected,
+        )
+
+    @Slot(str)
+    def _on_channel_template_selected(self, template_name: str) -> None:
+        if self._widget and self.config:
+            self._widget.channel_template_lineedit.setText(
+                str(pathlib.Path(self.config.templatedir) / template_name)
+            )

--- a/nowplaying/discord/settings.py
+++ b/nowplaying/discord/settings.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Discord settings UI class"""
 
+from __future__ import annotations
+
 import pathlib
 from typing import TYPE_CHECKING, Any
 

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -704,7 +704,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         qsettings.setValue("djaypro/artist_query_scope", "entire_library")
         qsettings.setValue("djaypro/selected_playlists", "")
         qsettings.setValue("djaypro/analyzed_data_delay", _ANALYZED_DATA_RETRY_DEFAULT)
-        qsettings.setValue("djaypro/deckskip", None)
+        qsettings.setValue("djaypro/deckskip", "")
         qsettings.setValue("djaypro/location_max_age_days", 7)
         qsettings.setValue("djaypro/rebuild_location_db", False)
 

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -369,11 +369,11 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self._last_error_log_time = 0  # Reset logging timer
 
     def defaults(self, qsettings: "QSettings") -> None:
-        qsettings.setValue("jriver/host", None)
+        qsettings.setValue("jriver/host", "")
         qsettings.setValue("jriver/port", "52199")
-        qsettings.setValue("jriver/username", None)
-        qsettings.setValue("jriver/password", None)
-        qsettings.setValue("jriver/access_key", None)
+        qsettings.setValue("jriver/username", "")
+        qsettings.setValue("jriver/password", "")
+        qsettings.setValue("jriver/access_key", "")
 
     def validmixmodes(self) -> list[str]:
         """let the UI know which modes are valid"""

--- a/nowplaying/notifications/charts.py
+++ b/nowplaying/notifications/charts.py
@@ -657,6 +657,7 @@ class Plugin(NotificationPlugin):  # pylint: disable=too-many-instance-attribute
         qsettings.setValue("charts/enabled", True)
         qsettings.setValue("charts/charts_key", "")
         qsettings.setValue("charts/link_platform", True)
+        qsettings.setValue("charts/debug", False)
 
     def load_settingsui(self, qwidget: "QWidget"):
         """Load settings into UI"""

--- a/nowplaying/recognition/acoustid.py
+++ b/nowplaying/recognition/acoustid.py
@@ -430,8 +430,8 @@ class Plugin(RecognitionPlugin):
 
     def defaults(self, qsettings):
         qsettings.setValue("acoustidmb/enabled", False)
-        qsettings.setValue("acoustidmb/acoustidapikey", None)
-        qsettings.setValue("acoustidmb/fpcalcexe", None)
+        qsettings.setValue("acoustidmb/acoustidapikey", "")
+        qsettings.setValue("acoustidmb/fpcalcexe", "")
 
 
 async def main():

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -253,8 +253,8 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         qsettings.setValue("serato/interval", 10.0)
         qsettings.setValue("serato/local", True)
         qsettings.setValue("serato/mixmode", "newest")
-        qsettings.setValue("serato/url", None)
-        qsettings.setValue("serato/deckskip", None)
+        qsettings.setValue("serato/url", "")
+        qsettings.setValue("serato/deckskip", "")
         qsettings.setValue("serato/artist_query_scope", "entire_library")
         qsettings.setValue("serato/selected_playlists", "")
 

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -31,6 +31,7 @@ from PySide6.QtWidgets import (
 )
 
 import nowplaying.config
+import nowplaying.discord.settings
 import nowplaying.firstinstall
 import nowplaying.guessgame.settings
 import nowplaying.preview.textwindow
@@ -61,6 +62,16 @@ LOGGING_COMBOBOX = ["DEBUG", "INFO", "WARNING", "ERROR", "FATAL", "CRITICAL"]
 NOCOVER_COMBOBOX = ["None", "Fanart", "Logo", "Thumbnail"]
 TRAY_ICON_THEMES = ["auto", "light", "dark"]
 
+_SETTINGSCLASS_KEYS = [
+    "twitch",
+    "twitchchat",
+    "kick",
+    "kickchat",
+    "discordbot",
+    "requests",
+    "guessgame",
+]
+
 
 # settings UI
 class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-instance-attributes
@@ -81,17 +92,12 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self.errormessage = None
         self.widgets = {}
         self._webpreview_window: nowplaying.preview.window.WebPreviewWindow | None = None
-        self._discord_template_preview: nowplaying.preview.textwindow.TextPreviewWindow | None = (
-            None
-        )
-        self._discord_channel_template_preview: (
-            nowplaying.preview.textwindow.TextPreviewWindow | None
-        ) = None
         self.settingsclasses = {
             "twitch": nowplaying.twitch.settings.TwitchSettings(),
             "twitchchat": nowplaying.twitch.chat.TwitchChatSettings(),
             "kick": nowplaying.kick.settings.KickSettings(),
             "kickchat": nowplaying.kick.settings.KickChatSettings(),
+            "discordbot": nowplaying.discord.settings.DiscordSettings(),
             "requests": nowplaying.trackrequests.TrackRequestSettings(),
             "guessgame": nowplaying.guessgame.settings.GuessGameSettings(),
             "recognition_musicbrainz": nowplaying.musicbrainz.plugin.Plugin(config=self.config),
@@ -207,14 +213,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self._setup_widgets("destroy")
         self._setup_widgets("about")
 
-        for key in [
-            "twitch",
-            "twitchchat",
-            "kick",
-            "kickchat",
-            "requests",
-            "guessgame",
-        ]:
+        for key in _SETTINGSCLASS_KEYS:
             self.settingsclasses[key].load(self.config, self.widgets[key], self.uihelp)
             self.settingsclasses[key].connect(self.uihelp, self.widgets[key])
 
@@ -386,49 +385,6 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         qobject.template_button.clicked.connect(self.on_html_template_button)
         qobject.preview_button.clicked.connect(self.on_webserver_preview_button)
 
-    def _connect_discordbot_widget(self, qobject):
-        """connect discord widget signals"""
-        qobject.template_button.clicked.connect(self.on_discordbot_template_button)
-        qobject.template_preview_button.clicked.connect(self.on_discordbot_template_preview_button)
-        qobject.channel_template_button.clicked.connect(self.on_discordbot_channel_template_button)
-        qobject.channel_template_preview_button.clicked.connect(
-            self.on_discordbot_channel_template_preview_button
-        )
-        qobject.richpresence_enable_checkbox.toggled.connect(
-            lambda checked: self._update_discordbot_fields(qobject)
-        )
-        qobject.bot_enable_checkbox.toggled.connect(
-            lambda checked: self._update_discordbot_fields(qobject)
-        )
-
-    @staticmethod
-    def _update_discordbot_fields(qobject) -> None:
-        """enable/disable discord fields based on which modes are active"""
-        rp_enabled = qobject.richpresence_enable_checkbox.isChecked()
-        bot_enabled = qobject.bot_enable_checkbox.isChecked()
-        either_enabled = rp_enabled or bot_enabled
-
-        qobject.clientid_label.setEnabled(rp_enabled)
-        qobject.clientid_lineedit.setEnabled(rp_enabled)
-
-        qobject.token_label.setEnabled(bot_enabled)
-        qobject.token_lineedit.setEnabled(bot_enabled)
-        qobject.channel_id_label.setEnabled(bot_enabled)
-        qobject.channel_id_lineedit.setEnabled(bot_enabled)
-        qobject.channel_attach_image_checkbox.setEnabled(bot_enabled)
-        qobject.channel_image_size_label.setEnabled(bot_enabled)
-        qobject.channel_image_size_spinbox.setEnabled(bot_enabled)
-        qobject.channel_template_label.setEnabled(bot_enabled)
-        qobject.channel_template_lineedit.setEnabled(bot_enabled)
-        qobject.channel_template_button.setEnabled(bot_enabled)
-        qobject.channel_template_preview_button.setEnabled(bot_enabled)
-        qobject.channel_strip_extra_lines_checkbox.setEnabled(bot_enabled)
-
-        qobject.template_label.setEnabled(either_enabled)
-        qobject.template_lineedit.setEnabled(either_enabled)
-        qobject.template_button.setEnabled(either_enabled)
-        qobject.template_preview_button.setEnabled(either_enabled)
-
     def _connect_artistextras_widget(self, qobject):
         """connect the artistextras buttons to non-built-ins"""
         qobject.clearcache_button.clicked.connect(self.on_artistextras_clearcache_button)
@@ -492,16 +448,9 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self._upd_win_trackskip()
         self._upd_win_webserver()
         self._upd_win_obsws()
-        self._upd_win_discordbot()
         self._upd_win_quirks()
 
-        for key in [
-            "twitch",
-            "twitchchat",
-            "kick",
-            "requests",
-            "guessgame",
-        ]:
+        for key in _SETTINGSCLASS_KEYS:
             self.settingsclasses[key].load(self.config, self.widgets[key], self.uihelp)
 
     def _upd_win_artistextras(self):
@@ -631,33 +580,6 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
             self.config.cparser.value("obsws/template")
         )
 
-    def _upd_win_discordbot(self):
-        """update the discord settings to match config"""
-        widget = self.widgets["discordbot"]
-        widget.richpresence_enable_checkbox.setChecked(
-            self.config.cparser.value("discord/richpresence_enabled", type=bool)
-        )
-        widget.bot_enable_checkbox.setChecked(
-            self.config.cparser.value("discord/bot_enabled", type=bool)
-        )
-        widget.clientid_lineedit.setText(self.config.cparser.value("discord/clientid") or "")
-        widget.token_lineedit.setText(self.config.cparser.value("discord/token") or "")
-        widget.channel_id_lineedit.setText(self.config.cparser.value("discord/channel_id") or "")
-        widget.channel_attach_image_checkbox.setChecked(
-            self.config.cparser.value("discord/channel_attach_image", type=bool)
-        )
-        widget.channel_image_size_spinbox.setValue(
-            self.config.cparser.value("discord/channel_image_size", type=int) or 200
-        )
-        widget.channel_template_lineedit.setText(
-            self.config.cparser.value("discord/channel_template") or ""
-        )
-        widget.channel_strip_extra_lines_checkbox.setChecked(
-            self.config.cparser.value("discord/channel_strip_extra_lines", type=bool)
-        )
-        widget.template_lineedit.setText(self.config.cparser.value("discord/template") or "")
-        self._update_discordbot_fields(widget)
-
     def _upd_win_quirks(self):
         """update the quirks settings to match config"""
 
@@ -766,7 +688,6 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self._upd_conf_webserver()
         self._upd_conf_obsws()
         self._upd_conf_quirks()
-        self._upd_conf_discordbot()
         self._upd_conf_kickbot()
 
         self._upd_conf_recognition()
@@ -779,14 +700,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
 
     def _upd_conf_external_services(self):
         """Update external service configurations (Twitch, Kick, etc.)"""
-        for key in [
-            "twitch",
-            "twitchchat",
-            "kick",
-            "kickchat",
-            "requests",
-            "guessgame",
-        ]:
+        for key in _SETTINGSCLASS_KEYS:
             self.settingsclasses[key].save(self.config, self.widgets[key], self.tray.subprocesses)
 
     def _upd_conf_trackskip(self):
@@ -911,38 +825,6 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         if oldenabled != newenabled:
             self.tray.subprocesses.restart_obsws()
 
-    def _upd_conf_discordbot(self):
-        """update the discord settings"""
-        widget = self.widgets["discordbot"]
-
-        old_bot = self.config.cparser.value("discord/bot_enabled", type=bool)
-        old_rp = self.config.cparser.value("discord/richpresence_enabled", type=bool)
-        new_bot = widget.bot_enable_checkbox.isChecked()
-        new_rp = widget.richpresence_enable_checkbox.isChecked()
-
-        self.config.cparser.setValue("discord/richpresence_enabled", new_rp)
-        self.config.cparser.setValue("discord/bot_enabled", new_bot)
-        self.config.cparser.setValue("discord/clientid", widget.clientid_lineedit.text())
-        self.config.cparser.setValue("discord/token", widget.token_lineedit.text())
-        self.config.cparser.setValue("discord/channel_id", widget.channel_id_lineedit.text())
-        self.config.cparser.setValue(
-            "discord/channel_attach_image", widget.channel_attach_image_checkbox.isChecked()
-        )
-        self.config.cparser.setValue(
-            "discord/channel_image_size", widget.channel_image_size_spinbox.value()
-        )
-        self.config.cparser.setValue(
-            "discord/channel_template", widget.channel_template_lineedit.text()
-        )
-        self.config.cparser.setValue(
-            "discord/channel_strip_extra_lines",
-            widget.channel_strip_extra_lines_checkbox.isChecked(),
-        )
-        self.config.cparser.setValue("discord/template", widget.template_lineedit.text())
-
-        if old_bot != new_bot or old_rp != new_rp:
-            self.tray.subprocesses.restart_discordbot()
-
     def _upd_conf_kickbot(self):
         """update the kickbot settings"""
 
@@ -1061,69 +943,6 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         if api_cache_file.exists():
             logging.debug("Deleting API cache: %s", api_cache_file)
             api_cache_file.unlink()
-
-    @Slot()
-    def on_discordbot_template_button(self):
-        """discordbot presence template button clicked action"""
-        if self.uihelp:
-            self.uihelp.template_picker_lineedit(self.widgets["discordbot"].template_lineedit)
-
-    @Slot()
-    def on_discordbot_channel_template_button(self):
-        """discordbot channel template button clicked action"""
-        if self.uihelp:
-            self.uihelp.template_picker_lineedit(
-                self.widgets["discordbot"].channel_template_lineedit
-            )
-
-    def _show_discordbot_preview(
-        self,
-        attr: str,
-        config_key: str,
-        on_selected,
-    ) -> None:
-        """Create (if needed) and raise a discord text template preview window."""
-        window: nowplaying.preview.textwindow.TextPreviewWindow | None = getattr(self, attr)
-        if window is None:
-            window = nowplaying.preview.textwindow.TextPreviewWindow(
-                config=self.config,
-                config_key=config_key,
-                enable_select_button=True,
-            )
-            window.template_selected.connect(on_selected)
-            setattr(self, attr, window)
-        window.populate_templates()
-        nowplaying.utils.qt.focus_window(window)
-
-    @Slot()
-    def on_discordbot_template_preview_button(self):
-        """open or raise the discord presence template preview window"""
-        self._show_discordbot_preview(
-            "_discord_template_preview",
-            "discord/template",
-            self._on_discordbot_template_selected,
-        )
-
-    @Slot(str)
-    def _on_discordbot_template_selected(self, template_name: str) -> None:
-        self.widgets["discordbot"].template_lineedit.setText(
-            str(pathlib.Path(self.config.templatedir) / template_name)
-        )
-
-    @Slot()
-    def on_discordbot_channel_template_preview_button(self):
-        """open or raise the discord channel template preview window"""
-        self._show_discordbot_preview(
-            "_discord_channel_template_preview",
-            "discord/channel_template",
-            self._on_discordbot_channel_template_selected,
-        )
-
-    @Slot(str)
-    def _on_discordbot_channel_template_selected(self, template_name: str) -> None:
-        self.widgets["discordbot"].channel_template_lineedit.setText(
-            str(pathlib.Path(self.config.templatedir) / template_name)
-        )
 
     @Slot()
     def on_obsws_template_button(self):
@@ -1437,14 +1256,7 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         if not self.verify_regex_filters():
             return
 
-        for key in [
-            "twitch",
-            "twitchchat",
-            "kick",
-            "kickchat",
-            "requests",
-            "guessgame",
-        ]:
+        for key in _SETTINGSCLASS_KEYS:
             try:
                 if hasattr(self.settingsclasses[key], "verify"):
                     self.settingsclasses[key].verify(self.widgets[key])

--- a/tests-qt/test_settingsui.py
+++ b/tests-qt/test_settingsui.py
@@ -32,6 +32,9 @@ class MockSubprocesses:
     def start_twitchbot(self):
         """mock"""
 
+    def restart_discordbot(self):
+        """mock"""
+
     def stop_kickbot(self):
         """mock"""
 
@@ -61,6 +64,29 @@ class MockTray:
 
     def _link_twitch_to_charts(self):
         """mock"""
+
+
+def test_settingsui_default_save_values(bootstrap, qtbot):
+    """Fresh-install save must not write None for any key.
+
+    Catches stealth defaults: a key added to any plugin or settingsclass
+    save_settingsui()/save() but missing from defaults() causes the widget
+    to load with None and write None back to UserScope.
+    """
+    config = bootstrap
+    tray = MockTray(config)
+    settingsui = nowplaying.settingsui.SettingsUI(tray=tray)
+    qtbot.addWidget(settingsui.qtui)
+    qtbot.mouseClick(settingsui.qtui.save_button, Qt.MouseButton.LeftButton)
+
+    none_keys = [
+        k
+        for k in config.cparser.allKeys()
+        if "/" in k and config.cparser.value(k) is None
+    ]
+    assert not none_keys, (
+        f"Keys are None after default save (missing from defaults()): {none_keys}"
+    )
 
 
 def test_settingsui_cancel(bootstrap, qtbot):

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -52,11 +52,11 @@ def test_plugin_defaults():
     mock_qsettings = MagicMock()
     plugin.defaults(mock_qsettings)
 
-    mock_qsettings.setValue.assert_any_call("jriver/host", None)
+    mock_qsettings.setValue.assert_any_call("jriver/host", "")
     mock_qsettings.setValue.assert_any_call("jriver/port", "52199")
-    mock_qsettings.setValue.assert_any_call("jriver/username", None)
-    mock_qsettings.setValue.assert_any_call("jriver/password", None)
-    mock_qsettings.setValue.assert_any_call("jriver/access_key", None)
+    mock_qsettings.setValue.assert_any_call("jriver/username", "")
+    mock_qsettings.setValue.assert_any_call("jriver/password", "")
+    mock_qsettings.setValue.assert_any_call("jriver/access_key", "")
 
 
 def test_plugin_mixmodes():


### PR DESCRIPTION
Add defaults for all Twitch/Kick/Requests/Charts/Discord keys that were missing from config.py _defaults_*() methods. Extract _SETTINGSCLASS_KEYS constant in settingsui.py to fix four loop sites (discordbot and kickchat were missing from some loops). Fix DiscordSettings._show_preview() double-guard. Change plugin defaults from None to "" for jriver, acoustidmb, serato3, djaypro, and denon credential/deckskip fields. Add test_settingsui_default_save_values to catch any future keys written by save() but missing from defaults().

## Summary by Sourcery

Ensure all external service and plugin settings have explicit defaults and refactor Discord configuration handling into a dedicated settings class.

New Features:
- Introduce a dedicated DiscordSettings UI handler with load/save/defaults logic and template preview support.

Bug Fixes:
- Prevent QSettings keys from being implicitly initialized to None by providing explicit defaults for Twitch, Kick, Discord, requests, charts, recognition, quirks, and track-skip settings.
- Normalize credential and deck-skip configuration defaults across plugins from None to empty strings to avoid None leaking into user configuration.

Enhancements:
- Centralize external service settings handling via a shared settings key list used across load, save, and verification paths in the settings UI.
- Extend Discogs and recognition settings defaults to cover new options such as websites lookups and artist website replacement.
- Add a debug flag default for charts notifications and additional request-related defaults in the core configuration.

Tests:
- Add a settings UI test that verifies a fresh save does not write any None values, guarding against future missing-default regressions.