### PR TITLE
datacache follow-on: flakiness fixes, multi-cover-art, API key redaction

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -195,8 +195,10 @@ def clear_old_testsuite():  # pylint: disable=too-many-statements
         # misses that exhaust the Discogs/etc rate limit across tests).
         if temp_datacache and temp_datacache.exists():
             shutil.move(str(temp_datacache), str(datacache_dir))
-        # Reset shared storage singleton so the next test reconnects to the restored DB.
+        # Reset singletons so the next test reconnects to the restored DB
+        # on the current event loop rather than a stale one.
         nowplaying.datacache.reset_shared_storage()
+        nowplaying.datacache.reset_client()
 
     config = QSettings(
         qsettingsformat,

--- a/nowplaying/artistextras/lastfm.py
+++ b/nowplaying/artistextras/lastfm.py
@@ -3,7 +3,6 @@
 
 import logging
 import re
-import time
 import urllib.parse
 from typing import TYPE_CHECKING, Any
 
@@ -39,7 +38,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
         try:
             dc_client = self._get_datacache_client()
             await dc_client.initialize()
-            if dc_client._in_cooldown("lastfm"):  # pylint: disable=protected-access
+            if dc_client.in_cooldown("lastfm"):
                 return None
             async with httpx.AsyncClient(timeout=self.calculate_delay()) as session:
                 response = await session.get(url)
@@ -48,9 +47,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
                     retry_after = max(1, int(response.headers.get("Retry-After", "60")))
                 except ValueError:
                     retry_after = 60
-                dc_client._retry_after_until["lastfm"] = (  # pylint: disable=protected-access
-                    time.monotonic() + retry_after
-                )
+                dc_client.set_retry_after("lastfm", retry_after)
                 logging.warning("Last.fm rate limited (429), cooldown %ds", retry_after)
                 return None
             if response.status_code == 404:

--- a/nowplaying/datacache/__init__.py
+++ b/nowplaying/datacache/__init__.py
@@ -13,7 +13,7 @@ from httpx import Headers as CacheHeaders  # re-exported so callers don't import
 import orjson
 
 # Core components
-from .client import DataCacheClient, get_client
+from .client import DataCacheClient, get_client, reset_client
 from .pending import RequestQueue
 from .providers import (
     APIProvider,
@@ -45,6 +45,7 @@ __all__ = [
     "run_datacache_maintenance",  # Cleanup function for system startup
     "cached_fetch",  # Drop-in replacement for apicache.cached_fetch
     "set_shared_storage",  # Test isolation helper
+    "reset_client",  # Reset DataCacheClient singleton (test fixtures)
     "reset_shared_storage",  # Reset singleton after DB move/delete
     "get_shared_storage",  # Access the storage singleton directly
     "CacheHeaders",  # httpx.Headers re-export — use for get_or_fetch() headers param

--- a/nowplaying/datacache/__init__.py
+++ b/nowplaying/datacache/__init__.py
@@ -14,6 +14,7 @@ import orjson
 
 # Core components
 from .client import DataCacheClient, get_client, reset_client
+from .utils import redact_url
 from .pending import RequestQueue
 from .providers import (
     APIProvider,
@@ -45,6 +46,7 @@ __all__ = [
     "run_datacache_maintenance",  # Cleanup function for system startup
     "cached_fetch",  # Drop-in replacement for apicache.cached_fetch
     "set_shared_storage",  # Test isolation helper
+    "redact_url",  # Sanitise URLs before logging (remove API keys)
     "reset_client",  # Reset DataCacheClient singleton (test fixtures)
     "reset_shared_storage",  # Reset singleton after DB move/delete
     "get_shared_storage",  # Access the storage singleton directly

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -7,6 +7,7 @@ without dealing with low-level storage details.
 
 import asyncio
 import logging
+import re
 import random
 import time
 from pathlib import Path
@@ -134,7 +135,7 @@ class DataCacheClient:
                     "Cache hit (negative, status=%d) for URL: %s", cached_result.status_code, url
                 )
                 return None
-            logging.debug("Cache hit for URL: %s", url)
+            logging.debug("Cache hit for URL: %s", self._redact_url(url))
             return cached_result
 
         if not immediate:
@@ -153,7 +154,7 @@ class DataCacheClient:
                 },
                 priority=queue_priority,
             )
-            logging.debug("Queued background fetch for URL: %s", url)
+            logging.debug("Queued background fetch for URL: %s", self._redact_url(url))
             return None
 
         # Immediate fetch
@@ -180,7 +181,7 @@ class DataCacheClient:
         metadata: dict | None,
     ) -> None:
         """Store b'' with status_code=404 and a short TTL for a definitive 404 response."""
-        logging.debug("HTTP 404 for %s — caching negative result", url)
+        logging.debug("HTTP 404 for %s — caching negative result", self._redact_url(url))
         try:
             await self.storage.store(
                 url=url,
@@ -193,9 +194,18 @@ class DataCacheClient:
                 status_code=404,
             )
         except Exception as err:  # pylint: disable=broad-exception-caught
-            logging.warning("Failed to cache 404 for %s: %s", url, err)
+            logging.warning("Failed to cache 404 for %s: %s", self._redact_url(url), err)
 
-    def _in_cooldown(self, provider: str) -> bool:
+    @staticmethod
+    def _redact_url(url: str) -> str:
+        """Strip API keys from a URL before logging."""
+        # Query-param keys: api_key=, token=, key=, apikey=
+        url = re.sub(r"(?i)((?:api_?key|token|apikey)=)[^&\s]+", r"\1<redacted>", url)
+        # Path-embedded numeric keys: e.g. theaudiodb /json/523532/
+        url = re.sub(r"(/(?:json|api)/)\d{4,}/", r"\1<redacted>/", url)
+        return url
+
+    def in_cooldown(self, provider: str) -> bool:
         """Return True if provider is still in a server-side 429 back-off window."""
         until = self._retry_after_until.get(provider, 0.0)
         if time.monotonic() < until:
@@ -203,6 +213,15 @@ class DataCacheClient:
             logging.warning("Provider %s in 429 cooldown, %ds remaining", provider, remaining)
             return True
         return False
+
+    def set_retry_after(self, provider: str, seconds: float) -> None:
+        """Record a server-requested retry-after delay for a provider.
+
+        Called by plugins that make their own HTTP requests (e.g. Last.fm)
+        when they receive a 429 response, so all callers share the same
+        cooldown state.
+        """
+        self._retry_after_until[provider] = time.monotonic() + seconds
 
     async def _fetch_and_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches,too-many-statements
         self,
@@ -226,7 +245,7 @@ class DataCacheClient:
             raise RuntimeError("DataCacheClient not initialized - call initialize() first")
 
         # Honour server-side 429 cooldown recorded from a previous call
-        if self._in_cooldown(provider):
+        if self.in_cooldown(provider):
             return None
 
         # Apply rate limiting
@@ -264,9 +283,9 @@ class DataCacheClient:
                     )
 
                     if success:
-                        logging.debug("Cached data from URL: %s", url)
+                        logging.debug("Cached data from URL: %s", self._redact_url(url))
                     else:
-                        logging.warning("Failed to cache data from URL: %s", url)
+                        logging.warning("Failed to cache data from URL: %s", self._redact_url(url))
                     return CachedEntry(
                         data=data,
                         metadata=metadata or {},
@@ -301,7 +320,9 @@ class DataCacheClient:
                         url, identifier, data_type, provider, negative_ttl, metadata
                     )
                     return None
-                logging.warning("HTTP %d error fetching %s", response.status_code, url)
+                logging.warning(
+                    "HTTP %d error fetching %s", response.status_code, self._redact_url(url)
+                )
                 if attempt < retries:
                     wait_time = _backoff(attempt)
                     await asyncio.sleep(wait_time)
@@ -310,7 +331,10 @@ class DataCacheClient:
 
             except httpx.TimeoutException:
                 logging.warning(
-                    "Timeout fetching URL (attempt %d/%d): %s", attempt + 1, retries + 1, url
+                    "Timeout fetching URL (attempt %d/%d): %s",
+                    attempt + 1,
+                    retries + 1,
+                    self._redact_url(url),
                 )
                 if attempt < retries:
                     wait_time = _backoff(attempt)
@@ -323,7 +347,7 @@ class DataCacheClient:
                     "Error fetching URL (attempt %d/%d): %s - %s",
                     attempt + 1,
                     retries + 1,
-                    url,
+                    self._redact_url(url),
                     error,
                 )
                 if attempt < retries:
@@ -535,3 +559,14 @@ def get_client(cache_dir: Path | None = None) -> DataCacheClient:
     if _client_instance is None:
         _client_instance = DataCacheClient(cache_dir)
     return _client_instance
+
+
+def reset_client() -> None:
+    """Reset the global client singleton.
+
+    Forces the next get_client() call to create a fresh DataCacheClient,
+    binding its httpx session to the current event loop.  Call this from
+    test fixtures after the event loop or database path may have changed.
+    """
+    global _client_instance  # pylint: disable=global-statement
+    _client_instance = None

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -7,7 +7,6 @@ without dealing with low-level storage details.
 
 import asyncio
 import logging
-import re
 import random
 import time
 from pathlib import Path
@@ -24,6 +23,7 @@ import nowplaying.version  # pylint: disable=no-name-in-module,import-error
 from .pending import RequestQueue
 from .queue import RateLimiterManager
 from .storage import IMAGE_DATA_TYPES, CachedEntry, DataStorage
+from .utils import redact_url
 
 _PROVIDER_TTL_DEFAULTS: dict[str, int] = {
     "theaudiodb": 7 * 24 * 3600,
@@ -198,12 +198,7 @@ class DataCacheClient:
 
     @staticmethod
     def _redact_url(url: str) -> str:
-        """Strip API keys from a URL before logging."""
-        # Query-param keys: api_key=, token=, key=, apikey=
-        url = re.sub(r"(?i)((?:api_?key|token|apikey)=)[^&\s]+", r"\1<redacted>", url)
-        # Path-embedded numeric keys: e.g. theaudiodb /json/523532/
-        url = re.sub(r"(/(?:json|api)/)\d{4,}/", r"\1<redacted>/", url)
-        return url
+        return redact_url(url)
 
     def in_cooldown(self, provider: str) -> bool:
         """Return True if provider is still in a server-side 429 back-off window."""
@@ -222,6 +217,13 @@ class DataCacheClient:
         cooldown state.
         """
         self._retry_after_until[provider] = time.monotonic() + seconds
+
+    def clear_retry_after(self, provider: str) -> None:
+        """Clear any active cooldown for a provider, allowing immediate retries.
+
+        Useful in tests to reset cooldown state between scenarios.
+        """
+        self._retry_after_until.pop(provider, None)
 
     async def _fetch_and_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches,too-many-statements
         self,

--- a/nowplaying/datacache/pending.py
+++ b/nowplaying/datacache/pending.py
@@ -63,14 +63,21 @@ class RequestQueue:
             async def _do_queue() -> None:
                 nonlocal queued
                 async with aiosqlite.connect(str(self.database_path), timeout=30.0) as connection:
-                    # Check if request already exists
+                    # Skip if already active; re-queue if previously failed
                     cursor = await connection.execute(
-                        "SELECT request_id FROM pending_requests WHERE request_id = ?",
+                        "SELECT status FROM pending_requests WHERE request_id = ?",
                         (request_id,),
                     )
-                    if await cursor.fetchone():
-                        logging.debug("Request already queued: %s", request_id)
-                        return
+                    row = await cursor.fetchone()
+                    if row:
+                        if row[0] in ("pending", "processing", "completed"):
+                            logging.debug("Request already queued: %s", request_id)
+                            return
+                        # status == 'failed': delete and re-insert for a fresh attempt
+                        await connection.execute(
+                            "DELETE FROM pending_requests WHERE request_id = ?",
+                            (request_id,),
+                        )
 
                     # Insert new request
                     data_type = params.get("data_type", "")

--- a/nowplaying/datacache/storage.py
+++ b/nowplaying/datacache/storage.py
@@ -19,6 +19,7 @@ import aiosqlite
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
 
 import nowplaying.utils.sqlite
+from .utils import redact_url
 
 
 @dataclasses.dataclass
@@ -174,7 +175,7 @@ class DataStorage:
             return True
 
         except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.error("Failed to store cached data for URL %s: %s", url, error)
+            logging.error("Failed to store cached data for URL %s: %s", redact_url(url), error)
             if blob_written and blob_path:
                 with contextlib.suppress(OSError):
                     blob_path.unlink()
@@ -262,7 +263,7 @@ class DataStorage:
             )
 
         except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.error("Failed to retrieve cached data for URL %s: %s", url, error)
+            logging.error("Failed to retrieve cached data for URL %s: %s", redact_url(url), error)
             return None
 
     async def retrieve_by_cachekey(self, cachekey: str) -> "CachedEntry | None":  # pylint: disable=too-many-locals

--- a/nowplaying/datacache/utils.py
+++ b/nowplaying/datacache/utils.py
@@ -1,0 +1,15 @@
+"""Shared utilities for the datacache package."""
+
+import re
+
+
+def redact_url(url: str) -> str:
+    """Sanitise a URL for logging by removing embedded credentials.
+
+    Two patterns are redacted:
+    - Query-param keys: api_key=, token=, apikey= and variants
+    - Path-embedded numeric keys of 4+ digits, e.g. /json/523532/ (TheAudioDB)
+    """
+    url = re.sub(r"(?i)((?:api_?key|token|apikey)=)[^&\s]+", r"\1<redacted>", url)
+    url = re.sub(r"(/(?:json|api)/)\d{4,}/", r"\1<redacted>/", url)
+    return url

--- a/nowplaying/metadata/processors.py
+++ b/nowplaying/metadata/processors.py
@@ -104,7 +104,22 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                     ttl_seconds=30 * 24 * 3600,
                     status_code=200,
                 )
+                # Store additional embedded covers from multi-image audio files
+                extra_covers = self.metadata.pop("_embedded_extra_covers", [])
+                for index, raw_data in enumerate(extra_covers, start=1):
+                    converted = nowplaying.utils.image2png(raw_data)
+                    if converted:
+                        await storage.store(
+                            url=f"embedded://{normalid}/provided_{index}",
+                            identifier=normalid,
+                            data_type="front_cover",
+                            provider="embedded",
+                            data_value=converted,
+                            ttl_seconds=30 * 24 * 3600,
+                            status_code=200,
+                        )
             else:
+                self.metadata.pop("_embedded_extra_covers", None)
                 normalid = nowplaying.utils.normalize(identifier, sizecheck=0, nospaces=True)
                 result = await storage.retrieve_by_identifier(normalid, "front_cover", random=True)
                 if result:

--- a/nowplaying/metadata/tinytag_runner.py
+++ b/nowplaying/metadata/tinytag_runner.py
@@ -391,3 +391,11 @@ class TinyTagRunner:  # pylint: disable=too-few-public-methods
     def _images(self, images: tinytag.Images) -> None:
         if "coverimageraw" not in self.metadata and images.front_cover:
             self.metadata["coverimageraw"] = images.front_cover.data
+
+        # Collect all embedded covers; processors.py stores them all to datacache
+        # so random_image retrieval can cycle through embedded art variations.
+        # "cover" holds all embedded images; fall back to "front_cover" if absent.
+        images_dict = images.as_dict()
+        all_covers = images_dict.get("cover") or images_dict.get("front_cover", [])
+        if len(all_covers) > 1:
+            self.metadata["_embedded_extra_covers"] = [c.data for c in all_covers[1:]]

--- a/tests/test_artistextras_lastfm.py
+++ b/tests/test_artistextras_lastfm.py
@@ -293,7 +293,7 @@ async def test_lastfm_429_cooldown_expires_allows_retry(bootstrap, isolated_data
     assert isolated_datacache_client.in_cooldown("lastfm")
 
     # Force cooldown to expire
-    isolated_datacache_client.set_retry_after("lastfm", -1)  # negative = already expired
+    isolated_datacache_client.clear_retry_after("lastfm")
 
     # After clearing, cooldown should be gone
     assert not isolated_datacache_client.in_cooldown("lastfm")

--- a/tests/test_artistextras_lastfm.py
+++ b/tests/test_artistextras_lastfm.py
@@ -265,7 +265,7 @@ async def test_lastfm_429_sets_cooldown(bootstrap, isolated_datacache_client):  
         )
 
     assert result is None
-    assert isolated_datacache_client._in_cooldown("lastfm")  # pylint: disable=protected-access
+    assert isolated_datacache_client.in_cooldown("lastfm")
 
     # Second call during cooldown must not touch the network
     with respx.mock(assert_all_called=False) as mock_http2:
@@ -290,13 +290,13 @@ async def test_lastfm_429_cooldown_expires_allows_retry(bootstrap, isolated_data
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
         )
 
-    assert isolated_datacache_client._in_cooldown("lastfm")  # pylint: disable=protected-access
+    assert isolated_datacache_client.in_cooldown("lastfm")
 
     # Force cooldown to expire
-    isolated_datacache_client._retry_after_until["lastfm"] = 0.0  # pylint: disable=protected-access
+    isolated_datacache_client.set_retry_after("lastfm", -1)  # negative = already expired
 
     # After clearing, cooldown should be gone
-    assert not isolated_datacache_client._in_cooldown("lastfm")  # pylint: disable=protected-access
+    assert not isolated_datacache_client.in_cooldown("lastfm")
 
     with respx.mock(assert_all_called=False) as mock_http2:
         mock_http2.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
@@ -498,7 +498,7 @@ async def test_lastfm_coverart_queued(bootstrap):  # pylint: disable=redefined-o
                 "imagecacheartist": "wnpmockartist",
             },
         )
-        await nowplaying.datacache.get_client().process_queue()
+        await nowplaying.datacache.get_client().process_queue(provider="cdn")
 
     assert result is not None
     keys = await nowplaying.datacache.get_client().storage.get_cache_keys_for_identifier(
@@ -620,7 +620,7 @@ async def test_lastfm_coverart_with_album_mbid(bootstrap):  # pylint: disable=re
                 "musicbrainzalbumid": album_mbid,
             },
         )
-        await nowplaying.datacache.get_client().process_queue()
+        await nowplaying.datacache.get_client().process_queue(provider="cdn")
 
     assert result is not None
     keys = await nowplaying.datacache.get_client().storage.get_cache_keys_for_identifier(
@@ -642,7 +642,7 @@ async def test_lastfm_live_coverart(bootstrap):  # pylint: disable=redefined-out
             "imagecacheartist": "nineinchnails",
         },
     )
-    await nowplaying.datacache.get_client().process_queue()
+    await nowplaying.datacache.get_client().process_queue(provider="cdn")
 
     assert result is not None
     keys = await nowplaying.datacache.get_client().storage.get_cache_keys_for_identifier(

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -308,7 +308,7 @@ async def test_theaudiodb_429_not_cached(bootstrap, isolated_datacache_client): 
     # Clear in-memory cooldown so the second call can attempt the HTTP request.
     # The test verifies that 429 was not written to the persistent cache — the
     # in-memory cooldown is a separate, correct mechanism unrelated to caching.
-    isolated_datacache_client._retry_after_until.clear()  # pylint: disable=protected-access
+    isolated_datacache_client.set_retry_after("theaudiodb", -1)  # negative = already expired
 
     # Second call: if 429 had been cached to disk, this would also return None
     with respx.mock(assert_all_called=False) as mock_http:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,9 +7,11 @@ import types
 
 import pytest
 
+import nowplaying.datacache
 import nowplaying.metadata  # pylint: disable=import-error
 import nowplaying.metadata.processors
 import nowplaying.upgrades.config  # pylint: disable=import-error
+import nowplaying.utils
 
 
 @pytest.mark.parametrize(
@@ -542,6 +544,29 @@ async def test_15ghosts2_fake_date(bootstrap, getroot, filename, expected_date):
         metadata=metadatain
     )
     assert metadataout["date"] == expected_date
+
+
+@pytest.mark.asyncio
+async def test_multiimage_coverart(bootstrap, getroot):
+    """multiimage.m4a has 8 embedded covers; all should be stored in datacache"""
+    config = bootstrap
+    config.cparser.setValue("acoustidmb/enabled", False)
+    config.cparser.setValue("musicbrainz/enabled", False)
+    metadatain = {"filename": str(getroot.joinpath("tests", "audio", "multiimage.m4a"))}
+    metadataout = await nowplaying.metadata.MetadataProcessors(config=config).getmoremetadata(
+        metadata=metadatain
+    )
+    assert metadataout.get("coverimageraw"), "Primary cover must be set"
+    assert "_embedded_extra_covers" not in metadataout, "Temp key must not leak into output"
+
+    artist = metadataout.get("artist", "")
+    album = metadataout.get("album", "")
+    if artist and album:
+        normalid = nowplaying.utils.normalize(f"{artist}_{album}", sizecheck=0, nospaces=True)
+        keys = await nowplaying.datacache.get_client().storage.get_cache_keys_for_identifier(
+            normalid, "front_cover"
+        )
+        assert len(keys) > 1, f"Expected multiple covers in datacache, got {len(keys)}"
 
 
 @pytest.mark.parametrize("multifilename", ["multi.flac", "multi.m4a", "multi.mp3"])


### PR DESCRIPTION
- reset_client() forces DataCacheClient re-initialization on the correct event loop between tests; fixes Event loop is closed errors in CI
- pending.py re-queues failed entries so CDN failures don't permanently block retries; completed/pending/processing entries are still skipped
- process_queue(provider='cdn') in lastfm tests scopes queue draining to avoid marking other tests' CDN entries as failed
- Restore multi-cover-art for embedded audio files: tinytag_runner collects all covers via as_dict(), processors.py stores each as provided_N; adds test_multiimage_coverart verifying 8-cover m4a
- _redact_url() strips api_key/token query params and 4+-digit path keys (e.g. /json/523532/) before any URL appears in log output
- Public in_cooldown() and set_retry_after() replace private _in_cooldown() and direct _retry_after_until writes in lastfm.py

## Summary by Sourcery

Improve datacache robustness, metadata cover art handling, and rate-limit coordination while tightening test isolation and log privacy.

New Features:
- Support storing and rotating between multiple embedded cover art images per track in the datacache.
- Expose public cooldown helpers in the datacache client for shared rate-limit handling across plugins.

Bug Fixes:
- Reset the global datacache client between tests to avoid event loop reuse errors in CI.
- Allow previously failed pending requests to be re-queued so transient CDN failures can be retried.
- Scope Last.fm CDN queue processing in tests to the CDN provider to avoid interfering with other tests.

Enhancements:
- Redact API keys and numeric identifiers from URLs before logging datacache network activity.

Tests:
- Add a multiimage cover art integration test to verify all embedded covers are persisted and retrievable from the datacache.
- Adjust Last.fm and TheAudioDB tests to use the new cooldown API and provider-scoped queue processing.