### PR TITLE
djaypro: fix TSAF array typed scalar parse abort

### DIFF
--- a/nowplaying/djaypro/locationdb.py
+++ b/nowplaying/djaypro/locationdb.py
@@ -287,3 +287,11 @@ def rebuild(djay_dbfile: pathlib.Path, side_db: pathlib.Path) -> None:
         logging.debug("djaypro locationdb: could not stamp rebuild time: %s", err)
 
     tmp.replace(side_db)
+
+    try:
+        with nowplaying.utils.sqlite.sqlite_connection(str(side_db), timeout=1) as conn:
+            row = conn.execute("SELECT COUNT(*) FROM locations").fetchone()
+            count = row[0] if row else 0
+        logging.info("djaypro locationdb: rebuild complete, %d tracks indexed", count)
+    except (sqlite3.OperationalError, FileNotFoundError) as err:
+        logging.info("djaypro locationdb: rebuild complete (count unavailable: %s)", err)

--- a/nowplaying/djaypro/tsaf.py
+++ b/nowplaying/djaypro/tsaf.py
@@ -55,6 +55,12 @@ except ImportError:
     _HAS_MAC_ALIAS = False
 
 
+# Sentinel returned by _read_typed_value for unrecognised type codes.
+# Identity comparison (value is _TSAF_UNKNOWN) never accidentally matches a
+# real parsed value, including None.
+_TSAF_UNKNOWN = object()
+
+
 def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-many-statements
     """Deserialise a TSAF binary blob from the djay Pro MediaLibrary database.
 
@@ -113,6 +119,48 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
                     if v is not None and k not in target:
                         target[k] = v
 
+    def _read_typed_value(tc: int) -> object:
+        """Read the value for a scalar type code; return _TSAF_UNKNOWN if unrecognised.
+
+        Shared by read_array_element and parse_object so the type table stays
+        in one place.  The 0x2b (nested object), 0x0b (array), and 0x21
+        (string wrapper) types are structural and handled by their callers.
+        """
+        nonlocal pos
+        value: object = _TSAF_UNKNOWN
+        if tc == 0x08:
+            value = read_string()
+        elif tc == 0x0F:
+            # uint8: single value byte, no alignment
+            value = blob[pos] if pos < len(blob) else None
+            pos += 1
+        elif tc == 0x13:
+            value = read_float32()
+        elif tc in (0x14, 0x30):
+            value = read_float64()
+        elif tc == 0x0A:
+            value = read_aligned_int(2, "<h")
+        elif tc == 0x0C:
+            value = read_aligned_int(4, "<i")
+        elif tc in (0x11, 0x1A):
+            value = read_aligned_int(4, "<I")
+        elif tc == 0x12:
+            value = read_aligned_int(8, "<Q")
+        elif tc in (0x0D, 0x2D):
+            value = 0
+        elif tc == 0x0E:
+            value = 1
+        elif tc == 0x2E:
+            value = None
+        elif tc == 0x15:
+            # Binary blob: length may be larger than remaining bytes if the
+            # blob is truncated; clamp pos so subsequent fields aren't skipped.
+            length = read_aligned_int(4, "<I")
+            end = pos + length
+            value = bytes(blob[pos:end])
+            pos = min(end, len(blob))
+        return value
+
     def read_array_element() -> object:
         nonlocal pos
         if pos >= len(blob):
@@ -128,32 +176,9 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
             if pos < len(blob) and blob[pos] == 0x00:
                 pos += 1  # skip trailing null
             return s
-        if tc == 0x08:
-            value: object = read_string()
-        elif tc == 0x13:
-            value = read_float32()
-        elif tc in (0x14, 0x30):
-            value = read_float64()
-        elif tc == 0x0A:
-            value = read_aligned_int(2, "<h")
-        elif tc in (0x0C, 0x11, 0x1A):
-            value = read_aligned_int(4, "<I")
-        elif tc == 0x12:
-            value = read_aligned_int(8, "<Q")
-        elif tc == 0x0F:
-            value = blob[pos] if pos < len(blob) else None
-            pos += 1
-        elif tc in (0x0D, 0x2D):
-            value = 0
-        elif tc == 0x0E:
-            value = 1
-        elif tc == 0x2E:
-            value = None
-        elif tc == 0x15:
-            length = read_aligned_int(4, "<I")
-            value = bytes(blob[pos : pos + length])
-            pos += length
-        else:
+        value = _read_typed_value(tc)
+        if value is _TSAF_UNKNOWN:
+            logging.warning("Unknown TSAF type 0x%02x in array at offset %d", tc, pos - 1)
             return None
         # Typed array elements may carry a key — return a dict for _merge_list_into
         if pos < len(blob) and blob[pos] == 0x08:
@@ -228,87 +253,35 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
             tc = blob[pos]
             pos += 1
 
-            if tc == 0x0A:
-                # int16 (2-byte-aligned) — sortOrder in contentPacks
-                value: object = read_aligned_int(2, "<h")
-            elif tc == 0x08:
-                value: object = read_string()
-            elif tc == 0x0F:
-                # uint8: value is the next byte (e.g. deckNumber on macOS)
-                value = blob[pos] if pos < len(blob) else None
-                pos += 1
-            elif tc == 0x13:
-                # macOS: float32 with 4-byte alignment
-                value = read_float32()
-            elif tc in (0x14, 0x30):
-                # float64 with 8-byte alignment; 0x30 = timestamp
-                value = read_float64()
-            elif tc == 0x0D:
-                # Boolean False marker (zero-byte, implicit 0).  Seen on
-                # isStraightGrid, which djay sets on tracks that have a
-                # constant-tempo (straight) beatgrid.  Absent when djay has not
-                # analysed the track or when the grid is dynamic/variable.
-                value = 0
-            elif tc == 0x0E:
-                # Boolean True marker (zero-byte, implicit 1).  Completes the
-                # 0x0d/0x0e implicit boolean pair.  Seen on the "featured" flag
-                # in contentPacks.
-                value = 1
-            elif tc == 0x2D:
-                # Zero-byte integer marker seen before deckNumber=1 on macOS.
-                # The value is implicit (1); no value bytes precede the key.
-                value = 1
-            elif tc == 0x2E:
-                # Zero-byte null/indeterminate marker.  Seen before
-                # keySignatureIndex when djay has not determined the key for
-                # a track.  The value is implicit None; no value bytes precede
-                # the key.  Parsing continues so subsequent fields are read.
-                value = None
-            elif tc == 0x2B:
+            if tc == 0x2B:
                 # Inline nested object: merge fields into parent
                 sub = parse_object()
                 result.update(sub)
                 fields_read += 1
                 continue  # no separate key
-            elif tc == 0x0B:
+            if tc == 0x0B:
                 # Array: 4-byte-aligned int32 count, then elements
                 count = read_aligned_int(4, "<i")
-                value = [read_array_element() for _ in range(count) if pos < len(blob)]
+                value: object = [read_array_element() for _ in range(count) if pos < len(blob)]
             elif tc == 0x21:
                 if pos < len(blob):
                     pos += 1  # skip sub-type byte
                 value = read_string()
                 if pos < len(blob) and blob[pos] == 0x00:
                     pos += 1
-            elif tc == 0x0C:
-                # int32 (4-byte-aligned).  Seen in contentPacks and
-                # historySessions; not used for track metadata but handled
-                # so parsing continues past these fields without warnings.
-                value = read_aligned_int(4, "<i")
-            elif tc in (0x11, 0x1A):
-                # uint32 (4-byte-aligned).
-                # 0x11: fileSize in contentPacks
-                # 0x1a: colorIndex in mediaItemUserData
-                value = read_aligned_int(4, "<I")
-            elif tc == 0x12:
-                # uint64 (8-byte-aligned).  Inferred counterpart to 0x11;
-                # would be used for fileSize values exceeding 4 GB.
-                value = read_aligned_int(8, "<Q")
-            elif tc == 0x15:
-                # Binary blob: 4-byte-aligned uint32 length, then raw bytes
-                # Used on macOS for CFURLBookmarkData (urlBookmarkData field)
-                length = read_aligned_int(4, "<I")
-                value = bytes(blob[pos : pos + length])
-                pos += length
             else:
-                # Unknown type: the value size is unknowable so the cursor
-                # cannot be advanced safely.  Stop parsing this object and
-                # return what was collected so far.  Log at WARNING so new
-                # type codes added by djay Pro updates are visible.
-                logging.warning(
-                    "Unknown TSAF type 0x%02x at offset %d; stopping parse", tc, pos - 1
-                )
-                break
+                value = _read_typed_value(tc)
+                if value is _TSAF_UNKNOWN:
+                    # Unknown type: value size is unknowable so the cursor
+                    # cannot be advanced safely.  Stop and return what was
+                    # collected so far.  Log at WARNING so new type codes
+                    # added by djay Pro updates are visible.
+                    logging.warning(
+                        "Unknown TSAF type 0x%02x at offset %d; stopping parse",
+                        tc,
+                        pos - 1,
+                    )
+                    break
 
             if pos < len(blob) and blob[pos] == 0x08:
                 pos += 1

--- a/nowplaying/djaypro/tsaf.py
+++ b/nowplaying/djaypro/tsaf.py
@@ -16,7 +16,9 @@ Type codes:
   0x05  2-byte skip marker / field-count hint
   0x08  null-terminated UTF-8 string
   0x0a  int16 (2-byte-aligned) — seen in contentPacks (sortOrder)
-  0x0b  array (4-byte-aligned int32 count, then typed elements)
+  0x0b  array (4-byte-aligned int32 count, then typed elements); elements may
+        be objects (0x2b), strings (0x08/0x21), or typed key-value pairs where
+        any scalar type code is followed by its value bytes then 0x08+key
   0x0c  int32 (4-byte-aligned) — seen in contentPacks / historySessions
   0x0d  boolean False (implicit 0, zero-byte) — e.g. isStraightGrid; present on
         tracks with a constant-tempo beatgrid; absent when analysis was skipped
@@ -127,8 +129,38 @@ def parse_tsaf(blob: bytes) -> dict:  # pylint: disable=too-many-branches,too-ma
                 pos += 1  # skip trailing null
             return s
         if tc == 0x08:
-            return read_string()
-        return None
+            value: object = read_string()
+        elif tc == 0x13:
+            value = read_float32()
+        elif tc in (0x14, 0x30):
+            value = read_float64()
+        elif tc == 0x0A:
+            value = read_aligned_int(2, "<h")
+        elif tc in (0x0C, 0x11, 0x1A):
+            value = read_aligned_int(4, "<I")
+        elif tc == 0x12:
+            value = read_aligned_int(8, "<Q")
+        elif tc == 0x0F:
+            value = blob[pos] if pos < len(blob) else None
+            pos += 1
+        elif tc in (0x0D, 0x2D):
+            value = 0
+        elif tc == 0x0E:
+            value = 1
+        elif tc == 0x2E:
+            value = None
+        elif tc == 0x15:
+            length = read_aligned_int(4, "<I")
+            value = bytes(blob[pos : pos + length])
+            pos += length
+        else:
+            return None
+        # Typed array elements may carry a key — return a dict for _merge_list_into
+        if pos < len(blob) and blob[pos] == 0x08:
+            pos += 1
+            key = read_string()
+            return {key: value}
+        return value
 
     def parse_object() -> dict:  # pylint: disable=too-many-branches,too-many-statements
         nonlocal pos

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -215,6 +215,55 @@ def test_parse_blob_ignores_root_only_file_uri():
     assert result["filename"] is None
 
 
+def test_parse_blob_array_typed_scalar_field(caplog):
+    """Array elements may be typed float32 key-value pairs, not just objects/strings.
+
+    Regression: localMediaItemLocations blobs contain a 0x0b array whose second
+    element is a 0x13 float32 with a key (e.g. duration).  read_array_element
+    previously only handled 0x2b/0x21/0x08, so it consumed the 0x13 type byte
+    without reading the value bytes.  The main loop then saw 0x66 (the first
+    byte of the float32 value for ~354 s) as an unknown type and aborted.
+    """
+    # Build the blob manually to replicate the exact production structure.
+    # Offsets are calculated precisely so float32 alignment works out:
+    #   pos=120 when element-1 type byte (0x13) is consumed → pos=121
+    #   read_float32 pads 121→124, reads 4 bytes at 124-127, key at 128+
+    duration_float = 240.0
+    blob = (
+        b"TSAF"
+        + b"\x00" * 16  # 20-byte header
+        + b"\x2b"  # outer object
+        + b"\x08ADCMediaItemLocation\x00"  # class name
+        + b"\x0b"  # array type (no trailing key → merges into parent)
+        + b"\x02\x00\x00\x00"  # count=2
+        # element 0: nested ADCMediaItemTitleID object
+        + b"\x2b"
+        + b"\x08ADCMediaItemTitleID\x00"
+        + b"\x05\x02"  # local_max=2
+        + b"\x08WNP Mock Title\x00"
+        + b"\x08title\x00"
+        + b"\x08WNP Mock Artist\x00"
+        + b"\x08artist\x00"
+        # element 1 type byte is at offset 120; after consuming it pos=121
+        # read_float32 aligns 121→124; bytes 121-123 are skipped padding
+        + b"\x13"  # float32 type
+        + b"\x00\x00\x00"  # padding (alignment skip, any value)
+        + struct.pack("<f", duration_float)  # float32 value at offset 124
+        + b"\x08duration\x00"  # key
+        + b"\x00"  # end-of-object
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = nowplaying.djaypro.tsaf.parse_blob(blob)
+
+    assert result["artist"] == "WNP Mock Artist"
+    assert result["title"] == "WNP Mock Title"
+    assert result["duration"] == int(duration_float)
+    assert "Unknown TSAF type" not in caplog.text
+
+
 def test_parse_blob_no_float_returns_none_bpm_duration():
     """_parse_blob returns None for bpm/duration when those fields are absent."""
     blob = _build_tsaf_blob(

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -2,6 +2,7 @@
 """test djay Pro input plugin"""
 # pylint: disable=protected-access,too-many-lines
 
+import logging
 import pathlib
 import sqlite3
 import struct
@@ -252,8 +253,6 @@ def test_parse_blob_array_typed_scalar_field(caplog):
         + b"\x08duration\x00"  # key
         + b"\x00"  # end-of-object
     )
-
-    import logging
 
     with caplog.at_level(logging.WARNING):
         result = nowplaying.djaypro.tsaf.parse_blob(blob)


### PR DESCRIPTION
read_array_element only handled 0x2b/0x21/0x08 elements. localMediaItemLocations blobs contain arrays with typed scalar key-value pairs (e.g. 0x13 float32 duration). The unhandled type byte was consumed but its value bytes were not, causing the main loop to see a value byte (0x66) as an unknown type code and abort. Extend read_array_element to handle all scalar types and return {key: value} dicts when a key follows. Also add rebuild completion log line.

## Summary by Sourcery

Handle typed scalar key-value elements in TSAF arrays and report completion details after rebuilding the djaypro location database.

Bug Fixes:
- Fix TSAF array parsing to correctly consume and interpret typed scalar elements instead of aborting on unknown type codes.

Enhancements:
- Return key-value dicts for typed scalar elements in TSAF arrays so they merge correctly into parsed objects.
- Log a rebuild completion summary with the number of indexed tracks after rebuilding the djaypro location database, or a fallback message if the count cannot be retrieved.

Tests:
- Add a regression test to verify that TSAF blobs with typed scalar array elements (e.g., float32 duration fields) parse correctly without unknown type errors.