### PR TITLE
datacache: FetchRequest dataclass + checksum + on_complete callback

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -63,10 +63,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/whatsnowplaying/testsuite/datacache
-          key: datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-${{ github.run_id }}
-          restore-keys: |
-            datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-
-            datacache-${{ runner.os }}-
+          key: datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-${{ hashFiles('nowplaying/datacache/**') }}
       - name: tests
         shell: bash
         run: |
@@ -140,10 +137,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~\AppData\Local\whatsnowplaying\testsuite\datacache
-          key: datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-${{ github.run_id }}
-          restore-keys: |
-            datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-
-            datacache-${{ runner.os }}-
+          key: datacache-${{ runner.os }}-${{ steps.week.outputs.stamp }}-${{ hashFiles('nowplaying/datacache/**') }}
       - name: tests
         shell: bash
         run: |
@@ -245,11 +239,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/whatsnowplaying/testsuite/datacache
-          key: datacache-${{ runner.os }}-${{ matrix.python }}-${{ steps.week.outputs.stamp }}-${{ github.run_id }}
-          restore-keys: |
-            datacache-${{ runner.os }}-${{ matrix.python }}-${{ steps.week.outputs.stamp }}-
-            datacache-${{ runner.os }}-${{ matrix.python }}-
-            datacache-${{ runner.os }}-
+          key: datacache-${{ runner.os }}-${{ matrix.python }}-${{ steps.week.outputs.stamp }}-${{ hashFiles('nowplaying/datacache/**') }}
       - name: tests
         shell: bash
         run: |

--- a/nowplaying/artistextras/__init__.py
+++ b/nowplaying/artistextras/__init__.py
@@ -81,14 +81,16 @@ class ArtistExtrasPlugin(WNPBasePlugin):
         bulk_priority = _IMAGE_PRIORITY["artistfanart"]
         for i, url in enumerate(urls):
             await client.get_or_fetch(
-                url=url,
-                identifier=normalidentifier,
-                data_type=imagetype,
-                provider="cdn",  # CDN downloads are not rate-limited like API calls
-                immediate=False,
-                ttl_seconds=_IMAGE_TTL,
-                negative_ttl=3600,  # 1h: don't retry permanently-dead image URLs
-                queue_priority=first_priority if i == 0 else bulk_priority,
+                nowplaying.datacache.FetchRequest(
+                    url=url,
+                    identifier=normalidentifier,
+                    data_type=imagetype,
+                    provider="cdn",
+                    immediate=False,
+                    ttl_seconds=_IMAGE_TTL,
+                    negative_ttl=3600,
+                    queue_priority=first_priority if i == 0 else bulk_priority,
+                )
             )
 
     async def queue_front_cover(
@@ -106,13 +108,15 @@ class ArtistExtrasPlugin(WNPBasePlugin):
         identifier = f"{norm_artist}_{norm_album}"
         client = self._get_datacache_client()
         await client.get_or_fetch(
-            url=cover_url,
-            identifier=identifier,
-            data_type="front_cover",
-            provider="cdn",  # CDN downloads are not rate-limited like API calls
-            immediate=False,
-            queue_priority=_IMAGE_PRIORITY["front_cover"],
-            ttl_seconds=_IMAGE_TTL,
+            nowplaying.datacache.FetchRequest(
+                url=cover_url,
+                identifier=identifier,
+                data_type="front_cover",
+                provider="cdn",
+                immediate=False,
+                queue_priority=_IMAGE_PRIORITY["front_cover"],
+                ttl_seconds=_IMAGE_TTL,
+            )
         )
 
     def calculate_delay(self) -> float:

--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -36,15 +36,17 @@ class Plugin(ArtistExtrasPlugin):
         for artistid in metadata["musicbrainzartistid"]:
             url = f"http://webservice.fanart.tv/v3/music/{artistid}"
             result = await datacache_client.get_or_fetch(
-                url=url,
-                identifier=metadata.get("imagecacheartist", artistid),
-                data_type="artist",
-                provider="fanarttv",
-                timeout=self.calculate_delay(),
-                retries=3,
-                ttl_seconds=_FANARTTV_TTL,
-                headers=nowplaying.datacache.CacheHeaders({"client-key": apikey}),
-                negative_ttl=24 * 3600,  # 24h: artist not in FanartTV DB
+                nowplaying.datacache.FetchRequest(
+                    url=url,
+                    identifier=metadata.get("imagecacheartist", artistid),
+                    data_type="artist",
+                    provider="fanarttv",
+                    timeout=self.calculate_delay(),
+                    retries=3,
+                    ttl_seconds=_FANARTTV_TTL,
+                    headers=nowplaying.datacache.CacheHeaders({"client-key": apikey}),
+                    negative_ttl=24 * 3600,
+                )
             )
             if result is None:
                 continue

--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -46,14 +46,16 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
         url = f"{_THEAUDIODB_BASE}/{apikey}/{api}"
         logging.debug("Fetching async %s", api)
         result = await nowplaying.datacache.get_client().get_or_fetch(
-            url=url,
-            identifier=artist_name,
-            data_type="api_response",
-            provider="theaudiodb",
-            timeout=self.calculate_delay(),
-            retries=3,
-            ttl_seconds=_THEAUDIODB_TTL,
-            negative_ttl=24 * 3600,  # 24h: artist/album not in TheAudioDB
+            nowplaying.datacache.FetchRequest(
+                url=url,
+                identifier=artist_name,
+                data_type="api_response",
+                provider="theaudiodb",
+                timeout=self.calculate_delay(),
+                retries=3,
+                ttl_seconds=_THEAUDIODB_TTL,
+                negative_ttl=24 * 3600,
+            )
         )
         if result is None:
             return None

--- a/nowplaying/datacache/__init__.py
+++ b/nowplaying/datacache/__init__.py
@@ -13,7 +13,7 @@ from httpx import Headers as CacheHeaders  # re-exported so callers don't import
 import orjson
 
 # Core components
-from .client import DataCacheClient, get_client, reset_client
+from .client import DataCacheClient, FetchRequest, get_client, reset_client
 from .utils import redact_url
 from .pending import RequestQueue
 from .queue import RateLimiter, RateLimiterManager
@@ -23,6 +23,7 @@ from .storage import CachedEntry, DataStorage, get_datacache_path, run_datacache
 __all__ = [
     "get_client",  # Get DataCacheClient instance
     "DataCacheClient",  # Core client with get_or_fetch
+    "FetchRequest",  # Dataclass for get_or_fetch parameters
     "CachedEntry",  # Result dataclass from retrieve methods
     "DataStorage",  # Direct storage layer access
     "RequestQueue",  # Database-backed pending request queue

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -6,15 +6,19 @@ without dealing with low-level storage details.
 """
 
 import asyncio
+import dataclasses
+import hashlib
 import logging
 import random
 import time
+from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
 
 import ssl
 
 import httpx
+import orjson
 import truststore
 from httpx import Headers as CacheHeaders
 
@@ -35,6 +39,24 @@ _PROVIDER_TTL_DEFAULTS: dict[str, int] = {
 }
 _IMAGE_DATA_TYPES = IMAGE_DATA_TYPES  # re-exported from storage for TTL doubling logic
 _DEFAULT_TTL = 7 * 24 * 3600
+
+
+@dataclasses.dataclass
+class FetchRequest:
+    url: str
+    identifier: str
+    data_type: str
+    provider: str
+    timeout: float = 30.0
+    retries: int = 3
+    ttl_seconds: int | None = None
+    immediate: bool = True
+    metadata: dict | None = None
+    headers: CacheHeaders | None = None
+    negative_ttl: int | None = None
+    queue_priority: int = 2
+    expected_checksum: str | None = None
+    on_complete: Callable[[str, "CachedEntry | None"], Coroutine[Any, Any, None]] | None = None
 
 
 def _backoff(attempt: int) -> float:
@@ -61,6 +83,7 @@ class DataCacheClient:
         self._session: httpx.AsyncClient | None = None
         self._init_lock = asyncio.Lock()
         self._retry_after_until: dict[str, float] = {}
+        self._callbacks: dict[str, Callable] = {}
 
     async def initialize(self) -> None:
         """Initialize the client and underlying storage (concurrency-safe)."""
@@ -93,82 +116,72 @@ class DataCacheClient:
             self._session = None
         await self.storage.close()
 
-    async def get_or_fetch(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        self,
-        url: str,
-        identifier: str,
-        data_type: str,
-        provider: str,
-        timeout: float = 30.0,
-        retries: int = 3,
-        ttl_seconds: int | None = None,
-        immediate: bool = True,
-        metadata: dict | None = None,
-        headers: CacheHeaders | None = None,
-        negative_ttl: int | None = None,
-        queue_priority: int = 2,
-    ) -> CachedEntry | None:
+    async def get_or_fetch(self, request: FetchRequest) -> CachedEntry | None:
         """
         Get data from cache, or fetch from URL if not cached.
-
-        Args:
-            url: The URL to fetch data from
-            identifier: Artist identifier (e.g., "daft_punk")
-            data_type: Type of data ("thumbnail", "logo", "bio", etc.)
-            provider: Provider name ("theaudiodb", "discogs", etc.)
-            timeout: Request timeout in seconds
-            retries: Number of retry attempts
-            ttl_seconds: Cache TTL in seconds (None for provider default)
-            immediate: If True, fetch immediately; if False, queue for later
-            metadata: Optional metadata to store with cached item
 
         Returns:
             CachedEntry if found/fetched, None if failed or queued
         """
         await self.initialize()
 
-        # Try to retrieve from cache first
-        cached_result = await self.storage.retrieve_by_url(url)
+        cached_result = await self.storage.retrieve_by_url(request.url)
         if cached_result:
             if cached_result.status_code != 200:
                 logging.debug(
-                    "Cache hit (negative, status=%d) for URL: %s", cached_result.status_code, url
+                    "Cache hit (negative, status=%d) for URL: %s",
+                    cached_result.status_code,
+                    request.url,
                 )
                 return None
-            logging.debug("Cache hit for URL: %s", self._redact_url(url))
-            return cached_result
-
-        if not immediate:
-            # Queue for background processing
-            await self.queue.queue_request(
-                provider=provider,
-                request_key="fetch_url",
-                params={
-                    "url": url,
-                    "identifier": identifier,
-                    "data_type": data_type,
-                    "timeout": timeout,
-                    "retries": retries,
-                    "ttl_seconds": ttl_seconds,
-                    "metadata": metadata,
-                },
-                priority=queue_priority,
+            if (
+                request.expected_checksum is None
+                or cached_result.checksum == request.expected_checksum
+            ):
+                logging.debug("Cache hit for URL: %s", self._redact_url(request.url))
+                if request.on_complete:
+                    asyncio.create_task(request.on_complete(request.url, cached_result))
+                return cached_result
+            logging.debug(
+                "Cache hit checksum mismatch for URL: %s, re-fetching",
+                self._redact_url(request.url),
             )
-            logging.debug("Queued background fetch for URL: %s", self._redact_url(url))
+
+        if not request.immediate:
+            params = {
+                "url": request.url,
+                "identifier": request.identifier,
+                "data_type": request.data_type,
+                "timeout": request.timeout,
+                "retries": request.retries,
+                "ttl_seconds": request.ttl_seconds,
+                "metadata": request.metadata,
+                "expected_checksum": request.expected_checksum,
+            }
+            params_str = orjson.dumps(params, option=orjson.OPT_SORT_KEYS).decode()
+            request_id = f"{request.provider}:fetch_url:{hashlib.sha256(params_str.encode()).hexdigest()[:16]}"
+            if request.on_complete:
+                self._callbacks[request_id] = request.on_complete
+            await self.queue.queue_request(
+                provider=request.provider,
+                request_key="fetch_url",
+                params=params,
+                priority=request.queue_priority,
+            )
+            logging.debug("Queued background fetch for URL: %s", self._redact_url(request.url))
             return None
 
-        # Immediate fetch
         return await self._fetch_and_store(
-            url=url,
-            identifier=identifier,
-            data_type=data_type,
-            provider=provider,
-            timeout=timeout,
-            retries=retries,
-            ttl_seconds=ttl_seconds,
-            metadata=metadata,
-            headers=headers,
-            negative_ttl=negative_ttl,
+            url=request.url,
+            identifier=request.identifier,
+            data_type=request.data_type,
+            provider=request.provider,
+            timeout=request.timeout,
+            retries=request.retries,
+            ttl_seconds=request.ttl_seconds,
+            metadata=request.metadata,
+            headers=request.headers,
+            negative_ttl=request.negative_ttl,
         )
 
     async def _cache_negative(  # pylint: disable=too-many-arguments
@@ -225,7 +238,101 @@ class DataCacheClient:
         """
         self._retry_after_until.pop(provider, None)
 
-    async def _fetch_and_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches,too-many-statements
+    async def _stream_body(self, response: httpx.Response) -> tuple[bytes, str]:
+        """Stream response body, returning (data, sha256_hex)."""
+        h = hashlib.sha256()
+        chunks: list[bytes] = []
+        async for chunk in response.aiter_bytes(65536):
+            h.update(chunk)
+            chunks.append(chunk)
+        return b"".join(chunks), h.hexdigest()
+
+    async def _handle_429(
+        self,
+        response: httpx.Response,
+        provider: str,
+        attempt: int,
+        retries: int,
+        rate_limiter: Any,
+    ) -> bool:
+        """Record 429 cooldown and sleep if retries remain. Returns True to continue, False to break."""
+        try:
+            retry_after = max(1, int(response.headers.get("Retry-After", "60")))
+        except ValueError:
+            retry_after = 60
+        self._retry_after_until[provider] = time.monotonic() + retry_after
+        if attempt < retries:
+            logging.warning("Rate limited by %s, waiting %d seconds", provider, retry_after)
+            await asyncio.sleep(retry_after)
+            return await rate_limiter.acquire()
+        logging.warning("Rate limited by %s on final attempt, cooldown %ds", provider, retry_after)
+        return False
+
+    async def _fetch_with_retry(
+        self,
+        url: str,
+        provider: str,
+        timeout: float,
+        retries: int,
+        headers: CacheHeaders | None,
+        rate_limiter: Any,
+    ) -> tuple[bytes, str] | int | None:
+        """Stream-fetch url with retries.
+
+        Returns:
+            (data, checksum) on 200 success
+            int status code on terminal HTTP error (e.g. 404) after all retries
+            None on network/timeout failure
+        """
+        last_status: int | None = None
+        for attempt in range(retries + 1):
+            try:
+                async with self._session.stream(  # type: ignore[union-attr]
+                    "GET", url, timeout=httpx.Timeout(timeout), headers=headers
+                ) as response:
+                    if response.status_code == 200:
+                        return await self._stream_body(response)
+                    if response.status_code == 429:
+                        should_continue = await self._handle_429(
+                            response, provider, attempt, retries, rate_limiter
+                        )
+                        if should_continue:
+                            continue
+                        return None
+                    last_status = response.status_code
+                    logging.warning(
+                        "HTTP %d fetching %s", response.status_code, self._redact_url(url)
+                    )
+                    if attempt < retries:
+                        await asyncio.sleep(_backoff(attempt))
+                        continue
+                    return last_status
+            except httpx.TimeoutException:
+                logging.warning(
+                    "Timeout fetching URL (attempt %d/%d): %s",
+                    attempt + 1,
+                    retries + 1,
+                    self._redact_url(url),
+                )
+                if attempt < retries:
+                    await asyncio.sleep(_backoff(attempt))
+                    continue
+                return None
+            except Exception as error:  # pylint: disable=broad-except
+                logging.error(
+                    "Error fetching URL (attempt %d/%d): %s - %s",
+                    attempt + 1,
+                    retries + 1,
+                    self._redact_url(url),
+                    error,
+                )
+                if attempt < retries:
+                    await asyncio.sleep(_backoff(attempt))
+                    continue
+                return None
+        return last_status
+
+    async def _fetch_and_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         url: str,
         identifier: str,
@@ -238,19 +345,12 @@ class DataCacheClient:
         headers: CacheHeaders | None = None,
         negative_ttl: int | None = None,
     ) -> CachedEntry | None:
-        """
-        Fetch data from URL and store in cache.
-
-        Handles rate limiting and retries automatically.
-        """
         if not self._session:
             raise RuntimeError("DataCacheClient not initialized - call initialize() first")
 
-        # Honour server-side 429 cooldown recorded from a previous call
         if self.in_cooldown(provider):
             return None
 
-        # Apply rate limiting
         rate_limiter = self.rate_limiters.get_limiter(provider)
         if not await rate_limiter.acquire():
             logging.warning(
@@ -258,107 +358,43 @@ class DataCacheClient:
             )
             return None
 
-        # Default TTL based on provider and data type
         if ttl_seconds is None:
             ttl_seconds = self._get_default_ttl(provider, data_type)
 
-        # Fetch with retries
-        for attempt in range(retries + 1):
-            try:
-                # self._session is guaranteed non-None after the check above
-                response = await self._session.get(
-                    url, timeout=httpx.Timeout(timeout), headers=headers
+        result = await self._fetch_with_retry(
+            url, provider, timeout, retries, headers, rate_limiter
+        )
+        if not isinstance(result, tuple):
+            if result == 404 and negative_ttl is not None:
+                await self._cache_negative(
+                    url, identifier, data_type, provider, negative_ttl, metadata
                 )
-                if response.status_code == 200:
-                    data = response.content  # callers decode (e.g. orjson.loads) as needed
+            return None
 
-                    # Store in cache
-                    success = await self.storage.store(
-                        url=url,
-                        identifier=identifier,
-                        data_type=data_type,
-                        provider=provider,
-                        data_value=data,
-                        ttl_seconds=ttl_seconds,
-                        metadata=metadata,
-                        status_code=200,
-                    )
-
-                    if success:
-                        logging.debug("Cached data from URL: %s", self._redact_url(url))
-                    else:
-                        logging.warning("Failed to cache data from URL: %s", self._redact_url(url))
-                    return CachedEntry(
-                        data=data,
-                        metadata=metadata or {},
-                        status_code=200,
-                        mime_type=None,
-                        url=url,
-                    )
-                if response.status_code == 429:
-                    try:
-                        retry_after = max(1, int(response.headers.get("Retry-After", "60")))
-                    except ValueError:
-                        retry_after = 60
-                    # Record cooldown so the next get_or_fetch call skips immediately
-                    self._retry_after_until[provider] = time.monotonic() + retry_after
-                    if attempt < retries:
-                        logging.warning(
-                            "Rate limited by %s, waiting %d seconds", provider, retry_after
-                        )
-                        await asyncio.sleep(retry_after)
-                        # Re-acquire token after sleeping so local limiter stays in
-                        # sync with the server's actual rate-limit window.
-                        if not await rate_limiter.acquire():
-                            return None
-                        continue
-                    logging.warning(
-                        "Rate limited by %s on final attempt, cooldown %ds", provider, retry_after
-                    )
-                    break
-
-                if response.status_code == 404 and negative_ttl is not None:
-                    await self._cache_negative(
-                        url, identifier, data_type, provider, negative_ttl, metadata
-                    )
-                    return None
-                logging.warning(
-                    "HTTP %d error fetching %s", response.status_code, self._redact_url(url)
-                )
-                if attempt < retries:
-                    wait_time = _backoff(attempt)
-                    await asyncio.sleep(wait_time)
-                    continue
-                break
-
-            except httpx.TimeoutException:
-                logging.warning(
-                    "Timeout fetching URL (attempt %d/%d): %s",
-                    attempt + 1,
-                    retries + 1,
-                    self._redact_url(url),
-                )
-                if attempt < retries:
-                    wait_time = _backoff(attempt)
-                    await asyncio.sleep(wait_time)
-                    continue
-                break
-
-            except Exception as error:  # pylint: disable=broad-except
-                logging.error(
-                    "Error fetching URL (attempt %d/%d): %s - %s",
-                    attempt + 1,
-                    retries + 1,
-                    self._redact_url(url),
-                    error,
-                )
-                if attempt < retries:
-                    wait_time = _backoff(attempt)
-                    await asyncio.sleep(wait_time)
-                    continue
-                break
-
-        return None
+        data, content_checksum = result
+        success = await self.storage.store(
+            url=url,
+            identifier=identifier,
+            data_type=data_type,
+            provider=provider,
+            data_value=data,
+            ttl_seconds=ttl_seconds,
+            metadata=metadata,
+            status_code=200,
+            checksum=content_checksum,
+        )
+        if success:
+            logging.debug("Cached data from URL: %s", self._redact_url(url))
+        else:
+            logging.warning("Failed to cache data from URL: %s", self._redact_url(url))
+        return CachedEntry(
+            data=data,
+            metadata=metadata or {},
+            status_code=200,
+            mime_type=None,
+            url=url,
+            checksum=content_checksum,
+        )
 
     @staticmethod
     def _get_default_ttl(provider: str, data_type: str) -> int:
@@ -471,6 +507,13 @@ class DataCacheClient:
                     success = False
 
                 await self.queue.complete_request(request_id, success=success)
+
+                if request_id in self._callbacks:
+                    cb = self._callbacks.pop(request_id)
+                    url = request["params"]["url"]
+                    entry = await self.storage.retrieve_by_url(url) if success else None
+                    asyncio.create_task(cb(url, entry))
+
                 return success
 
             except Exception as error:  # pylint: disable=broad-except

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -42,7 +42,9 @@ _DEFAULT_TTL = 7 * 24 * 3600
 
 
 @dataclasses.dataclass
-class FetchRequest:
+class FetchRequest:  # pylint: disable=too-many-instance-attributes
+    """Parameters for a single get_or_fetch call."""
+
     url: str
     identifier: str
     data_type: str
@@ -59,12 +61,30 @@ class FetchRequest:
     on_complete: Callable[[str, "CachedEntry | None"], Coroutine[Any, Any, None]] | None = None
 
 
+_TERMINAL_HTTP_STATUSES: frozenset[int] = frozenset(range(400, 500)) - {429}
+
+
+@dataclasses.dataclass
+class FetchResult:
+    """Result of a single _fetch_with_retry call."""
+
+    data: bytes | None = None
+    checksum: str | None = None
+    status: int | None = None
+    terminal: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """True only on a successful 200 response with data."""
+        return self.status == 200 and self.data is not None
+
+
 def _backoff(attempt: int) -> float:
     """Exponential backoff with random jitter."""
     return (2**attempt) + random.uniform(0, 1.0)
 
 
-class DataCacheClient:
+class DataCacheClient:  # pylint: disable=too-many-instance-attributes
     """
     High-level client for datacache operations.
 
@@ -159,7 +179,8 @@ class DataCacheClient:
                 "expected_checksum": request.expected_checksum,
             }
             params_str = orjson.dumps(params, option=orjson.OPT_SORT_KEYS).decode()
-            request_id = f"{request.provider}:fetch_url:{hashlib.sha256(params_str.encode()).hexdigest()[:16]}"
+            digest = hashlib.sha256(params_str.encode()).hexdigest()[:16]
+            request_id = f"{request.provider}:fetch_url:{digest}"
             if request.on_complete:
                 self._callbacks[request_id] = request.on_complete
             await self.queue.queue_request(
@@ -238,7 +259,8 @@ class DataCacheClient:
         """
         self._retry_after_until.pop(provider, None)
 
-    async def _stream_body(self, response: httpx.Response) -> tuple[bytes, str]:
+    @staticmethod
+    async def _stream_body(response: httpx.Response) -> tuple[bytes, str]:
         """Stream response body, returning (data, sha256_hex)."""
         h = hashlib.sha256()
         chunks: list[bytes] = []
@@ -247,7 +269,7 @@ class DataCacheClient:
             chunks.append(chunk)
         return b"".join(chunks), h.hexdigest()
 
-    async def _handle_429(
+    async def _handle_429(  # pylint: disable=too-many-arguments
         self,
         response: httpx.Response,
         provider: str,
@@ -255,7 +277,10 @@ class DataCacheClient:
         retries: int,
         rate_limiter: Any,
     ) -> bool:
-        """Record 429 cooldown and sleep if retries remain. Returns True to continue, False to break."""
+        """Record 429 cooldown and sleep if retries remain.
+
+        Returns True to retry, False to give up.
+        """
         try:
             retry_after = max(1, int(response.headers.get("Retry-After", "60")))
         except ValueError:
@@ -268,7 +293,7 @@ class DataCacheClient:
         logging.warning("Rate limited by %s on final attempt, cooldown %ds", provider, retry_after)
         return False
 
-    async def _fetch_with_retry(
+    async def _fetch_with_retry(  # pylint: disable=too-many-arguments
         self,
         url: str,
         provider: str,
@@ -276,37 +301,40 @@ class DataCacheClient:
         retries: int,
         headers: CacheHeaders | None,
         rate_limiter: Any,
-    ) -> tuple[bytes, str] | int | None:
+    ) -> FetchResult:
         """Stream-fetch url with retries.
 
-        Returns:
-            (data, checksum) on 200 success
-            int status code on terminal HTTP error (e.g. 404) after all retries
-            None on network/timeout failure
+        4xx responses (except 429) are terminal — returned immediately without
+        consuming retry budget.  5xx and network errors are retried with
+        exponential backoff.
         """
-        last_status: int | None = None
+        last_result = FetchResult()
         for attempt in range(retries + 1):
             try:
                 async with self._session.stream(  # type: ignore[union-attr]
                     "GET", url, timeout=httpx.Timeout(timeout), headers=headers
                 ) as response:
                     if response.status_code == 200:
-                        return await self._stream_body(response)
+                        data, checksum = await self._stream_body(response)
+                        return FetchResult(data=data, checksum=checksum, status=200)
                     if response.status_code == 429:
                         should_continue = await self._handle_429(
                             response, provider, attempt, retries, rate_limiter
                         )
                         if should_continue:
                             continue
-                        return None
-                    last_status = response.status_code
+                        return FetchResult(status=429, terminal=False)
+                    if response.status_code in _TERMINAL_HTTP_STATUSES:
+                        logging.warning(
+                            "HTTP %d fetching %s (terminal)",
+                            response.status_code,
+                            self._redact_url(url),
+                        )
+                        return FetchResult(status=response.status_code, terminal=True)
                     logging.warning(
                         "HTTP %d fetching %s", response.status_code, self._redact_url(url)
                     )
-                    if attempt < retries:
-                        await asyncio.sleep(_backoff(attempt))
-                        continue
-                    return last_status
+                    last_result = FetchResult(status=response.status_code, terminal=False)
             except httpx.TimeoutException:
                 logging.warning(
                     "Timeout fetching URL (attempt %d/%d): %s",
@@ -314,10 +342,6 @@ class DataCacheClient:
                     retries + 1,
                     self._redact_url(url),
                 )
-                if attempt < retries:
-                    await asyncio.sleep(_backoff(attempt))
-                    continue
-                return None
             except Exception as error:  # pylint: disable=broad-except
                 logging.error(
                     "Error fetching URL (attempt %d/%d): %s - %s",
@@ -326,13 +350,11 @@ class DataCacheClient:
                     self._redact_url(url),
                     error,
                 )
-                if attempt < retries:
-                    await asyncio.sleep(_backoff(attempt))
-                    continue
-                return None
-        return last_status
+            if attempt < retries:
+                await asyncio.sleep(_backoff(attempt))
+        return last_result
 
-    async def _fetch_and_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    async def _fetch_and_store(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         url: str,
         identifier: str,
@@ -364,14 +386,14 @@ class DataCacheClient:
         result = await self._fetch_with_retry(
             url, provider, timeout, retries, headers, rate_limiter
         )
-        if not isinstance(result, tuple):
-            if result == 404 and negative_ttl is not None:
+        if not result.ok:
+            if result.terminal and result.status == 404 and negative_ttl is not None:
                 await self._cache_negative(
                     url, identifier, data_type, provider, negative_ttl, metadata
                 )
             return None
 
-        data, content_checksum = result
+        data, content_checksum = result.data, result.checksum  # type: ignore[assignment]
         success = await self.storage.store(
             url=url,
             identifier=identifier,

--- a/nowplaying/datacache/storage.py
+++ b/nowplaying/datacache/storage.py
@@ -31,6 +31,7 @@ class CachedEntry:
     status_code: int
     mime_type: str | None
     url: str | None = None  # populated by retrieve_by_cachekey and retrieve_by_identifier
+    checksum: str | None = None  # SHA-256 hex digest of data, set on store
 
 
 # Module-level lock for schema operations
@@ -98,6 +99,7 @@ class DataStorage:
         ttl_seconds: int,
         metadata: dict | None = None,
         status_code: int = 200,
+        checksum: str | None = None,
     ) -> bool:
         """Store bytes in the cache. Callers are responsible for encoding (e.g. orjson.dumps)."""
         await self.initialize()
@@ -111,6 +113,9 @@ class DataStorage:
             metadata_json = orjson.dumps(metadata).decode() if metadata else None
             new_cachekey = str(uuid.uuid4())
             data_size = len(data_value)
+            content_checksum = (
+                checksum if checksum is not None else hashlib.sha256(data_value).hexdigest()
+            )
 
             try:
                 mime_type: str | None = puremagic.from_string(data_value, mime=True)
@@ -137,8 +142,8 @@ class DataStorage:
                         (url, cachekey, identifier, data_type, provider,
                          data_value, file_path, metadata,
                          created_at, expires_at, last_accessed, data_size,
-                         status_code, mime_type)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         status_code, mime_type, content_checksum)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         ON CONFLICT(url) DO UPDATE SET
                           identifier = excluded.identifier,
                           data_type = excluded.data_type,
@@ -150,7 +155,8 @@ class DataStorage:
                           last_accessed = excluded.last_accessed,
                           data_size = excluded.data_size,
                           status_code = excluded.status_code,
-                          mime_type = excluded.mime_type
+                          mime_type = excluded.mime_type,
+                          content_checksum = excluded.content_checksum
                         """,
                         (
                             url,
@@ -167,6 +173,7 @@ class DataStorage:
                             data_size,
                             status_code,
                             mime_type,
+                            content_checksum,
                         ),
                     )
                     await connection.commit()
@@ -202,7 +209,8 @@ class DataStorage:
                 async with aiosqlite.connect(str(self.database_path), timeout=30.0) as connection:
                     cursor = await connection.execute(
                         """
-                        SELECT data_value, file_path, metadata, status_code, mime_type
+                        SELECT data_value, file_path, metadata, status_code,
+                               mime_type, content_checksum
                         FROM cached_data
                         WHERE url = ? AND expires_at > ?
                         """,
@@ -231,7 +239,9 @@ class DataStorage:
             if result is None:
                 return None
 
-            data_value, file_path_str, metadata_json, status_code, mime_type = result  # pylint: disable=unpacking-non-sequence
+            data_value, file_path_str, metadata_json, status_code, mime_type, content_checksum = (
+                result  # pylint: disable=unpacking-non-sequence
+            )
 
             if file_path_str:
                 full_path = self.database_path.parent / file_path_str
@@ -259,7 +269,11 @@ class DataStorage:
 
             metadata = orjson.loads(metadata_json) if metadata_json else {}
             return CachedEntry(
-                data=data, metadata=metadata, status_code=status_code, mime_type=mime_type
+                data=data,
+                metadata=metadata,
+                status_code=status_code,
+                mime_type=mime_type,
+                checksum=content_checksum,
             )
 
         except Exception as error:  # pylint: disable=broad-exception-caught
@@ -909,7 +923,8 @@ def _ensure_datacache_schema(database_path: Path) -> None:
                 last_accessed REAL NOT NULL,
                 data_size INTEGER NOT NULL,
                 status_code INTEGER NOT NULL DEFAULT 200,
-                mime_type TEXT              -- MIME type detected by puremagic, NULL for non-binary
+                mime_type TEXT,             -- MIME type detected by puremagic, NULL for non-binary
+                content_checksum TEXT       -- SHA-256 hex digest of stored content
             );
 
             CREATE TABLE IF NOT EXISTS pending_requests (

--- a/nowplaying/datacache/storage.py
+++ b/nowplaying/datacache/storage.py
@@ -202,10 +202,9 @@ class DataStorage:
 
         try:
             now = time.time()
-            result: Any = None
+            rows: list[tuple] = []
 
             async def _do_retrieve() -> None:
-                nonlocal result
                 async with aiosqlite.connect(str(self.database_path), timeout=30.0) as connection:
                     cursor = await connection.execute(
                         """
@@ -220,7 +219,7 @@ class DataStorage:
                     if not row:
                         return
 
-                    result = tuple(row)
+                    rows.append(tuple(row))
 
                     # Lazy access_count update: only write if not updated in last 5 min.
                     # Reduces WAL pressure when OBS polls every few seconds.
@@ -236,11 +235,11 @@ class DataStorage:
 
             await nowplaying.utils.sqlite.retry_sqlite_operation_async(_do_retrieve)
 
-            if result is None:
+            if not rows:
                 return None
 
             data_value, file_path_str, metadata_json, status_code, mime_type, content_checksum = (
-                result  # pylint: disable=unpacking-non-sequence
+                rows[0]
             )
 
             if file_path_str:
@@ -298,10 +297,9 @@ class DataStorage:
 
         try:
             now = time.time()
-            result: Any = None
+            rows: list[tuple] = []
 
-            async def _do_retrieve() -> None:
-                nonlocal result
+            async def _do_retrieve_by_key() -> None:
                 async with aiosqlite.connect(str(self.database_path), timeout=30.0) as connection:
                     cursor = await connection.execute(
                         """
@@ -315,7 +313,7 @@ class DataStorage:
                     if not row:
                         return
 
-                    result = tuple(row)
+                    rows.append(tuple(row))
 
                     await connection.execute(
                         """
@@ -327,12 +325,12 @@ class DataStorage:
                     )
                     await connection.commit()
 
-            await nowplaying.utils.sqlite.retry_sqlite_operation_async(_do_retrieve)
+            await nowplaying.utils.sqlite.retry_sqlite_operation_async(_do_retrieve_by_key)
 
-            if result is None:
+            if not rows:
                 return None
 
-            data_value, file_path_str, metadata_json, url, status_code, mime_type = result  # pylint: disable=unpacking-non-sequence
+            data_value, file_path_str, metadata_json, url, status_code, mime_type = rows[0]
 
             if file_path_str:
                 full_path = self.database_path.parent / file_path_str

--- a/tests/datacache/test_client.py
+++ b/tests/datacache/test_client.py
@@ -57,13 +57,14 @@ async def test_get_or_fetch_cache_hit(temp_client):  # pylint: disable=redefined
     )
     assert success is True
 
-    # Should return cached data without HTTP request
     result = await temp_client.get_or_fetch(
-        url=test_url,
-        identifier="test_artist",
-        data_type="thumbnail",
-        provider="test",
-        immediate=True,
+        nowplaying.datacache.FetchRequest(
+            url=test_url,
+            identifier="test_artist",
+            data_type="thumbnail",
+            provider="test",
+            immediate=True,
+        )
     )
 
     assert result is not None
@@ -76,11 +77,13 @@ async def test_get_or_fetch_immediate_false_queues_request(temp_client):  # pyli
     test_url = "https://example.com/queue_test.jpg"
 
     result = await temp_client.get_or_fetch(
-        url=test_url,
-        identifier="queue_artist",
-        data_type="thumbnail",
-        provider="test",
-        immediate=False,  # Should queue
+        nowplaying.datacache.FetchRequest(
+            url=test_url,
+            identifier="queue_artist",
+            data_type="thumbnail",
+            provider="test",
+            immediate=False,
+        )
     )
 
     # Should return None (queued for later)
@@ -155,12 +158,14 @@ async def test_get_cache_keys_for_identifier(temp_client):  # pylint: disable=re
 async def test_get_or_fetch_queues_for_background(temp_client):  # pylint: disable=redefined-outer-name
     """get_or_fetch(immediate=False) queues the URL and returns None"""
     result = await temp_client.get_or_fetch(
-        url="https://example.com/queue.jpg",
-        identifier="queue_artist",
-        data_type="thumbnail",
-        provider="test",
-        immediate=False,
-        queue_priority=1,
+        nowplaying.datacache.FetchRequest(
+            url="https://example.com/queue.jpg",
+            identifier="queue_artist",
+            data_type="thumbnail",
+            provider="test",
+            immediate=False,
+            queue_priority=1,
+        )
     )
 
     assert result is None  # queued for background processing

--- a/tests/datacache/test_client.py
+++ b/tests/datacache/test_client.py
@@ -458,6 +458,35 @@ async def test_4xx_not_stored_in_cache(temp_client):  # pylint: disable=redefine
 
 
 @pytest.mark.asyncio
+async def test_404_is_not_retried(temp_client):  # pylint: disable=redefined-outer-name
+    """404 is terminal — the server is called exactly once even when retries>0"""
+    url = "https://example.com/gone_retry.jpg"
+    call_count = 0
+
+    def _count(request):  # pylint: disable=unused-argument
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(404)
+
+    with respx.mock() as mock_responses:
+        mock_responses.get(url).mock(side_effect=_count)
+
+        result = await temp_client._fetch_and_store(  # pylint: disable=protected-access
+            url=url,
+            identifier="gone_retry_artist",
+            data_type="thumbnail",
+            provider="test",
+            timeout=30.0,
+            retries=3,
+            ttl_seconds=3600,
+            metadata=None,
+        )
+
+    assert result is None
+    assert call_count == 1, "404 must not consume retry budget"
+
+
+@pytest.mark.asyncio
 async def test_5xx_retry_then_success_stores_item(temp_client):  # pylint: disable=redefined-outer-name
     """503 on first attempt then 200 on retry — item ends up in the cache"""
     url = "https://example.com/flaky.jpg"

--- a/tests/datacache/test_integration.py
+++ b/tests/datacache/test_integration.py
@@ -38,14 +38,15 @@ async def test_full_image_caching_workflow(bootstrap, isolated_datacache_client)
             )
         )
 
-        # Cache image immediately
         result = await nowplaying.datacache.get_client().get_or_fetch(
-            url=test_url,
-            identifier="integration_test_artist",
-            data_type="thumbnail",
-            provider="test_provider",
-            immediate=True,
-            metadata={"source": "integration_test"},
+            nowplaying.datacache.FetchRequest(
+                url=test_url,
+                identifier="integration_test_artist",
+                data_type="thumbnail",
+                provider="test_provider",
+                immediate=True,
+                metadata={"source": "integration_test"},
+            )
         )
 
         assert result is not None
@@ -72,14 +73,15 @@ async def test_randomimage_functionality_integration(bootstrap, isolated_datacac
                 )
             )
 
-        # Cache all images
         for url in image_urls:
             await nowplaying.datacache.get_client().get_or_fetch(
-                url=url,
-                identifier="random_test_artist",
-                data_type="thumbnail",
-                provider="test_provider",
-                immediate=True,
+                nowplaying.datacache.FetchRequest(
+                    url=url,
+                    identifier="random_test_artist",
+                    data_type="thumbnail",
+                    provider="test_provider",
+                    immediate=True,
+                )
             )
 
         # Get random image
@@ -117,13 +119,14 @@ async def test_queue_and_process_workflow(bootstrap, isolated_datacache_client):
             )
         )
 
-        # Queue image for background processing
         result = await nowplaying.datacache.get_client().get_or_fetch(
-            url=test_url,
-            identifier="queue_test_artist",
-            data_type="logo",
-            provider="test_provider",
-            immediate=False,  # Queue for later
+            nowplaying.datacache.FetchRequest(
+                url=test_url,
+                identifier="queue_test_artist",
+                data_type="logo",
+                provider="test_provider",
+                immediate=False,
+            )
         )
 
         # Should return None (queued for background processing)
@@ -151,22 +154,25 @@ async def test_cache_hit_avoids_http_request(bootstrap, isolated_datacache_clien
         )
 
         result1 = await nowplaying.datacache.get_client().get_or_fetch(
+            nowplaying.datacache.FetchRequest(
+                url=test_url,
+                identifier="cache_hit_artist",
+                data_type="banner",
+                provider="test_provider",
+                immediate=True,
+            )
+        )
+
+        assert result1 is not None
+
+    result2 = await nowplaying.datacache.get_client().get_or_fetch(
+        nowplaying.datacache.FetchRequest(
             url=test_url,
             identifier="cache_hit_artist",
             data_type="banner",
             provider="test_provider",
             immediate=True,
         )
-
-        assert result1 is not None
-
-    # Second request without mock (should hit cache)
-    result2 = await nowplaying.datacache.get_client().get_or_fetch(
-        url=test_url,
-        identifier="cache_hit_artist",
-        data_type="banner",
-        provider="test_provider",
-        immediate=True,
     )
 
     assert result2 is not None
@@ -194,21 +200,24 @@ async def test_provider_filtering_works(bootstrap, isolated_datacache_client):  
             )
         )
 
-        # Cache images from different providers
         await nowplaying.datacache.get_client().get_or_fetch(
-            url=test_urls["theaudiodb"],
-            identifier="filter_test_artist",
-            data_type="fanart",
-            provider="theaudiodb",
-            immediate=True,
+            nowplaying.datacache.FetchRequest(
+                url=test_urls["theaudiodb"],
+                identifier="filter_test_artist",
+                data_type="fanart",
+                provider="theaudiodb",
+                immediate=True,
+            )
         )
 
         await nowplaying.datacache.get_client().get_or_fetch(
-            url=test_urls["discogs"],
-            identifier="filter_test_artist",
-            data_type="fanart",
-            provider="discogs",
-            immediate=True,
+            nowplaying.datacache.FetchRequest(
+                url=test_urls["discogs"],
+                identifier="filter_test_artist",
+                data_type="fanart",
+                provider="discogs",
+                immediate=True,
+            )
         )
 
         # Get cache keys filtered by provider
@@ -248,12 +257,14 @@ async def test_api_response_caching_integration(bootstrap, isolated_datacache_cl
         )
 
         result = await nowplaying.datacache.get_client().get_or_fetch(
-            url=test_url,
-            identifier="api_test_artist",
-            data_type="bio_en",
-            provider="test_api",
-            immediate=True,
-            metadata={"language": "en", "source": "test_api"},
+            nowplaying.datacache.FetchRequest(
+                url=test_url,
+                identifier="api_test_artist",
+                data_type="bio_en",
+                provider="test_api",
+                immediate=True,
+                metadata={"language": "en", "source": "test_api"},
+            )
         )
 
         assert result is not None
@@ -339,11 +350,13 @@ async def test_concurrent_storage_operations(bootstrap, isolated_datacache_clien
         tasks = []
         for i, url in enumerate(test_urls):
             task = isolated_datacache_client.get_or_fetch(
-                url=url,
-                identifier=f"concurrent_artist_{i}",
-                data_type="thumbnail",
-                provider="test_provider",
-                immediate=True,
+                nowplaying.datacache.FetchRequest(
+                    url=url,
+                    identifier=f"concurrent_artist_{i}",
+                    data_type="thumbnail",
+                    provider="test_provider",
+                    immediate=True,
+                )
             )
             tasks.append(task)
 
@@ -386,13 +399,15 @@ async def test_queue_and_process_random_image_bytes(bootstrap, isolated_datacach
 
         for url in image_urls:
             result = await nowplaying.datacache.get_client().get_or_fetch(
-                url=url,
-                identifier="fanart_artist",
-                data_type="fanart",
-                provider="cdn",
-                immediate=False,
+                nowplaying.datacache.FetchRequest(
+                    url=url,
+                    identifier="fanart_artist",
+                    data_type="fanart",
+                    provider="cdn",
+                    immediate=False,
+                )
             )
-            assert result is None  # queued for background processing
+            assert result is None
 
         stats = await nowplaying.datacache.get_client().process_queue()
         assert stats["processed"] == 3
@@ -432,24 +447,27 @@ async def test_live_immediate_fetch(bootstrap):  # pylint: disable=unused-argume
     url = _LIVE_FANART_URLS[0]
 
     result = await nowplaying.datacache.get_client().get_or_fetch(
-        url=url,
-        identifier="gary_numan",
-        data_type="fanart",
-        provider="theaudiodb",
-        immediate=True,
+        nowplaying.datacache.FetchRequest(
+            url=url,
+            identifier="gary_numan",
+            data_type="fanart",
+            provider="theaudiodb",
+            immediate=True,
+        )
     )
 
     assert result is not None
     assert isinstance(result.data, bytes)
     assert len(result.data) > 0
 
-    # Cache hit — no network call needed
     result2 = await nowplaying.datacache.get_client().get_or_fetch(
-        url=url,
-        identifier="gary_numan",
-        data_type="fanart",
-        provider="theaudiodb",
-        immediate=True,
+        nowplaying.datacache.FetchRequest(
+            url=url,
+            identifier="gary_numan",
+            data_type="fanart",
+            provider="theaudiodb",
+            immediate=True,
+        )
     )
     assert result2 is not None
     assert result2.data == result.data
@@ -462,15 +480,16 @@ async def test_live_queue_and_random_image_bytes(bootstrap):  # pylint: disable=
     # Use the production path (get_or_fetch checks cached_data before queuing)
     for url in _LIVE_FANART_URLS:
         result = await nowplaying.datacache.get_client().get_or_fetch(
-            url=url,
-            identifier="gary_numan",
-            data_type="fanart",
-            provider="cdn",
-            timeout=30.0,
-            retries=3,
-            immediate=False,
+            nowplaying.datacache.FetchRequest(
+                url=url,
+                identifier="gary_numan",
+                data_type="fanart",
+                provider="cdn",
+                timeout=30.0,
+                retries=3,
+                immediate=False,
+            )
         )
-        # Returns None when queued for background processing or already cached
         assert result is None or isinstance(result.data, bytes)
 
     await nowplaying.datacache.get_client().process_queue()


### PR DESCRIPTION
Replace get_or_fetch() positional kwargs with a FetchRequest dataclass. Adds expected_checksum (SHA-256 verification on retrieve) and on_complete async callback for post-fetch notification. Stores content_checksum in the DB schema. Update all callers in artistextras to use FetchRequest.

## Summary by Sourcery

Introduce a FetchRequest dataclass for datacache client requests, add checksum support and completion callbacks, and extend storage to persist and return content checksums.

New Features:
- Add a FetchRequest dataclass as the unified input to DataCacheClient.get_or_fetch, replacing multiple positional parameters.
- Support optional expected_checksum verification on cached entries and an async on_complete callback for both immediate and queued fetches.
- Persist content checksums in the cache storage schema and return them via CachedEntry.

Enhancements:
- Refactor HTTP fetching into reusable streaming and retry helpers with improved rate-limit handling.
- Update artistextras components and tests to use the new FetchRequest-based get_or_fetch API.