### PR TITLE
Replace aioresponses with aiointercept in test suite

### DIFF
--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -98,7 +98,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     return True
                 logging.error("JRiver server returned status %d", response.status)
                 return False
-        except aiohttp.ClientConnectorError:
+        except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError):
             if self._should_log_error():
                 logging.debug("JRiver is not running or not accessible at %s", self.base_url)
             return False
@@ -133,7 +133,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     return True
                 logging.error("No token received from JRiver server")
                 return False
-        except aiohttp.ClientConnectorError:
+        except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError):
             if self._should_log_error():
                 logging.debug(
                     "JRiver is not running or not accessible at %s for auth", self.base_url
@@ -176,7 +176,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     logging.error("JRiver API returned status %d", response.status)
                     return None
                 return await response.text()
-        except aiohttp.ClientConnectorError:
+        except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError):
             if not self._connection_failed:
                 if self._should_log_error():
                     logging.debug("JRiver is not running or not accessible at %s", self.base_url)
@@ -338,7 +338,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     return None
                 response_text = await response.text()
                 return self._extract_filename_from_xml(response_text, filekey)
-        except aiohttp.ClientConnectorError:
+        except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError):
             if not self._connection_failed:
                 if self._should_log_error():
                     logging.debug(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 #
 # tests
 #
-aioresponses==0.7.8
+aiointercept>=0.1.5
 respx==0.22.0
 pytest==9.0.3
 pytest-asyncio==1.4.0

--- a/tests/kick/test_kick_chat.py
+++ b/tests/kick/test_kick_chat.py
@@ -7,7 +7,7 @@ import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.kick.chat  # pylint: disable=no-name-in-module
 import nowplaying.kick.constants
@@ -81,7 +81,7 @@ async def test_kickchat_send_message_success(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock successful API response
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "https://api.kick.com/public/v1/chat",
             status=200,
@@ -122,7 +122,7 @@ async def test_kickchat_send_message_api_error(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock failed API response
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "https://api.kick.com/public/v1/chat",
             status=400,
@@ -149,7 +149,7 @@ async def test_kickchat_send_message_token_expired(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock 401 response (token expired)
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "https://api.kick.com/public/v1/chat", status=401, payload={"message": "Unauthorized"}
         )

--- a/tests/kick/test_kick_integration.py
+++ b/tests/kick/test_kick_integration.py
@@ -6,7 +6,8 @@ import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aioresponses import aioresponses
+import pytest_asyncio
+from aiointercept import aiointercept
 
 import nowplaying.kick.chat  # pylint: disable=import-error,no-name-in-module
 import nowplaying.kick.launch  # pylint: disable=import-error,no-name-in-module
@@ -61,10 +62,10 @@ def mock_chat_with_oauth(kick_integration_config):  # pylint: disable=redefined-
     return chat, stopevent
 
 
-@pytest.fixture
-def mock_aiohttp_success():
-    """Fixture that mocks successful aiohttp responses using aioresponses."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_aiohttp_success():
+    """Fixture that mocks successful aiohttp responses using aiointercept."""
+    async with aiointercept(mock_external_urls=True) as mock:
         # Setup default success responses for common endpoints (repeat=True for multiple calls)
         mock.post(
             "https://api.kick.com/public/v1/chat",
@@ -75,10 +76,10 @@ def mock_aiohttp_success():
         yield mock
 
 
-@pytest.fixture
-def mock_responses():
-    """Fixture that provides aioresponses for mocking HTTP calls."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_responses():
+    """Fixture that provides aiointercept for mocking HTTP calls."""
+    async with aiointercept(mock_external_urls=True) as mock:
         yield mock
 
 
@@ -298,8 +299,8 @@ async def test_error_handling_scenarios(  # pylint: disable=redefined-outer-name
         oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
         oauth.code_verifier = "test_verifier"
 
-        # Use aioresponses to mock network error
-        with aioresponses() as mock:
+        # Use aiointercept to mock network error
+        async with aiointercept(mock_external_urls=True) as mock:
             mock.post(f"{OAUTH_HOST}/oauth/token", exception=Exception("Network error"))
 
             if expected_behavior == "raises_exception":
@@ -408,8 +409,8 @@ async def test_malformed_api_responses(kick_integration_config):  # pylint: disa
     oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
     oauth.code_verifier = "test_verifier"
 
-    # Test malformed JSON response using aioresponses
-    with aioresponses() as mock:
+    # Test malformed JSON response using aiointercept
+    async with aiointercept(mock_external_urls=True) as mock:
         mock.post(f"{OAUTH_HOST}/oauth/token", status=200, body="invalid json content")
 
         with pytest.raises(Exception):
@@ -429,8 +430,8 @@ async def test_network_timeouts(kick_integration_config):  # pylint: disable=red
     mock_oauth.get_stored_tokens.return_value = ("valid_token", "refresh_token")
     chat.oauth = mock_oauth
 
-    # Test timeout during message sending using aioresponses
-    with aioresponses() as mock:
+    # Test timeout during message sending using aiointercept
+    async with aiointercept(mock_external_urls=True) as mock:
         mock.post(
             "https://api.kick.com/public/v1/chat",
             exception=TimeoutError("Request timed out"),

--- a/tests/kick/test_kick_oauth2.py
+++ b/tests/kick/test_kick_oauth2.py
@@ -7,8 +7,10 @@ import hashlib
 import re
 from unittest.mock import patch
 
+import aiohttp
 import pytest
-from aioresponses import aioresponses
+import pytest_asyncio
+from aiointercept import aiointercept
 
 import nowplaying.kick.oauth2  # pylint: disable=import-error,no-name-in-module
 from nowplaying.kick.constants import OAUTH_HOST  # pylint: disable=import-error,no-name-in-module
@@ -37,10 +39,10 @@ def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
     return oauth
 
 
-@pytest.fixture
-def mock_responses():
-    """Fixture that provides aioresponses for mocking HTTP calls."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_responses():
+    """Fixture that provides aiointercept for mocking HTTP calls."""
+    async with aiointercept(mock_external_urls=True) as mock:
         yield mock
 
 
@@ -421,9 +423,9 @@ async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disa
     oauth = oauth_with_pkce
 
     # Mock a timeout by using an exception
-    mock_responses.post(f"{OAUTH_HOST}/oauth/token", exception=TimeoutError("Request timed out"))
+    mock_responses.post(f"{OAUTH_HOST}/oauth/token", exception=True)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises((asyncio.TimeoutError, aiohttp.ClientConnectionError)):
         await oauth.exchange_code_for_token("test_code", oauth.state)
 
 

--- a/tests/notifications/test_notifications_remote.py
+++ b/tests/notifications/test_notifications_remote.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.notifications.remote
 
@@ -45,7 +45,7 @@ async def test_remote_plugin_no_secret(remote_plugin):  # pylint: disable=redefi
 
     metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
 
         await remote_plugin.notify_track_change(metadata)
@@ -69,7 +69,7 @@ async def test_remote_plugin_with_secret(remote_plugin):  # pylint: disable=rede
 
     metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 456})
 
         await remote_plugin.notify_track_change(metadata)
@@ -92,7 +92,7 @@ async def test_remote_plugin_auth_failure(remote_plugin):  # pylint: disable=red
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "http://localhost:8899/v1/remoteinput", status=403, payload={"error": "Invalid secret"}
         )
@@ -112,7 +112,7 @@ async def test_remote_plugin_server_error(remote_plugin):  # pylint: disable=red
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "http://localhost:8899/v1/remoteinput",
             status=500,
@@ -149,7 +149,7 @@ async def test_remote_plugin_strips_blobs(remote_plugin):  # pylint: disable=red
         "discordguild": "My Discord Server",  # Should be kept
     }
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
 
         await remote_plugin.notify_track_change(metadata)
@@ -694,7 +694,7 @@ async def test_remote_sets_charts_submitted_flag_when_charts_enabled(
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
         await remote_plugin.notify_track_change(metadata)
 
@@ -715,7 +715,7 @@ async def test_remote_omits_charts_submitted_flag_when_charts_disabled(
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
         await remote_plugin.notify_track_change(metadata)
 

--- a/tests/test_artistextras_lastfm.py
+++ b/tests/test_artistextras_lastfm.py
@@ -5,7 +5,7 @@ import os
 import urllib.parse
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from utils_artistextras import FakeImageCache, configuresettings, skip_no_lastfm_key
 
 import nowplaying.apicache
@@ -136,7 +136,7 @@ async def test_lastfm_bio_and_website(bootstrap):
     """successful fetch returns bio and website"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
 
         result = await plugin.download_async(
@@ -155,7 +155,7 @@ async def test_lastfm_bio_stripped(bootstrap):
     """Last.fm attribution is stripped from bio"""
     plugin, _ = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -172,7 +172,7 @@ async def test_lastfm_bio_disabled(bootstrap):
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/bio", False)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -190,7 +190,7 @@ async def test_lastfm_websites_disabled(bootstrap):
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/websites", False)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -207,7 +207,7 @@ async def test_lastfm_existing_bio_not_overwritten(bootstrap):
     """does not overwrite existing artistlongbio"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {
@@ -229,7 +229,7 @@ async def test_lastfm_api_error(bootstrap):
     """Last.fm API error response returns None"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(
             XYZ_URL,
             payload={"error": 6, "message": "Artist not found"},
@@ -251,7 +251,7 @@ async def test_lastfm_http_error(bootstrap, isolated_api_cache):  # pylint: disa
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
 
     try:
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_URL, status=503)
             result = await plugin.download_async(
                 {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -270,7 +270,7 @@ async def test_lastfm_both_disabled_returns_none(bootstrap):
     bootstrap.cparser.setValue("lastfm/bio", False)
     bootstrap.cparser.setValue("lastfm/websites", False)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -309,7 +309,7 @@ async def test_lastfm_lang_returned(bootstrap, isolated_api_cache):  # pylint: d
             }
         }
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(de_url, payload=de_response)
             result = await plugin.download_async(
                 {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -341,7 +341,7 @@ async def test_lastfm_lang_fallback_to_en(bootstrap, isolated_api_cache):  # pyl
             }
         }
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(ko_url, payload=ko_response)
             mockr.get(en_url, payload=NIN_RESPONSE)
             result = await plugin.download_async(
@@ -374,7 +374,7 @@ async def test_lastfm_lang_no_fallback(bootstrap, isolated_api_cache):  # pylint
             }
         }
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(ko_url, payload=ko_response)
             result = await plugin.download_async(
                 {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -480,7 +480,7 @@ async def test_lastfm_coverart_queued(bootstrap):
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
         result = await plugin.download_async(
@@ -504,7 +504,7 @@ async def test_lastfm_coverart_disabled(bootstrap):
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", False)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {
@@ -525,7 +525,7 @@ async def test_lastfm_coverart_skipped_when_coverimageraw_present(bootstrap):
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {
@@ -548,7 +548,7 @@ async def test_lastfm_coverart_no_album(bootstrap):
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         result = await plugin.download_async(
             {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -569,7 +569,7 @@ async def test_lastfm_coverart_album_api_error(bootstrap, isolated_api_cache):  
         plugin, imagecache = _setup_plugin(bootstrap)
         bootstrap.cparser.setValue("lastfm/coverart", True)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_URL, payload=NIN_RESPONSE)
             mockr.get(NIN_ALBUM_URL, payload={"error": 6, "message": "Album not found"})
             result = await plugin.download_async(
@@ -596,7 +596,7 @@ async def test_lastfm_coverart_with_album_mbid(bootstrap):
     album_mbid = "12345678-1234-1234-1234-123456789abc"
     mbid_url = _album_mbid_url(album_mbid)
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         mockr.get(NIN_URL, payload=NIN_RESPONSE)
         mockr.get(mbid_url, payload=NIN_ALBUM_RESPONSE)
         result = await plugin.download_async(

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -6,7 +6,7 @@ import logging
 import time
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from utils_artistextras import (
     FakeImageCache,
     configureplugins,
@@ -282,7 +282,7 @@ async def test_theaudiodb_429_rate_limit_handling(bootstrap):
     # Reset rate limit state
     nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         # Mock 429 response
         mockr.get(
             f"{TADB_BASE_URL}/search.php?s=test",
@@ -312,7 +312,7 @@ async def test_theaudiodb_429_cooldown_expiry(bootstrap):
     # Set rate limit in the past (expired)
     nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = time.time() - 1
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         # Mock successful response after cooldown
         mockr.get(
             f"{TADB_BASE_URL}/search.php?s=test",
@@ -334,7 +334,7 @@ async def test_theaudiodb_other_http_errors(bootstrap):
     # Reset rate limit state
     nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-    with aioresponses() as mockr:
+    async with aiointercept(mock_external_urls=True) as mockr:
         # Mock 404 response
         mockr.get(
             f"{TADB_BASE_URL}/search.php?s=notfound",
@@ -361,7 +361,7 @@ async def test_theaudiodb_429_not_cached(bootstrap, isolated_api_cache):  # pyli
         # Reset rate limit state
         nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             # Mock 429 response
             mockr.get(
                 f"{TADB_BASE_URL}/search.php?s=test",
@@ -444,7 +444,7 @@ async def test_theaudiodb_coverart_queued(bootstrap, isolated_api_cache):  # pyl
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
             mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
             result = await plugin.download_async(
@@ -474,7 +474,7 @@ async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_api_cache):  #
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
             mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE_HQ)
             result = await plugin.download_async(
@@ -503,7 +503,7 @@ async def test_theaudiodb_coverart_disabled(bootstrap, isolated_api_cache):  # p
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", False)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
             result = await plugin.download_async(
                 {
@@ -532,7 +532,7 @@ async def test_theaudiodb_coverart_skipped_when_coverimageraw_present(  # pylint
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
             result = await plugin.download_async(
                 {
@@ -560,7 +560,7 @@ async def test_theaudiodb_coverart_no_album(bootstrap, isolated_api_cache):  # p
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
             result = await plugin.download_async(
                 {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
@@ -583,7 +583,7 @@ async def test_theaudiodb_coverart_album_api_error(bootstrap, isolated_api_cache
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
+        async with aiointercept(mock_external_urls=True) as mockr:
             mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
             mockr.get(NIN_ALBUM_URL, payload={"album": None})
             result = await plugin.download_async(

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.inputs.jriver  # pylint: disable=import-error,no-name-in-module
 
@@ -268,7 +268,7 @@ async def test_test_connection_success():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Alive",
             body="""<Response Status="OK">
@@ -292,7 +292,7 @@ async def test_test_connection_wrong_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Alive",
             body="""<Response Status="OK">
@@ -315,7 +315,7 @@ async def test_test_connection_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Alive", status=404)
 
         result = await plugin._test_connection()  # pylint: disable=protected-access
@@ -333,7 +333,7 @@ async def test_test_connection_network_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Alive", exception=Exception("Connection failed")
         )
@@ -355,7 +355,7 @@ async def test_authenticate_success():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(
             url,
@@ -395,7 +395,7 @@ async def test_authenticate_no_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(
             url,
@@ -422,7 +422,7 @@ async def test_authenticate_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(url, status=401)
 
@@ -449,8 +449,8 @@ async def test_getplayingtrack_success(jriver_plugin_with_session):  # pylint: d
     plugin.base_url = "http://localhost:52199/MCWS/v1"
     plugin.token = "testtoken"
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the URL pattern, including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the URL pattern, including query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info?Token=testtoken",
             body="""<Response Status="OK">
@@ -479,7 +479,7 @@ async def test_getplayingtrack_minimal_data():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info",
             body="""
@@ -508,7 +508,7 @@ async def test_getplayingtrack_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", status=500)
 
         result = await plugin.getplayingtrack()
@@ -526,7 +526,7 @@ async def test_getplayingtrack_network_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info", exception=Exception("Network error")
         )
@@ -546,7 +546,7 @@ async def test_getplayingtrack_parse_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body="invalid xml content")
 
         result = await plugin.getplayingtrack()
@@ -564,7 +564,7 @@ async def test_getplayingtrack_with_xml_declaration():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # This simulates the actual JRiver response format with XML declaration
         jriver_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Response Status="OK">
@@ -600,8 +600,8 @@ async def test_getplayingtrack_with_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL including query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123",
             body='<Response Status="OK"></Response>',
@@ -622,8 +622,8 @@ async def test_getplayingtrack_without_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL without query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL without query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info",
             body='<Response Status="OK"></Response>',
@@ -644,8 +644,8 @@ async def test_getplayingtrack_with_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL including query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info?AccessKey=myaccesskey123",
             body='<Response Status="OK"></Response>',
@@ -667,8 +667,8 @@ async def test_getplayingtrack_with_token_and_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL including query parameters
         # Note: order of parameters in URL may vary, so we test the call was made correctly
         url = "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123&AccessKey=myaccesskey123"  # pylint: disable=line-too-long
         mock_resp.get(url, body='<Response Status="OK"></Response>')
@@ -688,7 +688,7 @@ async def test_get_filename_with_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&AccessKey=myaccesskey123"
         mock_resp.get(
             url,
@@ -714,7 +714,7 @@ async def test_get_filename_with_token_and_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = (
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&"
             "Token=mytoken123&AccessKey=myaccesskey123"
@@ -865,7 +865,7 @@ async def test_get_filename_success(jriver_plugin_with_session):  # pylint: disa
     plugin.base_url = "http://localhost:52199/MCWS/v1"
     plugin.token = "testtoken"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&Token=testtoken",
             body="""<Response Status="OK">
@@ -889,7 +889,7 @@ async def test_get_filename_not_found():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
             body="""
@@ -915,7 +915,7 @@ async def test_get_filename_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/File/GetInfo?File=12345", status=404)
 
         result = await plugin._get_filename("12345")  # pylint: disable=protected-access
@@ -933,7 +933,7 @@ async def test_get_filename_mpl_format():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # This simulates the actual JRiver MPL response format
         mpl_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <MPL Version="2.0" Title="MCWS - Files - 6096105472" PathSeparator="/">
@@ -963,7 +963,7 @@ async def test_get_filename_response_format():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # Test the old Response format for backwards compatibility
         response_format = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Response Status="OK">
@@ -990,7 +990,7 @@ async def test_test_connection_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Alive",
             exception=aiohttp.ClientConnectorError(
@@ -1013,7 +1013,7 @@ async def test_test_connection_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Alive", exception=aiohttp.ClientTimeout())
 
         result = await plugin._test_connection()  # pylint: disable=protected-access
@@ -1033,7 +1033,7 @@ async def test_authenticate_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(
             url,
@@ -1059,7 +1059,7 @@ async def test_authenticate_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(url, exception=aiohttp.ClientTimeout())
 
@@ -1078,7 +1078,7 @@ async def test_getplayingtrack_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info",
             exception=aiohttp.ClientConnectorError(
@@ -1101,7 +1101,7 @@ async def test_getplayingtrack_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info", exception=aiohttp.ClientTimeout()
         )
@@ -1121,7 +1121,7 @@ async def test_getplayingtrack_xml_none_safety():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # Return completely empty response that will cause XML parsing error
         mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body="")
 
@@ -1141,7 +1141,7 @@ async def test_get_filename_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
             exception=aiohttp.ClientConnectorError(
@@ -1164,7 +1164,7 @@ async def test_get_filename_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
             exception=aiohttp.ClientTimeout(),
@@ -1188,7 +1188,7 @@ async def test_auto_recovery_success():
         patch.object(plugin, "_test_connection", return_value=True),
         patch.object(plugin, "_authenticate", return_value=True),
     ):
-        with aioresponses() as mock_resp:
+        async with aiointercept(mock_external_urls=True) as mock_resp:
             mock_resp.get(
                 "http://localhost:52199/MCWS/v1/Playback/Info",
                 body='<Response><Item Name="Artist">Test Artist</Item>'
@@ -1230,7 +1230,7 @@ async def test_connection_error_sets_failed_state():
     plugin.session = aiohttp.ClientSession()
     plugin._connection_failed = False  # pylint: disable=protected-access
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info",
             exception=aiohttp.ClientConnectorError(

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest.mock
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.inputs.serato
 import nowplaying.utils.sqlite
@@ -553,7 +553,7 @@ async def test_streaming_track_artwork(bootstrap, serato_master_db):  # pylint: 
 
         fake_image = b"\x89PNG\r\n\x1a\n"  # PNG magic bytes
 
-        with aioresponses() as mock_resp:
+        async with aiointercept(mock_external_urls=True) as mock_resp:
             mock_resp.get(artwork_url, status=200, body=fake_image)
 
             try:
@@ -601,7 +601,7 @@ async def test_streaming_track_is_video(bootstrap, serato_master_db):  # pylint:
         plugin.setmixmode("newest")
         await plugin.start()
 
-        with aioresponses() as mock_resp:
+        async with aiointercept(mock_external_urls=True) as mock_resp:
             mock_resp.get("https://example.com/artwork.jpg", status=200, body=b"\x89PNG\r\n\x1a\n")
 
             try:

--- a/tests/twitch/test_twitch_oauth2.py
+++ b/tests/twitch/test_twitch_oauth2.py
@@ -6,8 +6,10 @@ import base64
 import hashlib
 from unittest.mock import patch
 
+import aiohttp
 import pytest
-from aioresponses import aioresponses
+import pytest_asyncio
+from aiointercept import aiointercept
 
 import nowplaying.twitch.oauth2  # pylint: disable=import-error,no-name-in-module
 from nowplaying.twitch.constants import API_HOST, OAUTH_HOST
@@ -37,10 +39,10 @@ def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
     return oauth
 
 
-@pytest.fixture
-def mock_responses():
-    """Fixture that provides aioresponses for mocking HTTP calls."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_responses():
+    """Fixture that provides aiointercept for mocking HTTP calls."""
+    async with aiointercept(mock_external_urls=True) as mock:
         yield mock
 
 
@@ -468,9 +470,9 @@ async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disa
     oauth = oauth_with_pkce
 
     # Mock a timeout by using an exception
-    mock_responses.post(f"{OAUTH_HOST}/oauth2/token", exception=TimeoutError("Request timed out"))
+    mock_responses.post(f"{OAUTH_HOST}/oauth2/token", exception=True)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises((asyncio.TimeoutError, aiohttp.ClientConnectionError)):
         await oauth.exchange_code_for_token("test_code", oauth.state)
 
 

--- a/tests/twitch/test_twitch_utils.py
+++ b/tests/twitch/test_twitch_utils.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.twitch.oauth2
 import nowplaying.twitch.utils
@@ -349,7 +349,7 @@ async def test_cache_token_del(bootstrap):
         assert bootstrap.cparser.value("twitchbot/refreshtoken") is None
 
 
-# User image retrieval tests using aioresponses
+# User image retrieval tests using aiointercept
 @pytest.mark.asyncio
 async def test_get_user_image_success():
     """Test successful user image retrieval."""
@@ -358,7 +358,7 @@ async def test_get_user_image_success():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # Mock user data response
         mock_resp.get(
             "https://api.twitch.tv/helix/users?login=test_user",
@@ -383,7 +383,7 @@ async def test_get_user_image_no_user():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "https://api.twitch.tv/helix/users?login=nonexistent_user",
             payload={"data": []},  # No user found
@@ -401,7 +401,7 @@ async def test_get_user_image_error():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "https://api.twitch.tv/helix/users?login=test_user",
             exception=Exception("Network error"),


### PR DESCRIPTION
Switch all HTTP mocking from aioresponses to aiointercept, which intercepts via DNS redirection to a local server rather than monkey-patching ClientSession._request. Requires async with and mock_external_urls=True for transparent interception, and async fixtures via pytest_asyncio.fixture.

Also fix jriver.py to catch ServerDisconnectedError alongside ClientConnectorError in all four network methods — both indicate JRiver is unreachable and should set _connection_failed=True.

## Summary by Sourcery

Switch HTTP mocking across the test suite from aioresponses to aiointercept and broaden JRiver connection error handling.

Bug Fixes:
- Treat aiohttp.ServerDisconnectedError the same as ClientConnectorError in JRiver connection, authentication, playback info, and filename retrieval paths so unreachable servers are consistently handled.

Tests:
- Replace aioresponses with aiointercept across async tests and fixtures, updating them to use async context managers and pytest_asyncio fixtures where needed.
- Adjust OAuth timeout tests to expect aiohttp connection-related errors compatible with aiointercept's behavior.