### PR TITLE
datacache CI: weekly rotating cache, LASTFM key, reset_client fix

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,8 @@ env:
   ACOUSTID_TEST_APIKEY: ${{ secrets.ACOUSTID_TEST_APIKEY }}  # pragma: allowlist secret
   DISCOGS_API_KEY: ${{ secrets.DISCOGS_API_KEY }}  # pragma: allowlist secret
   FANARTTV_API_KEY: ${{ secrets.FANARTTV_API_KEY }}  # pragma: allowlist secret
-  THEAUDIODB_API_KEY: ${{ secrets.THEAUDIODB_API_KEY }}  # pragma: allowlist secret
+  THEAUDIODB_API_KEY: ${{ secrets.THEAUDIODB_API_KEY }}
+  LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}  # pragma: allowlist secret  # pragma: allowlist secret
   # needed for upgrade test
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}    # pragma: allowlist secret
 
@@ -54,12 +55,18 @@ jobs:
           /tmp/venv/bin/python tools/setupnltk.py
           /tmp/venv/bin/python tools/build_templates.py
           /tmp/venv/bin/pyside6-rcc nowplaying/resources/settings.qrc > nowplaying/qtrc.py
+      - name: get week stamp
+        id: week
+        shell: bash
+        run: echo "stamp=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
       - name: restore datacache
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/whatsnowplaying/testsuite/datacache
-          key: datacache-${{ runner.os }}-${{ hashFiles('nowplaying/datacache/**') }}
-          restore-keys: datacache-${{ runner.os }}-
+          key: datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-${{ github.run_id }}
+          restore-keys: |
+            datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-
+            datacache-${{ runner.os }}-
       - name: tests
         shell: bash
         run: |
@@ -125,12 +132,18 @@ jobs:
           python tools/setupnltk.py
           python tools/build_templates.py
           pyside6-rcc nowplaying/resources/settings.qrc > nowplaying/qtrc.py
+      - name: get week stamp
+        id: week
+        shell: bash
+        run: echo "stamp=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
       - name: restore datacache
         uses: actions/cache@v5
         with:
           path: ~\AppData\Local\whatsnowplaying\testsuite\datacache
-          key: datacache-${{ runner.os }}-${{ hashFiles('nowplaying/datacache/**') }}
-          restore-keys: datacache-${{ runner.os }}-
+          key: datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-${{ github.run_id }}
+          restore-keys: |
+            datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-
+            datacache-${{ runner.os }}-
       - name: tests
         shell: bash
         run: |
@@ -225,12 +238,16 @@ jobs:
           /tmp/venv/bin/python tools/setupnltk.py
           /tmp/venv/bin/python tools/build_templates.py
           /tmp/venv/bin/pyside6-rcc nowplaying/resources/settings.qrc > nowplaying/qtrc.py
+      - name: get week stamp
+        id: week
+        run: echo "stamp=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
       - name: restore datacache
         uses: actions/cache@v5
         with:
           path: ~/.cache/whatsnowplaying/testsuite/datacache
-          key: datacache-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('nowplaying/datacache/**') }}
+          key: datacache-${{ runner.os }}-${{ matrix.python }}-${{ steps.week.outputs.stamp }}-${{ github.run_id }}
           restore-keys: |
+            datacache-${{ runner.os }}-${{ matrix.python }}-${{ steps.week.outputs.stamp }}-
             datacache-${{ runner.os }}-${{ matrix.python }}-
             datacache-${{ runner.os }}-
       - name: tests

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,7 +16,7 @@ env:
   DISCOGS_API_KEY: ${{ secrets.DISCOGS_API_KEY }}  # pragma: allowlist secret
   FANARTTV_API_KEY: ${{ secrets.FANARTTV_API_KEY }}  # pragma: allowlist secret
   THEAUDIODB_API_KEY: ${{ secrets.THEAUDIODB_API_KEY }}
-  LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}  # pragma: allowlist secret  # pragma: allowlist secret
+  LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}  # pragma: allowlist secret
   # needed for upgrade test
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}    # pragma: allowlist secret
 

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -524,6 +524,15 @@ def reset_client() -> None:
     Forces the next get_client() call to create a fresh DataCacheClient,
     binding its httpx session to the current event loop.  Call this from
     test fixtures after the event loop or database path may have changed.
+
+    Nulls out the httpx session before dropping the instance so that
+    Windows's ProactorEventLoop does not emit ResourceWarning about
+    unclosed transports — the connections are abandoned rather than
+    cleanly closed, which is acceptable in test fixtures that run
+    synchronously.
     """
     global _client_instance  # pylint: disable=global-statement
+    if _client_instance is not None:
+        _client_instance._session = None  # pylint: disable=protected-access
+        _client_instance._initialized = False  # pylint: disable=protected-access
     _client_instance = None


### PR DESCRIPTION
- Cache datacache SQLite between CI runs using actions/cache with a weekly rotating key (YYYY-WW + run_id) so data accumulates within the week and refreshes every Monday; restore-keys fall back to the most recent same-week then any prior entry for a warm start
- Add LASTFM_API_KEY to CI workflow env so live lastfm tests run
- reset_client() nulls _session and _initialized before dropping the instance to suppress ResourceWarning on Windows ProactorEventLoop

## Summary by Sourcery

Introduce weekly-rotating datacache reuse in CI workflows and harden the datacache client reset behavior for tests.

Bug Fixes:
- Ensure reset_client() clears the datacache client's HTTP session state before dropping the instance to avoid ResourceWarning on Windows event loops.

Enhancements:
- Improve datacache client reset semantics so subsequent uses start from a clean, uninitialized state in tests.

CI:
- Add a weekly-based cache key for the datacache in CI to allow reuse of cached data within a week while periodically refreshing it.
- Expose LASTFM_API_KEY in the CI workflow environment so live Last.fm tests can run.