### PR TITLE
fix: restore config on cancel after reset; preserve charts key

### DIFF
--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -151,15 +151,26 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             task.add_done_callback(self.tasks.discard)
             self.tasks.add(task)
 
-    async def switch_input_plugin(self):
-        """handle user switching source input while running"""
-        if not self.previousinput or self.previousinput != self.config.cparser.value(
-            "settings/input"
-        ):
+    async def switch_input_plugin(self) -> bool:
+        """Handle user switching source input while running.
+
+        Returns True when an input plugin is active and ready for gettrack(),
+        False when no input is configured or the plugin failed to start.
+        Callers use the False return to skip polling until the next cycle.
+        """
+        configured: str | None = self.config.cparser.value("settings/input")
+        if not configured:
             if self.input:
                 logging.info("stopping %s", self.previousinput)
                 await self.input.stop()
-            self.previousinput: str | None = self.config.cparser.value("settings/input")
+                self.input = None
+                self.previousinput = None
+            return False
+        if self.previousinput != configured:
+            if self.input:
+                logging.info("stopping %s", self.previousinput)
+                await self.input.stop()
+            self.previousinput: str | None = configured
             self.input = self.plugins[f"nowplaying.inputs.{self.previousinput}"].Plugin(
                 config=self.config
             )

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -12,7 +12,7 @@ import os
 import pathlib
 import re
 import shutil
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 # pylint: disable=no-name-in-module
 from PySide6.QtCore import QCoreApplication, QEventLoop, QFile, QStandardPaths, Qt, Slot
@@ -54,6 +54,7 @@ import nowplaying.twitch.chat
 import nowplaying.twitch.settings
 import nowplaying.uihelp
 import nowplaying.utils
+import nowplaying.utils.config_json
 import nowplaying.utils.filters
 
 if TYPE_CHECKING:
@@ -113,7 +114,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         self.simple_filter_manager = nowplaying.utils.filters.FilterManager()
 
         self.uihelp = None
-        self.ui_populated = False  # Track if UI widgets are populated with config data
+        self.ui_populated = False
+        self._reset_backup: dict[str, Any] | None = None
         self.load_qtui()
         if not self.config.iconfile:
             self.tray.cleanquit()
@@ -413,6 +415,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
 
     def _set_source_description(self, index):
         item = self.widgets["source"].sourcelist.item(index)
+        if not item:
+            return
         display_name = item.text().lower()
         plugin = self.input_display_to_module.get(display_name, display_name)
         self.config.plugins_description("inputs", plugin, self.widgets["source"].description)
@@ -540,6 +544,10 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         # Fallback: if no mapping found, try to find by the stored
         # value directly (for backward compatibility)
         search_term = target_display_name or currentinput
+
+        if not search_term:
+            self.widgets["source"].sourcelist.setCurrentItem(None)
+            return
 
         if curbutton := self.widgets["source"].sourcelist.findItems(search_term, Qt.MatchContains):
             self.widgets["source"].sourcelist.setCurrentItem(curbutton[0])
@@ -1202,6 +1210,14 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
     @Slot()
     def on_cancel_button(self):
         """cancel button clicked action"""
+        if self._reset_backup is not None:
+            nowplaying.utils.config_json.restore_config_data(
+                self.config.cparser, self._reset_backup
+            )
+            self._reset_backup = None
+            self.config.get()
+            self._connect_plugins()
+
         self._cleanup_settings_classes()
         if self.tray:
             self.tray.settings_action.setEnabled(True)
@@ -1217,10 +1233,12 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
 
     @Slot()
     def on_reset_button(self):
-        """cancel button clicked action"""
+        """reset config to defaults, keeping a backup so Cancel can undo it"""
+        self._reset_backup = nowplaying.utils.config_json.collect_config_data(self.config.cparser)
         self.config.reset()
         SettingsUI.httpenabled = self.config.cparser.value("weboutput/httpenabled", type=bool)
         SettingsUI.httpport = self.config.cparser.value("weboutput/httpport", type=int)
+        self._connect_plugins()
         self.refresh_ui()
 
     @Slot()
@@ -1267,8 +1285,9 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
                     self.errormessage.showMessage(error.message)
                 return
 
-        # Check if this is first-time setup before marking as initialized
-        is_first_install = not self.config.initialized
+        # True only on genuine first install, not after a config reset.
+        is_first_install = not self.config.initialized and self._reset_backup is None
+        self._reset_backup = None
 
         self.config.unpause()
         self.upd_conf()  # This sets initialized=True

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -701,8 +701,12 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.exit_everything()
         self.config.get()
         if not self.config.initialized:
+            charts_key = self.config.cparser.value("charts/charts_key", defaultValue="")
             self.config.cparser.clear()
             self.config.cparser.sync()
+            if charts_key:
+                self.config.cparser.setValue("charts/charts_key", charts_key)
+                self.config.cparser.sync()
 
         self._exit_app()
 

--- a/nowplaying/utils/config_json.py
+++ b/nowplaying/utils/config_json.py
@@ -60,6 +60,57 @@ PATH_KEYS: frozenset[str] = frozenset(
 )
 
 
+def collect_config_data(settings: QSettings) -> dict[str, t.Any]:
+    """
+    Collect user-scope settings into a plain dict.
+
+    Uses childGroups()/childKeys() to read only user-scope keys, avoiding
+    system-scope contamination that allKeys() causes on macOS.  IGNORE_KEYS
+    entries are excluded so the result mirrors what export_config() writes.
+
+    Args:
+        settings: QSettings instance to read from
+    Returns:
+        dict mapping "group/key" strings to their values
+    """
+    config_data: dict[str, t.Any] = {}
+    for group in settings.childGroups():
+        settings.beginGroup(group)
+        for key in settings.childKeys():
+            full_key = f"{group}/{key}"
+            if any(full_key.startswith(pattern) for pattern in IGNORE_KEYS):
+                continue
+            value = settings.value(key)
+            if isinstance(value, list):
+                value = [str(item) for item in value]
+            elif not isinstance(value, (bool, int, float, str, type(None))):
+                value = str(value)
+            config_data[full_key] = value
+        settings.endGroup()
+    return config_data
+
+
+def restore_config_data(settings: QSettings, data: dict[str, t.Any]) -> None:
+    """
+    Restore settings from a dict snapshot produced by collect_config_data().
+
+    Intended for same-machine undo (e.g. cancelling a config reset).  No path
+    remapping is performed; all keys are written back verbatim.
+
+    The blanket clear() is intentional: a partial clear scoped to the
+    snapshot's groups would leave behind keys written during the reset
+    (e.g. settings/initialized=False) that are not in the snapshot.
+
+    Args:
+        settings: QSettings instance to write into (cleared first)
+        data: dict previously returned by collect_config_data()
+    """
+    settings.clear()
+    for key, value in data.items():
+        settings.setValue(key, value)
+    settings.sync()
+
+
 def export_config(
     export_path: pathlib.Path,
     settings: QSettings,
@@ -77,45 +128,9 @@ def export_config(
     """
 
     try:
-        # Use childGroups() and childKeys() to avoid system preferences contamination
-        # that can occur with allKeys() on macOS
-        config_data = {}
+        config_data = collect_config_data(settings)
 
         home = str(pathlib.Path.home())
-
-        # Get keys from each configuration group (avoids system preferences)
-        for group in settings.childGroups():
-            settings.beginGroup(group)
-            group_keys = settings.childKeys()
-
-            for key in group_keys:
-                full_key = f"{group}/{key}"
-
-                # Skip excluded settings
-                if any(full_key.startswith(pattern) for pattern in IGNORE_KEYS):
-                    continue
-
-                value = settings.value(key)
-
-                # Convert QSettings types to JSON-serializable types
-                if (
-                    isinstance(value, bool)
-                    or value is not None
-                    and isinstance(value, (int, float, str))
-                ):
-                    pass  # bools are fine
-                elif value is None:
-                    value = None
-                elif isinstance(value, list):
-                    # Convert list items to strings
-                    value = [str(item) for item in value]
-                else:
-                    # Convert everything else to string
-                    value = str(value)
-
-                config_data[full_key] = value
-
-            settings.endGroup()
 
         # Add metadata about the export
         export_metadata = {

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -720,9 +720,9 @@ def test_build_embed_sets_description():
         ("#000000", (0, 0, 0)),
         ("#ffffff", (255, 255, 255)),
         ("notahex", None),
-        ("#gg0000", None),   # invalid hex digits
-        ("#ff660",  None),   # too short
-        ("",        None),
+        ("#gg0000", None),  # invalid hex digits
+        ("#ff660", None),  # too short
+        ("", None),
     ],
 )
 def test_parse_hex_rgb(token, expected):


### PR DESCRIPTION
* collect_config_data()/restore_config_data() extracted from export_config() in config_json.py (no allKeys(), same childGroups/childKeys traversal)
* on_reset_button() snapshots config before wiping so Cancel can do a full clear-then-restore instead of triggering cleanquit
* on_cancel_button() restores the snapshot when present; falls through to normal close (initialized=True, no cleanquit fired)
* cleanquit() preserves charts/charts_key across cparser.clear()
* on_save_button() is_first_install guards against post-reset saves
* _upd_win_input() early-returns on None search_term before findItems
* _set_source_description() guards against None item on row change
* trackpoll.switch_input_plugin() handles None configured input

## Summary by Sourcery

Improve configuration reset and cancellation behavior while preserving certain user data and handling null input states more safely.

New Features:
- Allow cancelling a configuration reset by snapshotting settings before reset and restoring them on cancel.

Bug Fixes:
- Prevent system preference contamination in configuration export by reusing a dedicated user-scope collection function.
- Ensure clean application quit preserves the charts key across configuration clears.
- Handle null or empty search terms when updating the input source selection to avoid invalid item lookups.
- Guard source description updates against missing list items on row changes.
- Allow track polling to correctly stop input plugins when the configured input is cleared or unset.

Enhancements:
- Extract reusable helpers for collecting and restoring configuration data to support undo-like behavior.
- Refine first-install detection to distinguish genuine first-time setup from post-reset saves.
- Minor test formatting cleanup for hex color parsing expectations.

Tests:
- Tidy hex color parsing test parameter formatting for consistency.