### PR TITLE
Migrate artistextras plugins from apicache to datacache

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -105,7 +105,7 @@ def bootstrap(getroot):  # pylint: disable=redefined-outer-name
 # don't stick around
 #
 @pytest.fixture(autouse=True, scope="function")
-def clear_old_testsuite():
+def clear_old_testsuite():  # pylint: disable=too-many-statements
     """clear out old testsuite configs"""
     if sys.platform == "win32":
         qsettingsformat = QSettings.IniFormat
@@ -153,11 +153,10 @@ def clear_old_testsuite():
         # misses that exhaust the Discogs/etc rate limit across tests).
         if temp_datacache and temp_datacache.exists():
             shutil.move(str(temp_datacache), str(datacache_dir))
-        # Reset the in-memory singleton so the next test reconnects to the
-        # restored database rather than the stale pre-move path.
+        # Reset singleton so the next test reconnects to the restored database.
         global _SHARED_DATACACHE_INSTANCE  # pylint: disable=global-statement
         _SHARED_DATACACHE_INSTANCE = None
-        nowplaying.datacache.set_shared_storage(None)
+        nowplaying.datacache.reset_shared_storage()
 
     config = QSettings(
         qsettingsformat,
@@ -244,12 +243,20 @@ async def isolated_datacache_storage():
             await storage.close()
 
 
+
+
 _SHARED_DATACACHE_INSTANCE = None
 
 
 @pytest_asyncio.fixture(scope="function")
 async def shared_datacache_storage():
-    """Shared DataStorage for artistextras tests to avoid redundant fetches."""
+    """Shared DataStorage for artistextras tests to avoid redundant fetches.
+
+    scope="function" is required by pytest-asyncio's function-scoped event loop.
+    The module-level singleton makes this a session singleton in practice.
+    No explicit close() needed: DataStorage uses connection-per-operation with
+    no persistent handle to release.
+    """
     global _SHARED_DATACACHE_INSTANCE  # pylint: disable=global-statement
     if _SHARED_DATACACHE_INSTANCE is None:
         _SHARED_DATACACHE_INSTANCE = nowplaying.datacache.DataStorage()

--- a/conftest.py
+++ b/conftest.py
@@ -243,8 +243,6 @@ async def isolated_datacache_storage():
             await storage.close()
 
 
-
-
 _SHARED_DATACACHE_INSTANCE = None
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,7 @@ from PySide6.QtCore import (  # pylint: disable=import-error, no-name-in-module
 import nowplaying.apicache
 import nowplaying.bootstrap
 import nowplaying.config
+import nowplaying.datacache
 
 # if sys.platform == 'darwin':
 #     import psutil
@@ -141,14 +142,22 @@ def clear_old_testsuite():
         logging.info("Removing %s", cachedir)
         shutil.rmtree(cachedir)
 
+        # Always recreate cachedir — other tests depend on it existing even if empty
+        cachedir.mkdir(parents=True, exist_ok=True)
+
         # Restore api_cache directory
         if temp_api_cache and temp_api_cache.exists():
-            cachedir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(temp_api_cache), str(api_cache_dir))
 
-        # Discard datacache (not preserved between tests)
+        # Restore datacache directory (preserved like api_cache to avoid cache
+        # misses that exhaust the Discogs/etc rate limit across tests).
         if temp_datacache and temp_datacache.exists():
-            shutil.rmtree(temp_datacache, ignore_errors=True)
+            shutil.move(str(temp_datacache), str(datacache_dir))
+        # Reset the in-memory singleton so the next test reconnects to the
+        # restored database rather than the stale pre-move path.
+        global _SHARED_DATACACHE_INSTANCE  # pylint: disable=global-statement
+        _SHARED_DATACACHE_INSTANCE = None
+        nowplaying.datacache.set_shared_storage(None)
 
     config = QSettings(
         qsettingsformat,
@@ -218,6 +227,52 @@ async def shared_api_cache():
         await _SHARED_CACHE_INSTANCE._initialize_db()  # pylint: disable=protected-access
 
     yield _SHARED_CACHE_INSTANCE
+
+
+@pytest_asyncio.fixture
+async def isolated_datacache_storage():
+    """Fresh DataStorage per test for verifying cache hit/miss behaviour."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage = nowplaying.datacache.DataStorage(pathlib.Path(temp_dir))
+        await storage.initialize()
+        original = nowplaying.datacache._shared_storage  # pylint: disable=protected-access
+        nowplaying.datacache.set_shared_storage(storage)
+        try:
+            yield storage
+        finally:
+            nowplaying.datacache.set_shared_storage(original)
+            await storage.close()
+
+
+_SHARED_DATACACHE_INSTANCE = None
+
+
+@pytest_asyncio.fixture(scope="function")
+async def shared_datacache_storage():
+    """Shared DataStorage for artistextras tests to avoid redundant fetches."""
+    global _SHARED_DATACACHE_INSTANCE  # pylint: disable=global-statement
+    if _SHARED_DATACACHE_INSTANCE is None:
+        _SHARED_DATACACHE_INSTANCE = nowplaying.datacache.DataStorage()
+        await _SHARED_DATACACHE_INSTANCE.initialize()
+    yield _SHARED_DATACACHE_INSTANCE
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def auto_shared_datacache_for_artistextras(request, shared_datacache_storage):  # pylint: disable=redefined-outer-name
+    """Mirror of auto_shared_api_cache_for_artistextras for the datacache layer."""
+    test_modules = ["test_artistextras", "test_musicbrainz", "test_metadata_multi_artist"]
+    test_manages_own_cache = (
+        "shared_datacache_storage" in request.fixturenames
+        or "isolated_datacache_storage" in request.fixturenames
+    )
+    if (
+        any(module in request.module.__name__ for module in test_modules)
+        and not test_manages_own_cache
+    ):
+        nowplaying.datacache.set_shared_storage(shared_datacache_storage)
+        yield
+    else:
+        yield
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/nowplaying/artistextras/discogs.py
+++ b/nowplaying/artistextras/discogs.py
@@ -3,7 +3,7 @@
 
 import logging
 
-import nowplaying.apicache
+import nowplaying.datacache
 import nowplaying.discogsclient
 import nowplaying.utils
 from nowplaying.artistextras import ArtistExtrasPlugin
@@ -78,12 +78,12 @@ class Plugin(ArtistExtrasPlugin):
             return result
 
         try:
-            cached_result = await nowplaying.apicache.cached_fetch(
+            cached_result = await nowplaying.datacache.cached_fetch(
                 provider="discogs",
                 artist_name=artist_name,
                 endpoint=f"search_{search_type}_{album_title}",
                 fetch_func=fetch_func,
-                ttl_seconds=None,  # Use provider default from apicache.py
+                ttl_seconds=None,  # Use provider default from _PROVIDER_TTL
             )
         except Exception as error:  # pylint: disable=broad-except
             logging.error(
@@ -135,12 +135,12 @@ class Plugin(ArtistExtrasPlugin):
             return None
 
         try:
-            cached_result = await nowplaying.apicache.cached_fetch(
+            cached_result = await nowplaying.datacache.cached_fetch(
                 provider="discogs",
                 artist_name=artist_name,
                 endpoint=f"artist_{artist_id}",
                 fetch_func=fetch_func,
-                ttl_seconds=None,  # Use provider default from apicache.py
+                ttl_seconds=None,  # Use provider default from _PROVIDER_TTL
             )
         except Exception as error:  # pylint: disable=broad-except
             logging.error(

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -7,7 +7,7 @@ import logging.handlers
 
 import aiohttp
 
-import nowplaying.apicache
+import nowplaying.datacache
 import nowplaying.utils
 from nowplaying.artistextras import ArtistExtrasPlugin
 from nowplaying.types import TrackMetadata
@@ -61,12 +61,12 @@ class Plugin(ArtistExtrasPlugin):
         async def fetch_func() -> dict[str, str] | None:
             return await self._fetch_async(apikey, artistid)
 
-        return await nowplaying.apicache.cached_fetch(
+        return await nowplaying.datacache.cached_fetch(
             provider="fanarttv",
             artist_name=artist_name,
             endpoint=f"music/{artistid}",  # Use the API endpoint path
             fetch_func=fetch_func,
-            ttl_seconds=None,  # Use provider default from apicache.py
+            ttl_seconds=None,  # Use provider default from _PROVIDER_TTL
         )
 
     async def download_async(self, metadata: TrackMetadata | None = None, imagecache=None):

--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
-import nowplaying.apicache
+import nowplaying.datacache
 import nowplaying.artistextras
 import nowplaying.config
 import nowplaying.utils
@@ -98,12 +98,12 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
             return await self._fetch_async(apikey, api)
 
         try:
-            return await nowplaying.apicache.cached_fetch(
+            return await nowplaying.datacache.cached_fetch(
                 provider="theaudiodb",
                 artist_name=artist_name,
                 endpoint=api,  # Use full API string so MBID is part of the cache key
                 fetch_func=fetch_func,
-                ttl_seconds=None,  # Use provider default from apicache.py
+                ttl_seconds=None,  # Use provider default from _PROVIDER_TTL
             )
         except RateLimitException:
             # Don't cache rate limit responses - return None without caching
@@ -345,7 +345,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
         async def fetch_func():
             return artist_data  # Already have the data, just cache it
 
-        return await nowplaying.apicache.cached_fetch(
+        return await nowplaying.datacache.cached_fetch(
             provider="theaudiodb",
             artist_name=artist_name,
             endpoint=f"artist_{artist_data['idArtist']}",

--- a/nowplaying/artistextras/wikimedia.py
+++ b/nowplaying/artistextras/wikimedia.py
@@ -5,7 +5,7 @@ import logging
 
 import aiohttp
 
-import nowplaying.apicache
+import nowplaying.datacache
 import nowplaying.wikiclient
 from nowplaying.artistextras import ArtistExtrasPlugin
 
@@ -52,7 +52,7 @@ class Plugin(ArtistExtrasPlugin):
                     max_images=5,  # Limit for performance during live shows
                 )
             except (aiohttp.ClientError, TimeoutError) as err:
-                # Returning None tells apicache to skip caching, so a transient
+                # Returning None tells cached_fetch to skip caching, so a transient
                 # wikidata failure (e.g. 429) does not poison the entry.  Only
                 # network/HTTP errors are caught here so genuine bugs in our
                 # own parsing logic still surface instead of being treated as
@@ -70,12 +70,12 @@ class Plugin(ArtistExtrasPlugin):
                 }
             return None
 
-        cached_result = await nowplaying.apicache.cached_fetch(
+        cached_result = await nowplaying.datacache.cached_fetch(
             provider="wikimedia",
             artist_name=artist_name,
             endpoint=f"{entity}_{lang}",  # Unique per entity + language combination
             fetch_func=fetch_func,
-            ttl_seconds=None,  # Use provider default from apicache.py
+            ttl_seconds=None,  # Use provider default from _PROVIDER_TTL
         )
 
         # Reconstruct WikiPage object from cached JSON data if needed

--- a/nowplaying/datacache/__init__.py
+++ b/nowplaying/datacache/__init__.py
@@ -1,57 +1,14 @@
-"""
-DataCache - Unified caching system for whats-now-playing application.
-
-This module provides a replacement for both apicache.py and imagecache.py
-with improved performance, multiprocess support, and URL-based caching.
-
-Key Features:
-- URL-based primary keys for natural deduplication
-- Support for randomimage() functionality via identifier+data_type indexing
-- Database-backed queues for multiprocess coordination
-- Async-first architecture with rate limiting
-- Unified interface for images, API responses, and metadata
-
-Example usage:
-
-    # Get providers instance
-    from nowplaying.datacache import get_providers
-
-    providers = get_providers()
-    await providers.initialize()
-
-    # Cache an artist thumbnail (immediate)
-    result = await providers.images.cache_artist_thumbnail(
-        url="https://example.com/image.jpg",
-        artist_identifier="daft_punk",
-        provider="theaudiodb",
-        immediate=True
-    )
-
-    # Queue background image fetch
-    await providers.images.cache_artist_logo(
-        url="https://example.com/logo.jpg",
-        artist_identifier="daft_punk",
-        provider="theaudiodb",
-        immediate=False  # Queues for background processing
-    )
-
-    # Get random image (replaces imagecache.randomimage)
-    random_thumb = await providers.images.get_random_image(
-        artist_identifier="daft_punk",
-        image_type="thumbnail"
-    )
-
-    # Cache API response
-    bio_result = await providers.api.cache_artist_bio(
-        url="https://api.example.com/artist/bio",
-        artist_identifier="daft_punk",
-        provider="example_api"
-    )
-"""
+"""DataCache - unified async caching for API responses and images."""
 
 from __future__ import annotations
 
+import base64
+import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
+
+import orjson
 
 # Core components
 from .client import DataCacheClient, get_client
@@ -83,6 +40,8 @@ __all__ = [
     # Utility functions
     "get_datacache_path",  # Get database path
     "run_datacache_maintenance",  # Cleanup function for system startup
+    "cached_fetch",  # Drop-in replacement for apicache.cached_fetch
+    "set_shared_storage",  # Test isolation helper
 ]
 
 # Module-level convenience functions
@@ -115,16 +74,101 @@ async def shutdown_datacache() -> None:
 
 
 def run_maintenance(cache_dir: Path | None = None) -> dict[str, int]:
-    """
-    Run datacache maintenance tasks.
-
-    This function runs cleanup operations and should be called
-    at system startup, similar to imagecache maintenance.
-
-    Args:
-        cache_dir: Optional custom cache directory
-
-    Returns:
-        Dictionary with maintenance statistics
-    """
+    """Run datacache maintenance tasks at system startup."""
     return run_datacache_maintenance(cache_dir)
+
+
+# TTL defaults matching apicache.py provider settings (seconds)
+_PROVIDER_TTL: dict[str, int] = {
+    "discogs": 7 * 24 * 3600,
+    "theaudiodb": 7 * 24 * 3600,
+    "fanarttv": 7 * 24 * 3600,
+    "lastfm": 7 * 24 * 3600,
+    "wikimedia": 24 * 3600,
+    "default": 24 * 3600,
+}
+
+_BYTES_KEY = "__bytes__"
+
+
+def _serialize_default(obj: Any) -> Any:
+    """orjson default handler: base64-encode raw bytes values inside dicts."""
+    if isinstance(obj, bytes):
+        return {_BYTES_KEY: base64.b64encode(obj).decode()}
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def _deserialize_bytes(data: Any) -> Any:
+    """Recursively restore base64-encoded bytes sentinels after orjson.loads."""
+    if isinstance(data, dict):
+        if len(data) == 1 and _BYTES_KEY in data:
+            return base64.b64decode(data[_BYTES_KEY])
+        return {k: _deserialize_bytes(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_deserialize_bytes(v) for v in data]
+    return data
+
+
+_shared_storage: DataStorage | None = None  # pylint: disable=invalid-name
+
+
+def _get_shared_storage() -> DataStorage:
+    global _shared_storage  # pylint: disable=global-statement
+    if _shared_storage is None:
+        _shared_storage = DataStorage()
+    return _shared_storage
+
+
+def set_shared_storage(storage: DataStorage | None) -> None:
+    """Replace the module-level storage singleton. Used by tests for isolation."""
+    global _shared_storage  # pylint: disable=global-statement
+    _shared_storage = storage
+
+
+async def cached_fetch(
+    provider: str,
+    artist_name: str,
+    endpoint: str,
+    fetch_func: Callable[[], Awaitable[Any]],
+    ttl_seconds: int | None = None,
+) -> Any | None:
+    """Drop-in replacement for apicache.cached_fetch using datacache storage.
+
+    Checks the local cache first; calls fetch_func() on a miss and stores the
+    result. Returns None without caching when fetch_func() returns None so
+    transient API failures (429, 5xx, timeout) do not poison the cache.
+    """
+    storage = _get_shared_storage()
+    normalized = artist_name.lower().strip()
+    url = f"apicache://{provider}/{normalized}/{endpoint}"
+
+    cached = await storage.retrieve_by_url(url)
+    if cached is not None:
+        data, _ = cached
+        try:
+            result = _deserialize_bytes(orjson.loads(data))
+            logging.debug("Cache HIT for %s:%s:%s", provider, artist_name, endpoint)
+            return result
+        except orjson.JSONDecodeError:
+            logging.warning("corrupt cached entry for %s — treating as miss", url)
+
+    logging.debug("Cache MISS for %s:%s:%s", provider, artist_name, endpoint)
+    fresh = await fetch_func()
+    if fresh is not None:
+        store_ttl = (
+            ttl_seconds
+            if ttl_seconds is not None
+            else _PROVIDER_TTL.get(provider, _PROVIDER_TTL["default"])
+        )
+        try:
+            await storage.store(
+                url=url,
+                identifier=normalized,
+                data_type="api_response",
+                provider=provider,
+                data_value=orjson.dumps(fresh, default=_serialize_default),
+                ttl_seconds=store_ttl,
+            )
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logging.warning("datacache store failed for %s: %s", url, err)
+    return fresh

--- a/nowplaying/datacache/__init__.py
+++ b/nowplaying/datacache/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     "run_datacache_maintenance",  # Cleanup function for system startup
     "cached_fetch",  # Drop-in replacement for apicache.cached_fetch
     "set_shared_storage",  # Test isolation helper
+    "reset_shared_storage",  # Reset singleton after DB move/delete
 ]
 
 # Module-level convenience functions
@@ -123,6 +124,17 @@ def set_shared_storage(storage: DataStorage | None) -> None:
     """Replace the module-level storage singleton. Used by tests for isolation."""
     global _shared_storage  # pylint: disable=global-statement
     _shared_storage = storage
+
+
+def reset_shared_storage() -> None:
+    """Reset the module-level storage singleton to None.
+
+    Call this after moving or deleting the underlying database file so the next
+    access creates a fresh DataStorage pointing at the new location rather than
+    trying to use the stale pre-move path.
+    """
+    global _shared_storage  # pylint: disable=global-statement
+    _shared_storage = None
 
 
 async def cached_fetch(

--- a/tests/datacache/test_client.py
+++ b/tests/datacache/test_client.py
@@ -539,8 +539,8 @@ async def test_rate_limiter_integration(temp_client):  # pylint: disable=redefin
     # Get rate limiter for test provider
     rate_limiter = temp_client.rate_limiters.get_limiter("test")
 
-    # Should have tokens available initially
-    assert rate_limiter.available_tokens() > 0
+    tokens_before = rate_limiter.available_tokens()
+    assert tokens_before > 0
 
     with respx.mock() as mock_responses:
         mock_responses.get("https://example.com/ratelimit_test.txt").mock(
@@ -562,5 +562,6 @@ async def test_rate_limiter_integration(temp_client):  # pylint: disable=redefin
         )
 
         assert result is not None
-        # Rate limiter should have consumed a token
-        assert rate_limiter.available_tokens() < rate_limiter.capacity
+        # Rate limiter must have been acquired: tokens_before - tokens_after >= 1
+        # (tokens may have partially refilled on slow runners, so check net consumption)
+        assert tokens_before - rate_limiter.tokens >= 1.0

--- a/tests/datacache/test_integration.py
+++ b/tests/datacache/test_integration.py
@@ -272,6 +272,39 @@ async def test_api_response_caching_integration(temp_datacache):  # pylint: disa
         assert metadata["source"] == "test_api"
 
 
+@pytest.mark.asyncio
+async def test_cached_fetch_bytes_round_trip(bootstrap, isolated_datacache_storage):  # pylint: disable=unused-argument
+    """cached_fetch must round-trip dicts containing bytes values via base64 sentinel."""
+    test_data = {"text": "hello", "raw": b"\x00\x01\x02binary"}
+    call_count = 0
+
+    async def fetch_func():
+        nonlocal call_count
+        call_count += 1
+        return test_data
+
+    result1 = await nowplaying.datacache.cached_fetch(
+        provider="test",
+        artist_name="testartist",
+        endpoint="bytes_test",
+        fetch_func=fetch_func,
+    )
+    assert result1 == test_data
+    assert isinstance(result1["raw"], bytes)
+    assert call_count == 1
+
+    # Second call must be a cache hit — fetch_func not invoked again
+    result2 = await nowplaying.datacache.cached_fetch(
+        provider="test",
+        artist_name="testartist",
+        endpoint="bytes_test",
+        fetch_func=fetch_func,
+    )
+    assert result2 == test_data
+    assert isinstance(result2["raw"], bytes)
+    assert call_count == 1, "cache hit should not call fetch_func again"
+
+
 def test_maintenance_integration():
     """Test maintenance functions work with real database"""
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/datacache/test_queue.py
+++ b/tests/datacache/test_queue.py
@@ -70,7 +70,7 @@ async def test_rate_limiter_timeout():
 
     assert success is False
     assert elapsed >= 0.1  # Should have waited at least timeout duration
-    assert elapsed < 0.2  # But not much longer
+    assert elapsed < 0.5  # But not much longer (generous for slow CI runners)
 
 
 @pytest.mark.asyncio

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -15,7 +15,7 @@ from utils_artistextras import (
     skip_no_discogs_key,
 )
 
-import nowplaying.apicache  # pylint: disable=import-error
+import nowplaying.datacache  # pylint: disable=import-error
 import nowplaying.discogsclient  # pylint: disable=import-error
 import nowplaying.metadata  # pylint: disable=import-error
 
@@ -646,14 +646,14 @@ async def test_discogs_cache_corruption_handling(bootstrap):
     plugin = plugins["discogs"]
 
     # Mock the cache to return corrupted data
-    original_cached_fetch = nowplaying.apicache.cached_fetch
+    original_cached_fetch = nowplaying.datacache.cached_fetch
 
     async def mock_corrupted_cache(*args, **kwargs):  # pylint: disable=unused-argument
         # Return corrupted data that would break normal processing
         return {"corrupted": "data", "invalid": True}
 
     # Test with corrupted cache
-    nowplaying.apicache.cached_fetch = mock_corrupted_cache
+    nowplaying.datacache.cached_fetch = mock_corrupted_cache
 
     try:
         # Should handle corrupted cache gracefully
@@ -668,7 +668,7 @@ async def test_discogs_cache_corruption_handling(bootstrap):
 
     finally:
         # Restore original cache function
-        nowplaying.apicache.cached_fetch = original_cached_fetch
+        nowplaying.datacache.cached_fetch = original_cached_fetch
 
 
 # Search Result Edge Case Tests
@@ -1071,82 +1071,74 @@ def test_discogs_configuration_validation_for_djs(bootstrap):
 
 @pytest.mark.asyncio
 @skip_no_discogs_key
-async def test_discogs_api_call_count(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_discogs_api_call_count(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that discogs plugin makes only one API call when cache is used"""
 
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    config = bootstrap
+    configuresettings("discogs", config.cparser)
+    config.cparser.setValue("discogs/apikey", os.environ["DISCOGS_API_KEY"])
+    imagecaches, plugins = configureplugins(config)
 
-    try:
-        config = bootstrap
-        configuresettings("discogs", config.cparser)
-        config.cparser.setValue("discogs/apikey", os.environ["DISCOGS_API_KEY"])
-        imagecaches, plugins = configureplugins(config)
+    plugin = plugins["discogs"]
 
-        plugin = plugins["discogs"]
+    # Test with known artist and album
+    metadata = {
+        "artist": "Daft Punk",
+        "album": "Random Access Memories",
+        "imagecacheartist": "daftpunk",
+    }
 
-        # Test with known artist and album
-        metadata = {
-            "artist": "Daft Punk",
-            "album": "Random Access Memories",
-            "imagecacheartist": "daftpunk",
-        }
+    # Mock the actual Discogs client API call to count calls
+    original_search = plugin.client.search_async if plugin.client else None
+    api_call_count = 0
 
-        # Mock the actual Discogs client API call to count calls
-        original_search = plugin.client.search_async if plugin.client else None
-        api_call_count = 0
+    async def mock_search_async(*args, **kwargs):
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug("Mock Discogs API call #%d", api_call_count)
+        # Call the original method to get real data
+        if original_search:
+            return await original_search(*args, **kwargs)
+        return None
 
-        async def mock_search_async(*args, **kwargs):
-            nonlocal api_call_count
-            api_call_count += 1
-            logging.debug("Mock Discogs API call #%d", api_call_count)
-            # Call the original method to get real data
+    if plugin.client:
+        plugin.client.search_async = mock_search_async
+
+        try:
+            # First call - should hit API and cache result
+            result1 = await plugin.download_async(
+                metadata.copy(), imagecache=imagecaches["discogs"]
+            )
+
+            # Verify one API call was made
+            assert api_call_count == 1, (
+                f"Expected 1 API call after first download, got {api_call_count}"
+            )
+
+            # Second call - should use cached result, no additional API call
+            result2 = await plugin.download_async(
+                metadata.copy(), imagecache=imagecaches["discogs"]
+            )
+
+            # Verify still only one API call was made (cache hit)
+            assert api_call_count == 1, (
+                f"Expected 1 API call after second download (cache hit), got {api_call_count}"
+            )
+
+            # Both results should be consistent
+            assert (result1 is None) == (result2 is None)
+            if result1:  # Only test if we got data back
+                logging.info("Discogs API cache verified: 1 API call for 2 downloads")
+                assert result1 == result2
+            else:
+                logging.info(
+                    "Discogs API cache test completed - cache working regardless of data found"
+                )
+
+        finally:
+            # Restore the original method
             if original_search:
-                return await original_search(*args, **kwargs)
-            return None
-
-        if plugin.client:
-            plugin.client.search_async = mock_search_async
-
-            try:
-                # First call - should hit API and cache result
-                result1 = await plugin.download_async(
-                    metadata.copy(), imagecache=imagecaches["discogs"]
-                )
-
-                # Verify one API call was made
-                assert api_call_count == 1, (
-                    f"Expected 1 API call after first download, got {api_call_count}"
-                )
-
-                # Second call - should use cached result, no additional API call
-                result2 = await plugin.download_async(
-                    metadata.copy(), imagecache=imagecaches["discogs"]
-                )
-
-                # Verify still only one API call was made (cache hit)
-                assert api_call_count == 1, (
-                    f"Expected 1 API call after second download (cache hit), got {api_call_count}"
-                )
-
-                # Both results should be consistent
-                assert (result1 is None) == (result2 is None)
-                if result1:  # Only test if we got data back
-                    logging.info("Discogs API cache verified: 1 API call for 2 downloads")
-                    assert result1 == result2
-                else:
-                    logging.info(
-                        "Discogs API cache test completed - cache working regardless of data found"
-                    )
-
-            finally:
-                # Restore the original method
-                if original_search:
-                    plugin.client.search_async = original_search
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+                plugin.client.search_async = original_search
 
 
 @pytest.mark.asyncio

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -14,7 +14,7 @@ from utils_artistextras import (
     skip_no_fanarttv_key,
 )
 
-import nowplaying.apicache
+import nowplaying.datacache
 
 
 def _setup_fanarttv_plugin(bootstrap):
@@ -52,54 +52,38 @@ async def test_fanarttv_apicache_usage(bootstrap):
 
 @pytest.mark.asyncio
 @skip_no_fanarttv_key
-async def test_fanarttv_apicache_api_call_count(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_fanarttv_apicache_api_call_count(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that fanarttv plugin makes only one API call when cache is used"""
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
 
-    try:
-        plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
-
-        await run_api_call_count_test(
-            plugin=plugin,
-            test_metadata=_get_test_metadata(),
-            mock_method_name="_fetch_async",
-            imagecache=imagecache,
-        )
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    await run_api_call_count_test(
+        plugin=plugin,
+        test_metadata=_get_test_metadata(),
+        mock_method_name="_fetch_async",
+        imagecache=imagecache,
+    )
 
 
 @pytest.mark.asyncio
 @skip_no_fanarttv_key
-async def test_fanarttv_apicache_api_failure_behavior(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_fanarttv_apicache_api_failure_behavior(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that fanarttv plugin doesn't cache failed API calls"""
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
 
-    try:
-        plugin, imagecache = _setup_fanarttv_plugin(bootstrap)
+    # Use test metadata with invalid MBID to trigger failure
+    test_metadata = {
+        "album": "Test Album",
+        "artist": "Test Artist",
+        "imagecacheartist": "testartist",
+        "musicbrainzartistid": ["invalid-mbid-that-will-fail"],  # Invalid MBID
+    }
 
-        # Use test metadata with invalid MBID to trigger failure
-        test_metadata = {
-            "album": "Test Album",
-            "artist": "Test Artist",
-            "imagecacheartist": "testartist",
-            "musicbrainzartistid": ["invalid-mbid-that-will-fail"],  # Invalid MBID
-        }
-
-        await run_failure_cache_test(
-            plugin=plugin,
-            test_metadata=test_metadata,
-            mock_method_name="_fetch_async",
-            imagecache=imagecache,
-        )
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    await run_failure_cache_test(
+        plugin=plugin,
+        test_metadata=test_metadata,
+        mock_method_name="_fetch_async",
+        imagecache=imagecache,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -15,7 +15,6 @@ from utils_artistextras import (
 )
 
 
-
 def _setup_fanarttv_plugin(bootstrap):
     """Set up FanartTV plugin for testing"""
     config = bootstrap

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -14,7 +14,6 @@ from utils_artistextras import (
     skip_no_fanarttv_key,
 )
 
-import nowplaying.datacache
 
 
 def _setup_fanarttv_plugin(bootstrap):

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -14,7 +14,7 @@ from utils_artistextras import (
     run_api_call_count_test,
 )
 
-import nowplaying.apicache
+import nowplaying.datacache
 import nowplaying.artistextras.theaudiodb
 from nowplaying.artistextras.theaudiodb import DEFAULT_THEAUDIODB_API_KEY
 
@@ -249,28 +249,20 @@ async def test_theaudiodb_invalid_musicbrainz_id_fallback(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_api_call_count(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_api_call_count(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that theaudiodb plugin makes only one API call when cache is used"""
 
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin(bootstrap)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin(bootstrap)
+    # Test with a known artist
+    metadata = {"artist": "Madonna", "imagecacheartist": "madonna"}
 
-        # Test with a known artist
-        metadata = {"artist": "Madonna", "imagecacheartist": "madonna"}
-
-        await run_api_call_count_test(
-            plugin=plugin,
-            test_metadata=metadata,
-            mock_method_name="_fetch_async",
-            imagecache=imagecache,
-        )
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+    await run_api_call_count_test(
+        plugin=plugin,
+        test_metadata=metadata,
+        mock_method_name="_fetch_async",
+        imagecache=imagecache,
+    )
 
 
 @pytest.mark.asyncio
@@ -349,49 +341,41 @@ async def test_theaudiodb_other_http_errors(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_429_not_cached(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_429_not_cached(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that theaudiodb 429 responses are not cached"""
     plugin, _ = _setup_theaudiodb_plugin_no_key(bootstrap)
 
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    # Reset rate limit state
+    nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-    try:
-        # Reset rate limit state
+    with aioresponses() as mockr:
+        # Mock 429 response
+        mockr.get(
+            f"{TADB_BASE_URL}/search.php?s=test",
+            status=429,
+        )
+
+        # Cached fetch should handle the rate limit exception and return None
+        result = await plugin._fetch_cached(
+            DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
+        )
+        assert result is None
+
+        # Rate limit should be set
+        assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until > time.time()
+
+        # Clear rate limit and add successful response
         nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
+        mockr.get(
+            f"{TADB_BASE_URL}/search.php?s=test",
+            payload={"test": "data"},
+        )
 
-        with aioresponses() as mockr:
-            # Mock 429 response
-            mockr.get(
-                f"{TADB_BASE_URL}/search.php?s=test",
-                status=429,
-            )
-
-            # Cached fetch should handle the rate limit exception and return None
-            result = await plugin._fetch_cached(
-                DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
-            )
-            assert result is None
-
-            # Rate limit should be set
-            assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until > time.time()
-
-            # Clear rate limit and add successful response
-            nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
-            mockr.get(
-                f"{TADB_BASE_URL}/search.php?s=test",
-                payload={"test": "data"},
-            )
-
-            # Now it should work and get the real data (not cached 429)
-            result2 = await plugin._fetch_cached(
-                DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
-            )
-            assert result2 == {"test": "data"}
-    finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+        # Now it should work and get the real data (not cached 429)
+        result2 = await plugin._fetch_cached(
+            DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
+        )
+        assert result2 == {"test": "data"}
 
 
 NIN_ARTIST_URL = f"{TADB_BASE_URL}/search.php?s=nine%20inch%20nails"
@@ -435,197 +419,156 @@ NIN_ALBUM_RESPONSE_HQ = {
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_queued(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_queued(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """album cover art URL is queued in imagecache when album is present"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", True)
+    with aioresponses() as mockr:
+        mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
-
-        assert result is not None
-        identifier = "Nine Inch Nails_The Downward Spiral"
-        assert identifier in imagecache.urls
-        assert imagecache.urls[identifier]["front_cover"] == [COVER_IMAGE_URL]
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    assert result is not None
+    identifier = "Nine Inch Nails_The Downward Spiral"
+    assert identifier in imagecache.urls
+    assert imagecache.urls[identifier]["front_cover"] == [COVER_IMAGE_URL]
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """strAlbumThumbHQ is preferred over strAlbumThumb when available"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", True)
+    with aioresponses() as mockr:
+        mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE_HQ)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE_HQ)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
-
-        assert result is not None
-        identifier = "Nine Inch Nails_The Downward Spiral"
-        assert imagecache.urls[identifier]["front_cover"] == [COVER_IMAGE_URL]
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    assert result is not None
+    identifier = "Nine Inch Nails_The Downward Spiral"
+    assert imagecache.urls[identifier]["front_cover"] == [COVER_IMAGE_URL]
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_disabled(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_disabled(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """album cover art is not fetched when coverart setting is disabled"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", False)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", False)
+    with aioresponses() as mockr:
+        mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
-
-        assert result is not None
-        assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    assert result is not None
+    assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
 
 
 @pytest.mark.asyncio
 async def test_theaudiodb_coverart_skipped_when_coverimageraw_present(  # pylint: disable=redefined-outer-name
-    bootstrap, isolated_api_cache
+    bootstrap,
+    isolated_datacache_storage,  # pylint: disable=unused-argument
 ):
     """album cover art fetch is skipped when coverimageraw already in metadata"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", True)
+    with aioresponses() as mockr:
+        mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+                "coverimageraw": b"\xff\xd8\xff",
+            },
+            imagecache=imagecache,
+        )
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                    "coverimageraw": b"\xff\xd8\xff",
-                },
-                imagecache=imagecache,
-            )
-
-        assert result is not None
-        assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    assert result is not None
+    assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_no_album(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_no_album(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """album cover art fetch is skipped when no album in metadata"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", True)
+    with aioresponses() as mockr:
+        mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        result = await plugin.download_async(
+            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+            imagecache=imagecache,
+        )
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            result = await plugin.download_async(
-                {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-                imagecache=imagecache,
-            )
-
-        assert result is not None
-        assert not any("front_cover" in imagecache.urls.get(k, {}) for k in imagecache.urls)
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    assert result is not None
+    assert not any("front_cover" in imagecache.urls.get(k, {}) for k in imagecache.urls)
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_album_api_error(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_album_api_error(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """album API error does not prevent artist data from being returned"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    try:
-        plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", True)
+    with aioresponses() as mockr:
+        mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        mockr.get(NIN_ALBUM_URL, payload={"album": None})
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload={"album": None})
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
-
-        assert result is not None
-        assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    assert result is not None
+    assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_live_coverart(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_live_coverart(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """live: album cover art URL is queued for Nine Inch Nails - The Downward Spiral"""
-    original_cache = nowplaying.apicache._global_cache_instance
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    plugin, imagecache = _setup_theaudiodb_plugin(bootstrap)
+    bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
     try:
-        plugin, imagecache = _setup_theaudiodb_plugin(bootstrap)
-        bootstrap.cparser.setValue("theaudiodb/coverart", True)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        pytest.fail(f"Plugin raised exception during live cover art test: {exc}")
 
-        try:
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            pytest.fail(f"Plugin raised exception during live cover art test: {exc}")
-
-        identifier = "Nine Inch Nails_The Downward Spiral"
-        assert result is not None
-        assert identifier in imagecache.urls, "Expected cover art to be queued"
-        assert imagecache.urls[identifier].get("front_cover"), "Expected front_cover URL list"
-    finally:
-        nowplaying.apicache.set_cache_instance(original_cache)
+    identifier = "Nine Inch Nails_The Downward Spiral"
+    assert result is not None
+    assert identifier in imagecache.urls, "Expected cover art to be queued"
+    assert imagecache.urls[identifier].get("front_cover"), "Expected front_cover URL list"

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -9,7 +9,7 @@ import pytest
 from aiohttp import ClientResponseError
 from utils_artistextras import configureplugins, configuresettings, run_cache_consistency_test
 
-import nowplaying.apicache  # pylint: disable=import-error
+import nowplaying.datacache  # pylint: disable=import-error
 import nowplaying.wikiclient  # pylint: disable=import-error
 
 
@@ -677,14 +677,14 @@ async def test_wikimedia_cache_corruption_handling(bootstrap):
     plugin = plugins["wikimedia"]
 
     # Mock the cache to return corrupted data
-    original_cached_fetch = nowplaying.apicache.cached_fetch
+    original_cached_fetch = nowplaying.datacache.cached_fetch
 
     async def mock_corrupted_cache(*args, **kwargs):  # pylint: disable=unused-argument
         # Return corrupted data that would break normal processing
         return {"corrupted": "data", "invalid": True, "type": "wikipage"}
 
     # Test with corrupted cache
-    nowplaying.apicache.cached_fetch = mock_corrupted_cache
+    nowplaying.datacache.cached_fetch = mock_corrupted_cache
 
     try:
         # Should handle corrupted cache gracefully
@@ -703,7 +703,7 @@ async def test_wikimedia_cache_corruption_handling(bootstrap):
 
     finally:
         # Restore original cache function
-        nowplaying.apicache.cached_fetch = original_cached_fetch
+        nowplaying.datacache.cached_fetch = original_cached_fetch
 
 
 @pytest.mark.asyncio
@@ -766,198 +766,163 @@ async def test_wikimedia_memory_stability_long_session(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_wikimedia_api_call_count(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_wikimedia_api_call_count(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that wikimedia plugin makes only one API call when cache is used"""
 
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    config = bootstrap
+    configuresettings("wikimedia", config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins["wikimedia"]
+
+    # Test with a known entity (Nine Inch Nails)
+    metadata = {
+        "artist": "Nine Inch Nails",
+        "imagecacheartist": "nineinchnails",
+        "artistwebsites": ["https://www.wikidata.org/wiki/Q11647"],
+    }
+
+    # Mock the actual Wikipedia API call to count calls.  This test
+    # verifies that the datacache layer short-circuits the second
+    # download_async; it is not testing Wikipedia's response.  Using a
+    # synthetic WikiPage (instead of delegating to the real network call)
+    # keeps the test deterministic when Wikipedia is rate-limiting CI.
+    original_get_page = nowplaying.wikiclient.get_page_async
+    api_call_count = 0
+
+    async def mock_get_page_async(*args, **kwargs):  # pylint: disable=unused-argument
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug("Mock Wikipedia API call #%d", api_call_count)
+        page = nowplaying.wikiclient.WikiPage(entity="Q11647", lang="en")
+        page.data = {
+            "claims": {},
+            "description": "American industrial rock band",
+        }
+        return page
+
+    # Replace the method with our mock
+    nowplaying.wikiclient.get_page_async = mock_get_page_async
 
     try:
-        config = bootstrap
-        configuresettings("wikimedia", config.cparser)
-        imagecaches, plugins = configureplugins(config)
+        # First call - should hit API and cache result
+        result1 = await plugin.download_async(metadata.copy(), imagecache=imagecaches["wikimedia"])
 
-        plugin = plugins["wikimedia"]
+        # Verify one API call was made
+        assert api_call_count == 1, (
+            f"Expected 1 API call after first download, got {api_call_count}"
+        )
 
-        # Test with a known entity (Nine Inch Nails)
-        metadata = {
-            "artist": "Nine Inch Nails",
-            "imagecacheartist": "nineinchnails",
-            "artistwebsites": ["https://www.wikidata.org/wiki/Q11647"],
-        }
+        # Second call - should use cached result, no additional API call
+        result2 = await plugin.download_async(metadata.copy(), imagecache=imagecaches["wikimedia"])
 
-        # Mock the actual Wikipedia API call to count calls.  This test
-        # verifies that the apicache layer short-circuits the second
-        # download_async; it is not testing Wikipedia's response.  Using a
-        # synthetic WikiPage (instead of delegating to the real network call)
-        # keeps the test deterministic when Wikipedia is rate-limiting CI.
-        original_get_page = nowplaying.wikiclient.get_page_async
-        api_call_count = 0
+        # Verify still only one API call was made (cache hit)
+        assert api_call_count == 1, (
+            f"Expected 1 API call after second download (cache hit), got {api_call_count}"
+        )
 
-        async def mock_get_page_async(*args, **kwargs):  # pylint: disable=unused-argument
-            nonlocal api_call_count
-            api_call_count += 1
-            logging.debug("Mock Wikipedia API call #%d", api_call_count)
-            page = nowplaying.wikiclient.WikiPage(entity="Q11647", lang="en")
-            page.data = {
-                "claims": {},
-                "description": "American industrial rock band",
-            }
-            return page
-
-        # Replace the method with our mock
-        nowplaying.wikiclient.get_page_async = mock_get_page_async
-
-        try:
-            # First call - should hit API and cache result
-            result1 = await plugin.download_async(
-                metadata.copy(), imagecache=imagecaches["wikimedia"]
+        # Both results should be consistent
+        assert (result1 is None) == (result2 is None)
+        if result1:  # Only test if we got data back
+            logging.info("Wikimedia API cache verified: 1 API call for 2 downloads")
+            assert result1 == result2
+        else:
+            logging.info(
+                "Wikimedia API cache test completed - cache working regardless of data found"
             )
 
-            # Verify one API call was made
-            assert api_call_count == 1, (
-                f"Expected 1 API call after first download, got {api_call_count}"
-            )
-
-            # Second call - should use cached result, no additional API call
-            result2 = await plugin.download_async(
-                metadata.copy(), imagecache=imagecaches["wikimedia"]
-            )
-
-            # Verify still only one API call was made (cache hit)
-            assert api_call_count == 1, (
-                f"Expected 1 API call after second download (cache hit), got {api_call_count}"
-            )
-
-            # Both results should be consistent
-            assert (result1 is None) == (result2 is None)
-            if result1:  # Only test if we got data back
-                logging.info("Wikimedia API cache verified: 1 API call for 2 downloads")
-                assert result1 == result2
-            else:
-                logging.info(
-                    "Wikimedia API cache test completed - cache working regardless of data found"
-                )
-
-        finally:
-            # Restore the original method
-            nowplaying.wikiclient.get_page_async = original_get_page
     finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+        # Restore the original method
+        nowplaying.wikiclient.get_page_async = original_get_page
 
 
 @pytest.mark.asyncio
-async def test_wikimedia_failure_cache(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_wikimedia_failure_cache(bootstrap, isolated_datacache_storage):  # pylint: disable=redefined-outer-name,unused-argument
     """test that wikimedia plugin handles cache failures gracefully"""
 
-    # Use isolated cache for this test to ensure clean state
-    original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
-    nowplaying.apicache.set_cache_instance(isolated_api_cache)
+    config = bootstrap
+    configuresettings("wikimedia", config.cparser)
+    imagecaches, plugins = configureplugins(config)
+
+    plugin = plugins["wikimedia"]
+
+    # Test with a known entity
+    metadata = {
+        "artist": "Nine Inch Nails",
+        "imagecacheartist": "nineinchnails",
+        "artistwebsites": ["https://www.wikidata.org/wiki/Q11647"],
+    }
+
+    # Mock the Wikipedia API to simulate failures then success
+    original_get_page = nowplaying.wikiclient.get_page_async
+    api_call_count = 0
+
+    async def mock_get_page_with_failure(*args, **kwargs):  # pylint: disable=unused-argument
+        nonlocal api_call_count
+        api_call_count += 1
+        logging.debug("Mock Wikipedia API call #%d", api_call_count)
+
+        if api_call_count == 1:
+            # First call: simulate API failure
+            logging.debug("Simulating Wikipedia API failure on first call")
+            return None
+        # Second call: simulate successful response
+        logging.debug("Simulating successful Wikipedia API response on second call")
+
+        # Return a minimal WikiPage-like object
+        class MockWikiPage:  # pylint: disable=too-few-public-methods
+            """Mock WikiPage for testing."""
+
+            def __init__(self):
+                """Initialize mock WikiPage."""
+                self.entity = "Q11647"
+                self.lang = "en"
+                self.data = {
+                    "extract": "Nine Inch Nails is an American industrial rock band.",
+                    "claims": {},  # Add claims field expected by the plugin
+                }
+                self._images = []
+
+            def images(self, fields=None):  # pylint: disable=unused-argument
+                """Return images for compatibility."""
+                return self._images
+
+            @staticmethod
+            def some_method():
+                """Add method to meet pylint requirement."""
+                return True
+
+        return MockWikiPage()
+
+    # Replace the method with our mock
+    nowplaying.wikiclient.get_page_async = mock_get_page_with_failure
 
     try:
-        config = bootstrap
-        configuresettings("wikimedia", config.cparser)
-        imagecaches, plugins = configureplugins(config)
+        # First call - API fails, should return empty dict and NOT cache the failure
+        result1 = await plugin.download_async(metadata.copy(), imagecache=imagecaches["wikimedia"])
 
-        plugin = plugins["wikimedia"]
+        assert api_call_count == 1, (
+            f"Expected 1 API call after first download, got {api_call_count}"
+        )
+        assert result1 == {}, "Expected empty dict result from failed Wikipedia API call"
 
-        # Test with a known entity
-        metadata = {
-            "artist": "Nine Inch Nails",
-            "imagecacheartist": "nineinchnails",
-            "artistwebsites": ["https://www.wikidata.org/wiki/Q11647"],
-        }
+        # Second call - should retry (failure not cached) and succeed
+        result2 = await plugin.download_async(metadata.copy(), imagecache=imagecaches["wikimedia"])
 
-        # Mock the Wikipedia API to simulate failures then success
-        original_get_page = nowplaying.wikiclient.get_page_async
-        api_call_count = 0
+        assert api_call_count == 2, (
+            f"Expected 2 API calls after second download (retry after failure), "
+            f"got {api_call_count}"
+        )
+        assert result2 is not None, "Expected successful result from second Wikipedia API call"
 
-        async def mock_get_page_with_failure(*args, **kwargs):  # pylint: disable=unused-argument
-            nonlocal api_call_count
-            api_call_count += 1
-            logging.debug("Mock Wikipedia API call #%d", api_call_count)
+        # Third call - should use cached success result, no additional API call
+        result3 = await plugin.download_async(metadata.copy(), imagecache=imagecaches["wikimedia"])
 
-            if api_call_count == 1:
-                # First call: simulate API failure
-                logging.debug("Simulating Wikipedia API failure on first call")
-                return None
-            # Second call: simulate successful response
-            logging.debug("Simulating successful Wikipedia API response on second call")
+        assert api_call_count == 2, (
+            f"Expected 2 API calls after third download (cache hit), got {api_call_count}"
+        )
+        assert result2 == result3
+        logging.info("Wikimedia cache failure test passed - failures not cached, successes are")
 
-            # Return a minimal WikiPage-like object
-            class MockWikiPage:  # pylint: disable=too-few-public-methods
-                """Mock WikiPage for testing."""
-
-                def __init__(self):
-                    """Initialize mock WikiPage."""
-                    self.entity = "Q11647"
-                    self.lang = "en"
-                    self.data = {
-                        "extract": "Nine Inch Nails is an American industrial rock band.",
-                        "claims": {},  # Add claims field expected by the plugin
-                    }
-                    self._images = []
-
-                def images(self, fields=None):  # pylint: disable=unused-argument
-                    """Return images for compatibility."""
-                    return self._images
-
-                @staticmethod
-                def some_method():
-                    """Add method to meet pylint requirement."""
-                    return True
-
-            return MockWikiPage()
-
-        # Replace the method with our mock
-        nowplaying.wikiclient.get_page_async = mock_get_page_with_failure
-
-        try:
-            # First call - API fails, should return None and NOT cache the failure
-            result1 = await plugin.download_async(
-                metadata.copy(), imagecache=imagecaches["wikimedia"]
-            )
-
-            # Verify one API call was made and result is empty dict (failure)
-            assert api_call_count == 1, (
-                f"Expected 1 API call after first download, got {api_call_count}"
-            )
-            assert result1 == {}, "Expected empty dict result from failed Wikipedia API call"
-
-            # Second call - should retry (not use cached failure) and succeed
-            result2 = await plugin.download_async(
-                metadata.copy(), imagecache=imagecaches["wikimedia"]
-            )
-
-            # Verify second API call was made (failure wasn't cached)
-            assert api_call_count == 2, (
-                f"Expected 2 API calls after second download (retry after failure), "
-                f"got {api_call_count}"
-            )
-
-            # Should get valid result from successful second call
-            assert result2 is not None, "Expected successful result from second Wikipedia API call"
-
-            # Third call - should use cached success result, no additional API call
-            result3 = await plugin.download_async(
-                metadata.copy(), imagecache=imagecaches["wikimedia"]
-            )
-
-            # Verify still only two API calls (third used cached success)
-            assert api_call_count == 2, (
-                f"Expected 2 API calls after third download (cache hit), got {api_call_count}"
-            )
-            # Results should be consistent for successful calls
-            assert result2 == result3
-            logging.info(
-                "Wikimedia cache failure test passed - failures not cached, successes are"
-            )
-
-        finally:
-            # Restore the original method
-            nowplaying.wikiclient.get_page_async = original_get_page
     finally:
-        # Restore original cache
-        nowplaying.apicache.set_cache_instance(original_cache)
+        nowplaying.wikiclient.get_page_async = original_get_page


### PR DESCRIPTION
Replaces nowplaying.apicache.cached_fetch with datacache.cached_fetch across wikimedia, discogs, theaudiodb and fanarttv. Adds bytes round-trip support via base64 sentinel, corrupt-entry logging, and test isolation fixtures; fixes test suite cache lifecycle so Discogs rate limits do not bleed across tests.

## Summary by Sourcery

Migrate artistextras plugins from apicache to the shared datacache layer and align tests and fixtures with the new caching mechanism.

New Features:
- Introduce a datacache.cached_fetch helper with TTL defaults and bytes-safe serialization for API responses.
- Add shared and isolated datacache storage fixtures to control cache reuse and isolation in tests.

Bug Fixes:
- Ensure corrupted cache entries are detected, logged, and treated as cache misses instead of breaking plugins.
- Preserve and reset datacache directories between test runs to avoid exhausting external API rate limits.
- Relax a datacache queue timeout assertion to be more tolerant on slow CI runners.

Enhancements:
- Refactor artistextras Discogs, TheAudioDB, Wikimedia, and Fanart.tv plugins to use datacache instead of apicache while keeping cache semantics consistent.
- Simplify artistextras tests by relying on datacache fixtures instead of manually swapping global cache instances.