### PR TITLE
feat: add Lumia Stream notification plugin

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -179,6 +179,12 @@ variable and exportable.
 * Optional cover art in announcements
 * Rich Presence support (independently toggleable from Bot Mode)
 
+### [Lumia Stream](output/lumiastream.md)
+
+* Fires a `nowplaying-switchSong` alert in Lumia Stream on every track change
+* Sends title, artist, album, label, BPM, key, duration, ISRC, and cover art URL
+* Enables light shows, overlays, and automations that react to your music in real time
+
 ## Audience Engagement
 
 ### [Guess Game](output/guessgame.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -73,3 +73,4 @@
 - [Recognition](https://whatsnowplaying.github.io/whats-now-playing/latest/recognition/): AcoustID and MusicBrainz track identification
 - [API Reference](https://whatsnowplaying.github.io/whats-now-playing/latest/reference/api/): Web server REST API endpoints
 - [Charts](https://whatsnowplaying.github.io/whats-now-playing/latest/output/charts/): Community charts service at whatsnowplaying.com; includes chat token for Nightbot, StreamElements, and Streamlabs
+- [Lumia Stream](https://whatsnowplaying.github.io/whats-now-playing/latest/output/lumiastream/): Lumia Stream lighting integration; fires nowplaying-switchSong alert with track metadata on every track change

--- a/docs/output/index.md
+++ b/docs/output/index.md
@@ -8,6 +8,7 @@
 - **[Discord](discord.md)** - Discord rich presence integration
 - **[Guess Game](guessgame.md)** - Interactive hangman-style game for Twitch chat
 - **[Kick Bot](kickbot.md)** - Kick streaming platform bot
+- **[Lumia Stream](lumiastream.md)** - Lumia Stream lighting and automation integration
 - **[OBS WebSocket](obswebsocket.md)** - Direct integration with OBS Studio
 - **[Remote Output](../input/remote.md#client-side)** - Send track data to another What's Now Playing instance
 - **[Text Output](textoutput.md)** - Simple text file output

--- a/docs/output/lumiastream.md
+++ b/docs/output/lumiastream.md
@@ -1,0 +1,51 @@
+# Lumia Stream
+
+Lumia Stream integration fires a **nowplaying-switchSong** alert in Lumia Stream each time a new
+track becomes live, enabling light shows, overlays, and automations that react to your music.
+
+## What it provides
+
+When a track changes, What's Now Playing sends the following metadata to Lumia Stream:
+
+* **title** - Track title
+* **artist** - Artist name
+* **album** - Album name
+* **label** - Record label
+* **bpm** - Tempo in BPM
+* **key** - Musical key
+* **comment** - Track comment field
+* **length** - Duration in seconds
+* **id** - ISRC code (if available)
+* **image** - Cover art URL (served from What's Now Playing's built-in web server)
+
+## Setup
+
+1. Open Lumia Stream and go to **Settings → Advanced**.
+2. Enable the **Developers API** and click **Show Token** to reveal your API token.
+3. In What's Now Playing, open **Output & Display → Lumia Stream**.
+4. Check **Enable** and paste your token into the **API Token** field.
+5. Leave **Port** at the default (`39231`) unless you have changed it in Lumia Stream.
+
+## Configuration
+
+* **Enable** - Turn Lumia Stream integration on or off
+* **API Token** - The token from Lumia Stream's Developers API settings (stored securely)
+* **Port** - The port Lumia Stream listens on (default: `39231`)
+
+## How it works
+
+When enabled, the plugin sends an HTTP POST to `http://localhost:{port}/api/send` each time a
+track changes. The payload fires Lumia Stream's built-in `nowplaying-switchSong` alert type, which
+you can map to light commands, overlays, or any other Lumia automation in the Lumia Stream UI.
+
+Cover art is delivered as a URL pointing to What's Now Playing's local web server
+(`http://localhost:{webserver-port}/cover.png`), so Lumia Stream can fetch the image directly.
+The **Web Server** output must be enabled for cover art to be available.
+
+## Troubleshooting
+
+* **No lights changing** - Confirm Lumia Stream is running and the Developers API is enabled.
+* **Authentication failed (401)** - Re-copy the token from Lumia Stream; tokens reset if you
+  restart Lumia Stream or regenerate them.
+* **Connection refused** - Verify the port matches what Lumia Stream is configured to use.
+* **No cover art** - Enable the **Web Server** output so the cover image endpoint is active.

--- a/nowplaying/notifications/lumiastream.py
+++ b/nowplaying/notifications/lumiastream.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Lumia Stream Notification Plugin"""
+
+import logging
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from nowplaying.exceptions import PluginVerifyError
+from nowplaying.types import TrackMetadata
+
+from . import NotificationPlugin
+
+if TYPE_CHECKING:
+    from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
+    from PySide6.QtWidgets import QWidget
+
+    import nowplaying.config
+
+_DEFAULT_PORT = 39231
+
+
+class Plugin(NotificationPlugin):
+    """Lumia Stream Notification Handler"""
+
+    def __init__(
+        self,
+        config: "nowplaying.config.ConfigFile | None" = None,
+        qsettings: "QWidget | None" = None,
+    ):
+        super().__init__(config=config, qsettings=qsettings)
+        self.displayname = "Lumia Stream"
+        self.enabled = False
+        self.token: str = ""
+        self.port: int = _DEFAULT_PORT
+        self._session: aiohttp.ClientSession | None = None
+
+    async def notify_track_change(self, metadata: TrackMetadata) -> None:
+        """Send track metadata to Lumia Stream when a new track becomes live."""
+        await self.start()
+        if not self.enabled or not self.token:
+            return
+
+        payload = self.build_payload(metadata)
+        url = f"http://localhost:{self.port}/api/send?token={self.token}"
+
+        try:
+            session = await self._get_session()
+            async with session.post(
+                url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+            ) as response:
+                if response.status == 200:
+                    logging.debug(
+                        "Lumia Stream accepted track: %s - %s",
+                        metadata.get("artist"),
+                        metadata.get("title"),
+                    )
+                else:
+                    error_text = ""
+                    try:
+                        error_text = await response.text()
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                    logging.error(
+                        "Lumia Stream returned status %d: %s", response.status, error_text
+                    )
+        except aiohttp.ClientError as exc:
+            logging.error("Failed to connect to Lumia Stream on port %d: %s", self.port, exc)
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error("Unexpected error sending to Lumia Stream: %s", exc)
+
+    @staticmethod
+    def build_payload(metadata: TrackMetadata) -> dict:
+        """Build the Lumia Stream nowplaying-switchSong alert payload."""
+        httpport = metadata.get("httpport")
+        image_url = f"http://localhost:{httpport}/cover.png" if httpport else ""
+
+        duration = metadata.get("duration")
+        isrc_list = metadata.get("isrc")
+
+        extra: dict = {
+            "title": metadata.get("title", ""),
+            "artist": metadata.get("artist", ""),
+            "album": metadata.get("album", ""),
+            "label": metadata.get("label", ""),
+            "bpm": metadata.get("bpm", ""),
+            "key": metadata.get("key", ""),
+            "comment": metadata.get("comments", ""),
+            "length": str(duration) if duration is not None else "",
+            "id": isrc_list[0] if isrc_list else "",
+            "image": image_url,
+            "artwork": "",
+            "url": "",
+            "spotify_url": "",
+            "beatport_url": "",
+            "beatport_id": "",
+            "file_key": "",
+            "rating": "",
+        }
+
+        return {
+            "type": "alert",
+            "params": {
+                "value": "nowplaying-switchSong",
+                "extraSettings": extra,
+            },
+        }
+
+    async def start(self) -> None:
+        """Read current config values."""
+        if not self.config:
+            return
+        self.enabled = self.config.cparser.value(
+            "lumiastream/enabled", type=bool, defaultValue=False
+        )
+        self.token = self.config.cparser.value("lumiastream/token", defaultValue="")
+        self.port = self.config.cparser.value(
+            "lumiastream/port", type=int, defaultValue=_DEFAULT_PORT
+        )
+
+    async def stop(self) -> None:
+        """Close the aiohttp session."""
+        await self._close_session()
+        if self.enabled:
+            logging.debug("Lumia Stream notifications stopped")
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create aiohttp session."""
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=10)
+            self._session = aiohttp.ClientSession(timeout=timeout)
+        return self._session
+
+    async def _close_session(self) -> None:
+        """Close aiohttp session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    def defaults(self, qsettings: "QSettings") -> None:
+        """Set default configuration values."""
+        qsettings.setValue("lumiastream/enabled", False)
+        qsettings.setValue("lumiastream/token", "")
+        qsettings.setValue("lumiastream/port", _DEFAULT_PORT)
+
+    def load_settingsui(self, qwidget: "QWidget") -> None:
+        """Load settings into UI."""
+        qwidget.enable_checkbox.setChecked(
+            self.config.cparser.value("lumiastream/enabled", type=bool, defaultValue=False)
+        )
+        qwidget.token_lineedit.setText(
+            self.config.cparser.value("lumiastream/token", defaultValue="")
+        )
+        qwidget.port_lineedit.setText(
+            str(
+                self.config.cparser.value("lumiastream/port", type=int, defaultValue=_DEFAULT_PORT)
+            )
+        )
+
+    def save_settingsui(self, qwidget: "QWidget") -> None:
+        """Save settings from UI."""
+        self.config.cparser.setValue("lumiastream/enabled", qwidget.enable_checkbox.isChecked())
+        self.config.cparser.setValue("lumiastream/token", qwidget.token_lineedit.text())
+        try:
+            port = int(qwidget.port_lineedit.text())
+            self.config.cparser.setValue("lumiastream/port", port)
+        except ValueError:
+            pass
+
+    def verify_settingsui(self, qwidget: "QWidget") -> bool:
+        """Verify settings."""
+        if qwidget.enable_checkbox.isChecked():
+            if not qwidget.token_lineedit.text().strip():
+                raise PluginVerifyError(
+                    "Lumia Stream API token is required when Lumia Stream is enabled. "
+                    "Find it in Lumia Stream: Settings > Advanced > Enable Developers API."
+                )
+            try:
+                port = int(qwidget.port_lineedit.text())
+                if not 1 <= port <= 65535:
+                    raise PluginVerifyError("Port must be between 1 and 65535")
+            except ValueError as err:
+                raise PluginVerifyError("Port must be a valid number") from err
+        return True
+
+    def desc_settingsui(self, qwidget: "QWidget") -> None:
+        """Description for settings UI."""
+        qwidget.setText(
+            "Send now-playing track metadata to Lumia Stream lighting software when tracks change."
+        )

--- a/nowplaying/notifications/lumiastream.py
+++ b/nowplaying/notifications/lumiastream.py
@@ -26,7 +26,7 @@ class Plugin(NotificationPlugin):
     def __init__(
         self,
         config: "nowplaying.config.ConfigFile | None" = None,
-        qsettings: "QWidget | None" = None,
+        qsettings: "QSettings | None" = None,
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Lumia Stream"
@@ -37,7 +37,6 @@ class Plugin(NotificationPlugin):
 
     async def notify_track_change(self, metadata: TrackMetadata) -> None:
         """Send track metadata to Lumia Stream when a new track becomes live."""
-        await self.start()
         if not self.enabled or not self.token:
             return
 

--- a/nowplaying/resources/ui/notifications_lumiastream.ui
+++ b/nowplaying/resources/ui/notifications_lumiastream.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>notifications_lumiastream_ui</class>
+ <widget class="QWidget" name="notifications_lumiastream_ui">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Lumia Stream</string>
+  </property>
+  <property name="displayName" stdset="0">
+   <string>Lumia Stream</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout">
+   <property name="margin">
+    <number>10</number>
+   </property>
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="header_label">
+     <property name="text">
+      <string>**Lumia Stream Support**</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::MarkdownText</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="enable_checkbox">
+     <property name="text">
+      <string>Enable</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="token_layout">
+     <item>
+      <widget class="QLabel" name="token_label">
+       <property name="text">
+        <string>API Token:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="token_lineedit">
+       <property name="placeholderText">
+        <string>Paste token from Lumia Stream Settings &gt; Advanced</string>
+       </property>
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="port_layout">
+     <item>
+      <widget class="QLabel" name="port_label">
+       <property name="text">
+        <string>Port:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="port_lineedit">
+       <property name="placeholderText">
+        <string>39231</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="description_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body&gt;
+&lt;p&gt;Lumia Stream integration fires a &lt;b&gt;nowplaying-switchSong&lt;/b&gt; alert in Lumia Stream each time a new track becomes live.&lt;/p&gt;
+&lt;ol&gt;
+&lt;li&gt;Open Lumia Stream and go to &lt;b&gt;Settings &amp;gt; Advanced&lt;/b&gt;.&lt;/li&gt;
+&lt;li&gt;Enable the Developers API and copy the token.&lt;/li&gt;
+&lt;li&gt;Paste the token above and click Enable.&lt;/li&gt;
+&lt;/ol&gt;
+&lt;p&gt;Sends: title, artist, album, label, BPM, key, duration, ISRC, and cover art URL.&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/notifications/test_notifications_lumiastream.py
+++ b/tests/notifications/test_notifications_lumiastream.py
@@ -3,6 +3,7 @@
 
 import logging
 
+import aiohttp
 import pytest
 import pytest_asyncio
 from aioresponses import aioresponses
@@ -113,11 +114,11 @@ def test_lumia_payload_no_isrc():
 
 
 @pytest.mark.asyncio
-async def test_lumia_connection_error_logged(
-    lumia_plugin,
-    caplog,  # pylint: disable=redefined-outer-name
+async def test_lumia_client_error_logged(
+    lumia_plugin,  # pylint: disable=redefined-outer-name
+    caplog,
 ):
-    """connection errors are logged, not raised"""
+    """aiohttp.ClientError is caught and logged, not raised"""
     lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)
     lumia_plugin.config.cparser.setValue("lumiastream/token", "testtoken123")
     lumia_plugin.config.cparser.setValue("lumiastream/port", 39231)
@@ -128,18 +129,42 @@ async def test_lumia_connection_error_logged(
     with aioresponses() as mock_resp:
         mock_resp.post(
             "http://localhost:39231/api/send?token=testtoken123",
-            exception=Exception("connection refused"),
+            exception=aiohttp.ClientConnectionError("connection refused"),
         )
         with caplog.at_level(logging.ERROR):
             await lumia_plugin.notify_track_change(metadata)
 
-        assert any("Lumia Stream" in r.message for r in caplog.records)
+        assert any("Failed to connect to Lumia Stream" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_lumia_generic_error_logged(
+    lumia_plugin,  # pylint: disable=redefined-outer-name
+    caplog,
+):
+    """unexpected non-aiohttp errors are caught and logged, not raised"""
+    lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)
+    lumia_plugin.config.cparser.setValue("lumiastream/token", "testtoken123")
+    lumia_plugin.config.cparser.setValue("lumiastream/port", 39231)
+    await lumia_plugin.start()
+
+    metadata = {"artist": "WNP Mock Artist", "title": "Mock Track"}
+
+    with aioresponses() as mock_resp:
+        mock_resp.post(
+            "http://localhost:39231/api/send?token=testtoken123",
+            exception=ValueError("unexpected"),
+        )
+        with caplog.at_level(logging.ERROR):
+            await lumia_plugin.notify_track_change(metadata)
+
+        assert any("Unexpected error" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_lumia_non_200_logged(
-    lumia_plugin,
-    caplog,  # pylint: disable=redefined-outer-name
+    lumia_plugin,  # pylint: disable=redefined-outer-name
+    caplog,
 ):
     """non-200 HTTP responses are logged"""
     lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)

--- a/tests/notifications/test_notifications_lumiastream.py
+++ b/tests/notifications/test_notifications_lumiastream.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Tests for Lumia Stream notification plugin"""
+
+import logging
+
+import pytest
+import pytest_asyncio
+from aioresponses import aioresponses
+
+import nowplaying.notifications.lumiastream
+
+
+@pytest_asyncio.fixture
+async def lumia_plugin(bootstrap):  # pylint: disable=redefined-outer-name
+    """bootstrap a lumia stream notification plugin"""
+    plugin = nowplaying.notifications.lumiastream.Plugin(config=bootstrap)
+    await plugin.start()
+    try:
+        yield plugin
+    finally:
+        await plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_lumia_disabled_skips_request(lumia_plugin):  # pylint: disable=redefined-outer-name
+    """plugin does nothing when disabled"""
+    lumia_plugin.config.cparser.setValue("lumiastream/enabled", False)
+    lumia_plugin.config.cparser.setValue("lumiastream/token", "sometoken")
+    await lumia_plugin.start()
+
+    with aioresponses() as mock_resp:
+        await lumia_plugin.notify_track_change({"artist": "WNP Mock Artist", "title": "Test"})
+        assert len(mock_resp.requests) == 0
+
+
+@pytest.mark.asyncio
+async def test_lumia_no_token_skips_request(lumia_plugin):  # pylint: disable=redefined-outer-name
+    """plugin does nothing when enabled but token is missing"""
+    lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)
+    lumia_plugin.config.cparser.setValue("lumiastream/token", "")
+    await lumia_plugin.start()
+
+    with aioresponses() as mock_resp:
+        await lumia_plugin.notify_track_change({"artist": "WNP Mock Artist", "title": "Test"})
+        assert len(mock_resp.requests) == 0
+
+
+@pytest.mark.asyncio
+async def test_lumia_sends_on_track_change(lumia_plugin):  # pylint: disable=redefined-outer-name
+    """plugin POSTs alert payload when enabled with token"""
+    lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)
+    lumia_plugin.config.cparser.setValue("lumiastream/token", "testtoken123")
+    lumia_plugin.config.cparser.setValue("lumiastream/port", 39231)
+    await lumia_plugin.start()
+
+    metadata = {
+        "artist": "WNP Mock Artist",
+        "title": "Mock Track",
+        "album": "Mock Album",
+        "httpport": 8899,
+    }
+
+    with aioresponses() as mock_resp:
+        mock_resp.post("http://localhost:39231/api/send?token=testtoken123", status=200)
+        await lumia_plugin.notify_track_change(metadata)
+        assert len(mock_resp.requests) == 1
+
+
+def test_lumia_payload_fields():
+    """payload contains all expected Lumia extraSettings fields"""
+    metadata = {
+        "artist": "WNP Mock Artist",
+        "title": "Mock Track",
+        "album": "Mock Album",
+        "label": "Mock Label",
+        "bpm": "128",
+        "key": "Am",
+        "comments": "test comment",
+        "duration": 210,
+        "isrc": ["USABC1234567"],
+        "httpport": 8899,
+    }
+
+    payload = nowplaying.notifications.lumiastream.Plugin.build_payload(metadata)
+
+    assert payload["type"] == "alert"
+    assert payload["params"]["value"] == "nowplaying-switchSong"
+    extra = payload["params"]["extraSettings"]
+    assert extra["title"] == "Mock Track"
+    assert extra["artist"] == "WNP Mock Artist"
+    assert extra["album"] == "Mock Album"
+    assert extra["label"] == "Mock Label"
+    assert extra["bpm"] == "128"
+    assert extra["key"] == "Am"
+    assert extra["comment"] == "test comment"
+    assert extra["length"] == "210"
+    assert extra["id"] == "USABC1234567"
+    assert extra["image"] == "http://localhost:8899/cover.png"
+
+
+def test_lumia_payload_no_httpport():
+    """image field is empty when httpport is absent"""
+    metadata = {"artist": "WNP Mock Artist", "title": "Mock Track"}
+    payload = nowplaying.notifications.lumiastream.Plugin.build_payload(metadata)
+    assert payload["params"]["extraSettings"]["image"] == ""
+
+
+def test_lumia_payload_no_isrc():
+    """id field is empty when isrc is absent"""
+    metadata = {"artist": "WNP Mock Artist", "title": "Mock Track"}
+    payload = nowplaying.notifications.lumiastream.Plugin.build_payload(metadata)
+    assert payload["params"]["extraSettings"]["id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_lumia_connection_error_logged(
+    lumia_plugin,
+    caplog,  # pylint: disable=redefined-outer-name
+):
+    """connection errors are logged, not raised"""
+    lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)
+    lumia_plugin.config.cparser.setValue("lumiastream/token", "testtoken123")
+    lumia_plugin.config.cparser.setValue("lumiastream/port", 39231)
+    await lumia_plugin.start()
+
+    metadata = {"artist": "WNP Mock Artist", "title": "Mock Track"}
+
+    with aioresponses() as mock_resp:
+        mock_resp.post(
+            "http://localhost:39231/api/send?token=testtoken123",
+            exception=Exception("connection refused"),
+        )
+        with caplog.at_level(logging.ERROR):
+            await lumia_plugin.notify_track_change(metadata)
+
+        assert any("Lumia Stream" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_lumia_non_200_logged(
+    lumia_plugin,
+    caplog,  # pylint: disable=redefined-outer-name
+):
+    """non-200 HTTP responses are logged"""
+    lumia_plugin.config.cparser.setValue("lumiastream/enabled", True)
+    lumia_plugin.config.cparser.setValue("lumiastream/token", "testtoken123")
+    lumia_plugin.config.cparser.setValue("lumiastream/port", 39231)
+    await lumia_plugin.start()
+
+    metadata = {"artist": "WNP Mock Artist", "title": "Mock Track"}
+
+    with aioresponses() as mock_resp:
+        mock_resp.post(
+            "http://localhost:39231/api/send?token=testtoken123",
+            status=401,
+            body="Unauthorized",
+        )
+        with caplog.at_level(logging.ERROR):
+            await lumia_plugin.notify_track_change(metadata)
+
+        assert any("401" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_lumia_defaults(bootstrap):
+    """defaults() sets expected QSettings keys"""
+    plugin = nowplaying.notifications.lumiastream.Plugin(config=bootstrap)
+    plugin.defaults(bootstrap.cparser)
+
+    assert bootstrap.cparser.value("lumiastream/enabled", type=bool) is False
+    assert bootstrap.cparser.value("lumiastream/token", defaultValue="") == ""
+    assert bootstrap.cparser.value("lumiastream/port", type=int) == 39231


### PR DESCRIPTION
Fires nowplaying-switchSong alert to Lumia Stream's HTTP API on each track change. Sends title, artist, album, label, BPM, key, duration, ISRC, and cover art URL. Includes settings UI (enable, token, port), 9 tests, and docs.

## Summary by Sourcery

Add a Lumia Stream notification plugin that sends now-playing track metadata to Lumia Stream on track changes and integrate it into the outputs system and documentation.

New Features:
- Introduce a Lumia Stream notification plugin that posts nowplaying-switchSong alerts with rich track metadata to Lumia Stream via its HTTP API.
- Add configuration and settings UI for enabling Lumia Stream notifications, configuring API token, and choosing the local API port.

Documentation:
- Document Lumia Stream output integration, including setup, configuration, behavior, and troubleshooting steps, and link it from the features and output index pages.

Tests:
- Add a dedicated Lumia Stream notification test suite covering enablement/token gating, payload structure, HTTP error handling, and default configuration values.