### PR TITLE
docs: add chat token to charts documentation

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -250,6 +250,9 @@ requires no account to start, and is built into WNP with no configuration needed
   * Replay: year-in-review analytics for your streams
 * Community charts showing top tracks and artists across all streamers
 * Online Guess Game leaderboard integration
+* [Chat Token](https://whatsnowplaying.com/docs/chat-token): a read-only token for displaying
+  the currently playing track in Nightbot, StreamElements, Streamlabs Cloudbot, or any chatbot
+  supporting URL fetching
 
 ## Platform Support
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -45,6 +45,9 @@
 >   profile for each DJ showing genre breakdowns, top tracks, setlists, and
 >   a year-in-review Replay. No account needed to start contributing; claim
 >   your key to unlock the full profile. Completely free, no paid tiers.
+> - **Chat Token**: claimed accounts get a read-only chat token for displaying
+>   the currently playing track in Nightbot, StreamElements, Streamlabs Cloudbot,
+>   or any chatbot supporting URL fetching.
 > - **Free and open source**: no subscription, no Pro version, no feature
 >   gating. Everything works out of the box on Windows, macOS, and Linux.
 > - **EarShot always-accept**: When WNP EarShot (Shazam-based identification)
@@ -69,4 +72,4 @@
 - [Artist Data](https://whatsnowplaying.github.io/whats-now-playing/latest/extras/): Discogs, FanArt.TV, TheAudioDB, Last.fm, and Wikimedia enrichment
 - [Recognition](https://whatsnowplaying.github.io/whats-now-playing/latest/recognition/): AcoustID and MusicBrainz track identification
 - [API Reference](https://whatsnowplaying.github.io/whats-now-playing/latest/reference/api/): Web server REST API endpoints
-- [Charts](https://whatsnowplaying.github.io/whats-now-playing/latest/output/charts/): Community charts service at whatsnowplaying.com
+- [Charts](https://whatsnowplaying.github.io/whats-now-playing/latest/output/charts/): Community charts service at whatsnowplaying.com; includes chat token for Nightbot, StreamElements, and Streamlabs

--- a/docs/output/charts.md
+++ b/docs/output/charts.md
@@ -34,6 +34,9 @@ See your profile page on <https://whatsnowplaying.com/signup> for the full view.
 * **[Online Guess Game Board](guessgame.md#online-game-board)**: a public web page at
   `https://whatsnowplaying.com/guessgame/(your-username)` that shows your active guess game,
   masked track/artist, live leaderboards, and game status, shareable with your viewers
+* **[Chat Token](https://whatsnowplaying.com/docs/chat-token)**: a read-only token for displaying
+  your currently playing track in stream chat via Nightbot, StreamElements, Streamlabs Cloudbot,
+  or any chatbot that supports URL fetching
 
 ## Automatic Setup
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add chat token to charts feature list and output documentation as a read-only way to show currently playing tracks in chat bots.