### PR TITLE
Add missing files for tufup-publish CI workflow on branch-5.2

### DIFF
--- a/bincomponents/wnp_prod_key.pub
+++ b/bincomponents/wnp_prod_key.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "e88aec1aa1d98e306c90a89f1e82f029b3263819aa1a59c11de688c4aa2e10c7"}}

--- a/nowplaying/resources/tufup/root.json
+++ b/nowplaying/resources/tufup/root.json
@@ -1,0 +1,50 @@
+{
+ "signatures": [
+  {
+   "keyid": "3009823a498e7d7dd5b244f5f7c3fab05d5a7f0923e141de96d0f1eaa8d2fe9e",
+   "sig": "1d783c1f3c8704aa5688a9b53a9316330776d70cf75a9fd42c839c2a14f39cb9194fcaa753aa16babcc2e4ecfb3dd8271145959f469bff7839ea07b52244ce04"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": false,
+  "expires": "2027-05-21T14:33:19Z",
+  "keys": {
+   "3009823a498e7d7dd5b244f5f7c3fab05d5a7f0923e141de96d0f1eaa8d2fe9e": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "e88aec1aa1d98e306c90a89f1e82f029b3263819aa1a59c11de688c4aa2e10c7"
+    },
+    "scheme": "ed25519"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "3009823a498e7d7dd5b244f5f7c3fab05d5a7f0923e141de96d0f1eaa8d2fe9e"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "3009823a498e7d7dd5b244f5f7c3fab05d5a7f0923e141de96d0f1eaa8d2fe9e"
+    ],
+    "threshold": 1
+   },
+   "targets": {
+    "keyids": [
+     "3009823a498e7d7dd5b244f5f7c3fab05d5a7f0923e141de96d0f1eaa8d2fe9e"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "3009823a498e7d7dd5b244f5f7c3fab05d5a7f0923e141de96d0f1eaa8d2fe9e"
+    ],
+    "threshold": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1
+ }
+}

--- a/requirements-tufup.txt
+++ b/requirements-tufup.txt
@@ -1,0 +1,14 @@
+# Pinned tufup version for CI workflows that re-sign or generate
+# TUF metadata.  Bump deliberately after testing -- upstream changes
+# can affect archive-format suffix, signing semantics, and CLI
+# argument parsing.
+tufup==0.10.0
+# tufup 0.10.0's `tufup/repo/__init__.py` does an unconditional
+# `import setuptools.config.expand` wrapped in a too-narrow
+# try/except AssertionError.  When setuptools isn't installed at
+# all the missing-module import raises ModuleNotFoundError which
+# isn't caught, and `tufup.__init__` fails to load.  Bundling
+# setuptools as a runtime dep sidesteps it.  Can drop once tufup
+# upstream widens the except (or moves the import behind a feature
+# check).
+setuptools

--- a/tools/tufup_publish.py
+++ b/tools/tufup_publish.py
@@ -43,7 +43,6 @@ import sys
 
 from tufup.repo import Repository, make_gztar_archive  # pylint: disable=import-error
 
-
 KEY_NAME = "wnp_prod_key"
 
 
@@ -81,7 +80,7 @@ def _write_config(repo_dir: pathlib.Path, keys_dir: pathlib.Path) -> pathlib.Pat
         "key_map": {role: [KEY_NAME] for role in roles},
         "keys_dir": str(keys_dir),
         "repo_dir": str(repo_dir),
-        "thresholds": {role: 1 for role in roles},
+        "thresholds": dict.fromkeys(roles, 1),
     }
     config_path = config_cwd / ".tufup-repo-config"
     config_path.write_text(json.dumps(config, indent=4))


### PR DESCRIPTION
requirements-tufup.txt, wnp_prod_key.pub, root.json trust anchor, and tufup_publish.py were present in main but missing from branch-5.2, causing tufup-publish.yaml to fail on 5.2.x release tags.

## Summary by Sourcery

Restore tufup publishing support on the 5.2 branch by adding missing repository configuration assets and aligning the tufup publish script with main.

Enhancements:
- Simplify construction of the TUF role threshold mapping in the tufup_publish helper script.

Build:
- Add tufup-specific requirements file to ensure necessary dependencies are installed for the publish workflow.

CI:
- Unblock the tufup-publish GitHub Actions workflow on 5.2.x release tags by providing the previously missing configuration and key files used during publishing.