### PR TITLE
Fix yamllint

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: Deploy Documentation
 
 on:  # yamllint disable-line rule:truthy

--- a/.github/workflows/ghpages-test.yaml
+++ b/.github/workflows/ghpages-test.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: website-test
 
 # Test that documentation builds successfully on all pushes

--- a/.github/workflows/tufup-publish.yaml
+++ b/.github/workflows/tufup-publish.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: tufup publish on release
 
 # Triggered when a draft release is published.  Downloads the 4

--- a/.github/workflows/tufup-resign.yaml
+++ b/.github/workflows/tufup-resign.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: tufup daily resign
 
 # Re-signs TUF metadata daily so timestamp.json (24h expiry),


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add yamllint line-length rule disable comments at the top of GitHub workflow YAMLs to satisfy linting.