### PR TITLE
Fix flaky test_cache_expiration on slow Windows CI

### DIFF
--- a/tests-qt/test_settingsui.py
+++ b/tests-qt/test_settingsui.py
@@ -80,9 +80,7 @@ def test_settingsui_default_save_values(bootstrap, qtbot):
     qtbot.mouseClick(settingsui.qtui.save_button, Qt.MouseButton.LeftButton)
 
     none_keys = [
-        k
-        for k in config.cparser.allKeys()
-        if "/" in k and config.cparser.value(k) is None
+        k for k in config.cparser.allKeys() if "/" in k and config.cparser.value(k) is None
     ]
     assert not none_keys, (
         f"Keys are None after default save (missing from defaults()): {none_keys}"

--- a/tests/test_apicache.py
+++ b/tests/test_apicache.py
@@ -165,15 +165,16 @@ async def test_cache_expiration(isolated_api_cache):  # pylint: disable=redefine
 
     test_data = {"test": "data"}
 
-    # Store with very short TTL
-    await cache.put("test_provider", "Test Artist", "search", test_data, ttl_seconds=1)
+    # Store with short TTL — use 3s so int(time.time()) truncation on slow
+    # Windows CI runners (up to ~1s between put and get) doesn't cause a false miss
+    await cache.put("test_provider", "Test Artist", "search", test_data, ttl_seconds=3)
 
     # Should be available immediately
     result = await cache.get("test_provider", "Test Artist", "search")
     assert result == test_data
 
     # Wait for expiration with extra buffer for timing issues
-    await asyncio.sleep(2.5)
+    await asyncio.sleep(4.5)
 
     # Should now be expired
     result = await cache.get("test_provider", "Test Artist", "search")


### PR DESCRIPTION
ttl_seconds=1 with int(time.time()) truncation means a put at T.9 and get at T+1.0 sees expires_at == current_time, failing the expires_at > current_time check. Bump to 3s TTL and 4.5s wait to give slow runners a comfortable margin.

## Summary by Sourcery

Stabilize a flaky cache expiration test by relaxing its timing assumptions and clean up a minor test formatting issue.

Bug Fixes:
- Adjust cache expiration test TTL and wait duration to accommodate slow runners and avoid timing-related false negatives.

Tests:
- Update cache expiration test parameters to use a longer TTL and sleep interval for more reliable timing behavior.
- Reformat a settings UI test assertion comprehension for clearer, single-line expression.