### PR TITLE
Rework djay Pro location index: event-driven, QSettings-signalled

### DIFF
--- a/nowplaying/djaypro/locationdb.py
+++ b/nowplaying/djaypro/locationdb.py
@@ -155,11 +155,11 @@ def _fetch_new_rows(
         return None
 
 
-def sync(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
-    """Sync new location rows from djay Pro's DB into the WNP-owned index.
+def catchup_index(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
+    """Index any location rows added to djay Pro's DB since the last run.
 
-    Only processes rows newer than the last sync, so the steady-state cost
-    is a single MAX(rowid) probe when the library has not changed.
+    Steady-state cost is a single MAX(rowid) probe; only opens djay's DB
+    a second time when new rows are actually present.
     """
     djay_max = _probe_djay_max_rowid(djay_dbfile)
     if djay_max is None:
@@ -272,7 +272,7 @@ def rebuild(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
     if tmp.exists():
         tmp.unlink()
 
-    sync(djay_dbfile, tmp)
+    catchup_index(djay_dbfile, tmp)
 
     if not tmp.exists():
         # sync() bailed early (djay DB unreachable) — leave old index intact

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -91,6 +91,10 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self._wal_timer_lock = threading.Lock()
         self._deck_tracks: dict[str, nowplaying.djaypro.mediadb.DeckTrack] = {}
         self._location_db_path: pathlib.Path = nowplaying.djaypro.locationdb.default_db_path()
+        self._started: bool = False
+        self._index_initialized: bool = False
+        self._rebuilding: bool = False
+        self._rebuild_lock: threading.Lock = threading.Lock()
         # Record launch time in Core Data epoch (seconds since 2001-01-01 UTC)
         # so we can skip tracks that were already playing when WNP started.
         self._launch_time: float = (
@@ -141,37 +145,37 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             "key": None,
         }
 
-    async def _maybe_rebuild_location_db(self) -> None:
-        """Rebuild the location index if the manual flag is set or it has aged out."""
-        rebuild = self.config.cparser.value(
-            "djaypro/rebuild_location_db", type=bool, defaultValue=False
+    def _check_rebuild_age(self) -> None:
+        """Set the rebuild flag in QSettings if the index has aged out."""
+        max_age_days = max(
+            1,
+            self.config.cparser.value("djaypro/location_max_age_days", type=int, defaultValue=7),
         )
-        if not rebuild and self._location_db_path.exists():
-            max_age_days = max(
-                1,
-                self.config.cparser.value(
-                    "djaypro/location_max_age_days", type=int, defaultValue=7
-                ),
+        last_rebuild = nowplaying.djaypro.locationdb.get_last_rebuild_time(self._location_db_path)
+        age_days = (time.time() - last_rebuild) / 86400
+        if age_days > max_age_days:
+            logging.info(
+                "djay Pro location index is %.1f days old (max %d); scheduling rebuild",
+                age_days,
+                max_age_days,
             )
-            last_rebuild = nowplaying.djaypro.locationdb.get_last_rebuild_time(
-                self._location_db_path
-            )
-            age_days = (time.time() - last_rebuild) / 86400
-            if age_days > max_age_days:
-                logging.info(
-                    "djay Pro location index is %.1f days old (max %d); rebuilding",
-                    age_days,
-                    max_age_days,
-                )
-                rebuild = True
+            self.config.cparser.setValue("djaypro/rebuild_location_db", True)
 
-        if rebuild:
+    def _do_rebuild(self) -> None:
+        """Thread target: full atomic rebuild of the location index."""
+        try:
             dbfile = self._get_db_path()
             if dbfile:
-                await asyncio.to_thread(
-                    nowplaying.djaypro.locationdb.rebuild, dbfile, self._location_db_path
-                )
-                self.config.cparser.setValue("djaypro/rebuild_location_db", False)
+                nowplaying.djaypro.locationdb.rebuild(dbfile, self._location_db_path)
+        finally:
+            self.config.cparser.setValue("djaypro/rebuild_location_db", False)
+            self._rebuilding = False
+
+    def _do_catchup(self) -> None:
+        """Thread target: index any location rows added since the last run."""
+        dbfile = self._get_db_path()
+        if dbfile:
+            nowplaying.djaypro.locationdb.catchup_index(dbfile, self._location_db_path)
 
     async def setup_watcher(self, configkey: str = "djaypro/directory"):
         """set up a custom watch on the djay Pro directory"""
@@ -232,10 +236,19 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             self._wal_timer.daemon = True
             self._wal_timer.start()
 
-    def _wal_timer_fired(self):
+    def _wal_timer_fired(self) -> None:
         """Called by the debounce timer; clears the timer reference then checks."""
         with self._wal_timer_lock:
             self._wal_timer = None
+        if self.config.cparser.value("djaypro/rebuild_location_db", type=bool, defaultValue=False):
+            with self._rebuild_lock:
+                if not self._rebuilding:
+                    self._rebuilding = True
+                    threading.Thread(target=self._do_rebuild, daemon=True).start()
+        else:
+            with self._rebuild_lock:
+                if not self._rebuilding:
+                    threading.Thread(target=self._do_catchup, daemon=True).start()
         self._check_for_new_track()
 
     def _get_deckskip(self) -> list[str]:
@@ -594,7 +607,6 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             if filename is not None or loc_isrc is not None:
                 return filename, title_id, loc_isrc
 
-        nowplaying.djaypro.locationdb.sync(dbfile, self._location_db_path)
         return nowplaying.djaypro.locationdb.lookup(artist, title, self._location_db_path)
 
     async def stop(self):
@@ -608,10 +620,25 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             self.observer.join()
             self.observer = None
         self._deck_tracks.clear()
+        self._started = False
+        self._rebuilding = False
 
-    async def start(self):
+    async def start(self) -> None:
         """setup the watcher"""
-        await self._maybe_rebuild_location_db()
+        if self._started:
+            await self.setup_watcher()
+            return
+        self._started = True
+        if not self._index_initialized:
+            self._index_initialized = True
+            self._check_rebuild_age()
+            if self.config.cparser.value(
+                "djaypro/rebuild_location_db", type=bool, defaultValue=False
+            ):
+                self._rebuilding = True
+                threading.Thread(target=self._do_rebuild, daemon=True).start()
+            else:
+                threading.Thread(target=self._do_catchup, daemon=True).start()
         await self.setup_watcher()
 
     async def getplayingtrack(self) -> TrackMetadata:

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -169,13 +169,18 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 nowplaying.djaypro.locationdb.rebuild(dbfile, self._location_db_path)
         finally:
             self.config.cparser.setValue("djaypro/rebuild_location_db", False)
-            self._rebuilding = False
+            with self._rebuild_lock:
+                self._rebuilding = False
 
     def _do_catchup(self) -> None:
         """Thread target: index any location rows added since the last run."""
-        dbfile = self._get_db_path()
-        if dbfile:
-            nowplaying.djaypro.locationdb.catchup_index(dbfile, self._location_db_path)
+        try:
+            dbfile = self._get_db_path()
+            if dbfile:
+                nowplaying.djaypro.locationdb.catchup_index(dbfile, self._location_db_path)
+        finally:
+            with self._rebuild_lock:
+                self._rebuilding = False
 
     async def setup_watcher(self, configkey: str = "djaypro/directory"):
         """set up a custom watch on the djay Pro directory"""
@@ -248,6 +253,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         else:
             with self._rebuild_lock:
                 if not self._rebuilding:
+                    self._rebuilding = True
                     threading.Thread(target=self._do_catchup, daemon=True).start()
         self._check_for_new_track()
 
@@ -638,6 +644,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 self._rebuilding = True
                 threading.Thread(target=self._do_rebuild, daemon=True).start()
             else:
+                self._rebuilding = True
                 threading.Thread(target=self._do_catchup, daemon=True).start()
         await self.setup_watcher()
 

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -9,6 +9,7 @@ import tempfile
 
 import pytest
 
+import nowplaying.djaypro.locationdb
 import nowplaying.djaypro.mediadb
 import nowplaying.djaypro.tsaf
 import nowplaying.inputs.djaypro
@@ -515,6 +516,7 @@ def test_check_for_new_track_uses_analyzed_bpm(bootstrap):
             },
         )
 
+        nowplaying.djaypro.locationdb.catchup_index(dbfile, plugin._location_db_path)
         plugin._check_for_new_track()
 
         assert plugin.metadata["artist"] == "Beat Artist"
@@ -657,6 +659,7 @@ def test_check_for_new_track_isrc_sources(  # pylint: disable=too-many-arguments
             collections["localMediaItemLocations"] = [("loc-uuid", location_blob)]
         _make_db_with_collections(dbfile, collections)
 
+        nowplaying.djaypro.locationdb.catchup_index(dbfile, plugin._location_db_path)
         plugin._check_for_new_track()
 
         assert plugin.metadata.get("artist") == artist


### PR DESCRIPTION
* Rename locationdb.sync() → catchup_index() to better describe its
  behaviour (probe MAX(rowid), insert only new rows, return immediately
  if nothing has changed)
* Replace the 30-second background polling loop with event-driven I/O:
  catchup_index() is called from _wal_timer_fired() so index updates
  are tied to actual djay Pro DB writes, not a timer
* Full rebuild is triggered via a QSettings flag (djaypro/rebuild_location_db)
  so it survives restarts and is writable from both the settings UI and
  the plugin process; age check runs once per session at startup
* _index_initialized flag prevents repeated startup work across
  stop/start cycles without blocking the event loop
* threading.Lock guards _rebuilding check-and-set in the watchdog
  thread only; event loop path is lock-free
* _check_for_new_track() always called unconditionally at the end of
  _wal_timer_fired() so track detection is never skipped on Windows
  during a rebuild

## Summary by Sourcery

Move djay Pro location database indexing and rebuild work from the main async flow into background threads, while keeping the index up to date incrementally.

Enhancements:
- Add background-thread tasks to rebuild and incrementally catch up the djay Pro location index instead of doing synchronous syncs in the playback path.
- Introduce state and locking around index initialization and rebuilds to avoid concurrent or repeated rebuild operations.
- Adjust location index maintenance to trigger either a full rebuild or a catch-up run based on index age and configuration flags.

Tests:
- Update djay Pro input tests to explicitly populate the side location index using the new incremental catch-up function before validating metadata lookups.