### PR TITLE
fix: WebGL/generic-dj cover image MIME type jpeg -> png

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * Fixed template preview window showing a stale template list when
     reopened after new templates were added or removed
+* Wrong image type in the generic DJ display templates
 * Fixed several settings that could silently fall back to Qt's built-in
     defaults instead of WNP's intended defaults when no value had ever
     been explicitly stored (e.g. after a clean install or config reset)

--- a/template-src/components/js/generic-dj-display.js
+++ b/template-src/components/js/generic-dj-display.js
@@ -4,11 +4,11 @@ function updateDisplay(data) {
     // Update cover image with artist thumbnail fallback
     const coverImg = document.getElementById('cover-image');
     if (data.coverimagebase64) {
-        coverImg.src = 'data:image/jpeg;base64,' + data.coverimagebase64;
+        coverImg.src = 'data:image/png;base64,' + data.coverimagebase64;
         coverImg.alt = 'Album cover for ' + (data.album || 'Unknown Album');
     } else if (data.artistthumbnailbase64) {
         // Fallback to artist thumbnail if no cover
-        coverImg.src = 'data:image/jpeg;base64,' + data.artistthumbnailbase64;
+        coverImg.src = 'data:image/png;base64,' + data.artistthumbnailbase64;
         coverImg.alt = 'Artist thumbnail for ' + (data.artist || 'Unknown Artist');
     } else {
         // Keep the default transparent placeholder if neither is available


### PR DESCRIPTION
data:image/jpeg;base64 was hardcoded since the WebGL templates shipped in #1588

## Summary by Sourcery

Bug Fixes:
- Correct the hardcoded MIME type for base64 cover and artist thumbnail images from JPEG to PNG to match the actual image format.