### PR TITLE
Extract release upload into composite GitHub Actions action

### DIFF
--- a/.github/actions/release-upload/action.yml
+++ b/.github/actions/release-upload/action.yml
@@ -3,6 +3,8 @@ name: Upload zip to GitHub Release
 description: >
   Create the release (as draft) if it does not already exist, then
   upload a zip artifact.  Works on Linux, macOS, and Windows runners.
+  Windows requires Git Bash to be available (shell: bash), which is
+  present on all GitHub-hosted Windows runners.
 
 inputs:
   release_token:
@@ -26,12 +28,15 @@ runs:
         TAG: ${{ inputs.tag }}
         ZIP_GLOB: ${{ inputs.zip_glob }}
       run: |
+        set -euo pipefail
         gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
           || gh release create "$TAG" \
                --repo "$GITHUB_REPOSITORY" \
                --draft \
                --title "$TAG" \
                --generate-notes
+        # ZIP_GLOB is intentionally unquoted so the shell expands it as a glob.
+        # shellcheck disable=SC2086
         gh release upload "$TAG" \
           --repo "$GITHUB_REPOSITORY" \
           --clobber \

--- a/.github/actions/release-upload/action.yml
+++ b/.github/actions/release-upload/action.yml
@@ -1,0 +1,38 @@
+---
+name: Upload zip to GitHub Release
+description: >
+  Create the release (as draft) if it does not already exist, then
+  upload a zip artifact.  Works on Linux, macOS, and Windows runners.
+
+inputs:
+  release_token:
+    description: PAT with release-write scope
+    required: true
+  tag:
+    description: Release tag (e.g. 5.2.2-preview1)
+    required: true
+  zip_glob:
+    description: Glob pattern for the zip file(s) to upload
+    required: false
+    default: 'WhatsNowPlaying-*.zip'
+
+runs:
+  using: composite
+  steps:
+    - name: upload zip to GitHub Release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.release_token }}
+        TAG: ${{ inputs.tag }}
+        ZIP_GLOB: ${{ inputs.zip_glob }}
+      run: |
+        gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+          || gh release create "$TAG" \
+               --repo "$GITHUB_REPOSITORY" \
+               --draft \
+               --title "$TAG" \
+               --generate-notes
+        gh release upload "$TAG" \
+          --repo "$GITHUB_REPOSITORY" \
+          --clobber \
+          $ZIP_GLOB

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -159,17 +159,7 @@ jobs:
       # land on the public Releases page.
       - name: upload zip to GitHub Release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
-        env:
-          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
-            || gh release create "$TAG" \
-                 --repo "$GITHUB_REPOSITORY" \
-                 --draft \
-                 --title "$TAG" \
-                 --generate-notes
-          gh release upload "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber \
-            WhatsNowPlaying-*.zip
+        uses: ./.github/actions/release-upload
+        with:
+          release_token: ${{ env.RELEASE_TOKEN }}
+          tag: ${{ github.ref_name }}

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -67,20 +67,10 @@ jobs:
       # scoped to release-write on this repo only.
       - name: upload zip to GitHub Release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
-        env:
-          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
-            || gh release create "$TAG" \
-                 --repo "$GITHUB_REPOSITORY" \
-                 --draft \
-                 --title "$TAG" \
-                 --generate-notes
-          gh release upload "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber \
-            WhatsNowPlaying-*.zip
+        uses: ./.github/actions/release-upload
+        with:
+          release_token: ${{ env.RELEASE_TOKEN }}
+          tag: ${{ github.ref_name }}
 
   pyinstaller-linux-smoke:
     needs: pyinstaller-linux
@@ -252,18 +242,8 @@ jobs:
       # scoped to release-write on this repo only.
       - name: upload zip to GitHub Release
         if: ${{ env.RELEASE_TOKEN != '' && startsWith(github.ref, 'refs/tags/') }}
-        env:
-          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        shell: bash
-        run: |
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
-            || gh release create "$TAG" \
-                 --repo "$GITHUB_REPOSITORY" \
-                 --draft \
-                 --title "$TAG" \
-                 --generate-notes
-          gh release upload "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber \
-            WhatsNowPlaying-*-Windows.zip
+        uses: ./.github/actions/release-upload
+        with:
+          release_token: ${{ env.RELEASE_TOKEN }}
+          tag: ${{ github.ref_name }}
+          zip_glob: WhatsNowPlaying-*-Windows.zip


### PR DESCRIPTION
Eliminate the duplicated gh release view/create/upload block that appeared identically in the Linux, Windows, and macOS build jobs. All three now call .github/actions/release-upload with their RELEASE_TOKEN and tag; Windows passes an explicit zip_glob override.

## Summary by Sourcery

Extract a shared composite action for uploading build artifacts to GitHub Releases and update platform workflows to use it.

Enhancements:
- Introduce a reusable composite GitHub Action that creates (if needed) and uploads zip artifacts to GitHub Releases for a given tag.

CI:
- Refactor Linux, Windows, and macOS workflows to use the shared release-upload composite action instead of duplicating release creation and upload steps, with Windows specifying a custom zip glob pattern.