### PR TITLE
feat: first-run installation wizard

### DIFF
--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -18,6 +18,7 @@ import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
 import nowplaying.frozen
+import nowplaying.installwizard
 import nowplaying.singleinstance
 import nowplaying.startup
 import nowplaying.systemtray
@@ -74,6 +75,8 @@ def actualmain():  # pragma: no cover
             config = nowplaying.config.ConfigFile(logpath=logpath, bundledir=bundledir)
             logging.getLogger().setLevel(config.loglevel)
             logging.captureWarnings(True)
+
+            nowplaying.installwizard.maybe_show_wizard(config)
 
             startup_window.update_progress("Starting system tray...")
             qapp.processEvents()

--- a/nowplaying/artistextras/__init__.py
+++ b/nowplaying/artistextras/__init__.py
@@ -48,6 +48,8 @@ class ArtistExtrasPlugin(WNPBasePlugin):
             self._datacache_client = nowplaying.datacache.get_client()
         return self._datacache_client
 
+    requires_apikey: bool = True
+
     #### Plug-in methods
 
     async def download_async(  #  pylint: disable=no-self-use,unused-argument

--- a/nowplaying/artistextras/theaudiodb.py
+++ b/nowplaying/artistextras/theaudiodb.py
@@ -34,6 +34,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
         self.fnstr: str | None = None
         self.displayname: str = "TheAudioDB"
         self.priority: int = 50
+        self.requires_apikey: bool = False
 
     @staticmethod
     def _filter(text: str) -> str:

--- a/nowplaying/artistextras/wikimedia.py
+++ b/nowplaying/artistextras/wikimedia.py
@@ -17,6 +17,7 @@ class Plugin(ArtistExtrasPlugin):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Wikimedia"
         self.priority = 1000
+        self.requires_apikey = False
 
     def _check_missing(self, metadata):
         """check for missing required data"""

--- a/nowplaying/inputs/earshot.py
+++ b/nowplaying/inputs/earshot.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """EarShot input plugin"""
 
+import pathlib
+import sys
 from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import QWidget  # pylint: disable=import-error, no-name-in-module
@@ -23,6 +25,12 @@ class Plugin(nowplaying.inputs.remote.Plugin):
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "EarShot"
+
+    def install(self) -> bool:
+        """Detect WNP EarShot.app in /Applications on macOS."""
+        if sys.platform != "darwin":
+            return False
+        return pathlib.Path("/Applications/WNP EarShot.app").exists()
 
     def get_source_agent_data(self) -> dict:
         """EarShot preserves source_agent data set by the sender."""

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -167,7 +167,7 @@ class Plugin(IcecastPlugin):
                         if cmlpath.exists():
                             self.config.cparser.setValue("traktor/collections", str(cmlpath))
                             self.config.cparser.setValue("settings/input", "traktor")
-                            self.config.cparser.setValue("traktor/port", 8000)
+                            self.config.cparser.setValue("traktor/port", "8000")
                             return True
 
         return False

--- a/nowplaying/installwizard/__init__.py
+++ b/nowplaying/installwizard/__init__.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""First-run installation wizard."""
+
+# pylint: disable=no-name-in-module
+
+import logging
+
+from PySide6.QtWidgets import QWidget, QWizard
+
+import nowplaying.config
+from nowplaying.installwizard._artist_extras import _ArtistExtrasPage
+from nowplaying.installwizard._configure_outputs import _ConfigureOutputsPage
+from nowplaying.installwizard._constants import (
+    PAGE_ARTISTEXTRAS,
+    PAGE_CONFIGURE_OUTPUTS,
+    PAGE_FINISH,
+    PAGE_INPUT,
+    PAGE_INPUT_CONFIG,
+    PAGE_OUTPUTS,
+    PAGE_WELCOME,
+)
+from nowplaying.installwizard._finish import _FinishPage
+from nowplaying.installwizard._input_source import _InputSourcePage
+from nowplaying.installwizard._outputs import _OutputsPage
+from nowplaying.installwizard._welcome import _WelcomePage
+
+__all__ = [
+    "InstallWizard",
+    "maybe_show_wizard",
+    "PAGE_WELCOME",
+    "PAGE_INPUT",
+    "PAGE_INPUT_CONFIG",
+    "PAGE_ARTISTEXTRAS",
+    "PAGE_OUTPUTS",
+    "PAGE_CONFIGURE_OUTPUTS",
+    "PAGE_FINISH",
+]
+
+
+class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
+    """First-run setup wizard; shown when config.initialized is False."""
+
+    def __init__(
+        self, config: nowplaying.config.ConfigFile, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setWindowTitle("What's Now Playing — Setup")
+        self.setWizardStyle(QWizard.WizardStyle.ModernStyle)
+        self.setMinimumSize(620, 520)
+
+        self._welcome_page = _WelcomePage()
+        self._input_page = _InputSourcePage(config)
+        self._extras_page = _ArtistExtrasPage(config)
+        self._outputs_page = _OutputsPage(config)
+        self._configure_page = _ConfigureOutputsPage(self._outputs_page, config)
+        self._finish_page = _FinishPage()
+
+        self.setPage(PAGE_WELCOME, self._welcome_page)
+        self.setPage(PAGE_INPUT, self._input_page)
+        # PAGE_INPUT_CONFIG is reserved; populated dynamically by _InputSourcePage
+        self.setPage(PAGE_ARTISTEXTRAS, self._extras_page)
+        self.setPage(PAGE_OUTPUTS, self._outputs_page)
+        self.setPage(PAGE_CONFIGURE_OUTPUTS, self._configure_page)
+        self.setPage(PAGE_FINISH, self._finish_page)
+
+        self.setStartId(PAGE_WELCOME)
+        self.currentIdChanged.connect(self._on_page_changed)
+        self.accepted.connect(self._commit)
+
+    def _on_page_changed(self, page_id: int) -> None:
+        if page_id == PAGE_FINISH:
+            self._finish_page.set_summary(
+                self._input_page.selected_display_name(),
+                self._extras_page.enabled_display_names(),
+                self._outputs_page.enabled_display_names(),
+            )
+
+    def _commit(self) -> None:
+        """Persist all wizard choices to QSettings and mark initialized."""
+        cparser = self.config.cparser
+
+        # Plugin-specific config page (if one was registered) commits itself
+        if PAGE_INPUT_CONFIG in self.pageIds():
+            self.page(PAGE_INPUT_CONFIG).commit()
+
+        short_name = self._input_page.selected_short_name()
+        if short_name:
+            cparser.setValue("settings/input", short_name)
+            logging.info("wizard: set input source to %s", short_name)
+
+        for key in self.config.plugins.get("artistextras", {}):
+            sname = key.replace("nowplaying.artistextras.", "")
+            check = self._extras_page.enable_checks.get(sname)
+            if check is not None:
+                cparser.setValue(f"{sname}/enabled", check.isChecked())
+            edit = self._extras_page.apikey_edits.get(sname)
+            if edit is not None:
+                cparser.setValue(f"{sname}/apikey", edit.text().strip())
+
+        cparser.setValue(
+            "artistextras/prioritizenetworkart",
+            self._extras_page.prioritize_network.isChecked(),
+        )
+        cparser.setValue("artistextras/bio_dedup", self._extras_page.bio_dedup.isChecked())
+        cparser.setValue(
+            "artistextras/coverfornofanart",
+            self._extras_page.coverfornofanart.isChecked(),
+        )
+
+        op = self._outputs_page
+        cparser.setValue("weboutput/httpenabled", op.weboverlay_check.isChecked())
+        cparser.setValue("obsws/enabled", op.obsws_check.isChecked())
+        cparser.setValue("twitchbot/enabled", op.twitch_check.isChecked())
+        cparser.setValue("kick/enabled", op.kick_check.isChecked())
+        cparser.setValue("discord/bot_enabled", op.discord_bot_check.isChecked())
+        cparser.setValue("discord/richpresence_enabled", op.discord_rp_check.isChecked())
+
+        if op.needs_credentials():
+            cp = self._configure_page
+            if op.obsws_check.isChecked():
+                cparser.setValue("obsws/host", cp.obsws_host.text().strip() or "localhost")
+                cparser.setValue("obsws/port", cp.obsws_port.text().strip() or "4455")
+                cparser.setValue("obsws/secret", cp.obsws_secret.text())
+            if op.twitch_check.isChecked():
+                cparser.setValue("twitchbot/channel", cp.twitch_channel.text().strip())
+                cparser.setValue("twitchbot/clientid", cp.twitch_clientid.text().strip())
+                cparser.setValue("twitchbot/secret", cp.twitch_secret.text())
+            if op.kick_check.isChecked():
+                cparser.setValue("kick/channel", cp.kick_channel.text().strip())
+                cparser.setValue("kick/clientid", cp.kick_clientid.text().strip())
+                cparser.setValue("kick/secret", cp.kick_secret.text())
+            if op.discord_bot_check.isChecked() or op.discord_rp_check.isChecked():
+                cparser.setValue("discord/token", cp.discord_token.text().strip())
+
+        self.config.initialized = True
+        self.config.save()
+        logging.info("wizard: first-run setup complete")
+
+
+def maybe_show_wizard(config: nowplaying.config.ConfigFile) -> None:
+    """Show the setup wizard for a fresh install; no-op if already initialized."""
+    if config.initialized:
+        return
+    wizard = InstallWizard(config)
+    wizard.exec()

--- a/nowplaying/installwizard/_artist_extras.py
+++ b/nowplaying/installwizard/_artist_extras.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Artist extras configuration page for the installation wizard."""
+
+# pylint: disable=no-name-in-module
+
+import logging
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+    QWizardPage,
+)
+
+import nowplaying.config
+
+
+class _ArtistExtrasPage(QWizardPage):  # pylint: disable=too-few-public-methods
+    """Configure artist information services."""
+
+    def __init__(
+        self, config: nowplaying.config.ConfigFile, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Artist Information Sources")
+        self.setSubTitle(
+            "Choose which services to use for artist biographies and images. "
+            "Free services need no API key and are enabled by default."
+        )
+        self.enable_checks: dict[str, QCheckBox] = {}
+        self.apikey_edits: dict[str, QLineEdit] = {}
+        self.prioritize_network: QCheckBox
+        self.bio_dedup: QCheckBox
+        self.coverfornofanart: QCheckBox
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:  # pylint: disable=too-many-statements,too-many-locals
+        outer = QVBoxLayout()
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        inner_widget = QWidget()
+        inner = QVBoxLayout()
+
+        services_group = QGroupBox("Services")
+        services_layout = QVBoxLayout()
+
+        for key in sorted(self.config.plugins.get("artistextras", {})):
+            module = self.config.plugins["artistextras"][key]
+            short_name = key.replace("nowplaying.artistextras.", "")
+            try:
+                plugin_obj = module.Plugin(config=self.config)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.debug("wizard: could not load artistextras plugin %s", key)
+                continue
+
+            display = plugin_obj.displayname
+            needs_key = plugin_obj.requires_apikey
+            current_enabled = bool(
+                self.config.cparser.value(
+                    f"{short_name}/enabled", type=bool, defaultValue=not needs_key
+                )
+            )
+
+            row = QWidget()
+            row_layout = QHBoxLayout()
+            row_layout.setContentsMargins(0, 4, 0, 4)
+
+            if not needs_key:
+                check = QCheckBox(f"{display}  — free, no API key required")
+                check.setChecked(True)
+            else:
+                check = QCheckBox(display)
+                check.setChecked(current_enabled)
+
+            self.enable_checks[short_name] = check
+            row_layout.addWidget(check)
+
+            if needs_key:
+                key_label = QLabel("API Key:")
+                key_edit = QLineEdit()
+                key_edit.setPlaceholderText(f"{display} API key")
+                key_edit.setText(
+                    str(self.config.cparser.value(f"{short_name}/apikey", defaultValue="") or "")
+                )
+                key_edit.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+                self.apikey_edits[short_name] = key_edit
+                key_edit.setEnabled(check.isChecked())
+                check.toggled.connect(key_edit.setEnabled)
+                row_layout.addWidget(key_label)
+                row_layout.addWidget(key_edit)
+
+            row.setLayout(row_layout)
+            services_layout.addWidget(row)
+
+        services_group.setLayout(services_layout)
+        inner.addWidget(services_group)
+
+        common_group = QGroupBox("Common Settings")
+        common_layout = QVBoxLayout()
+
+        self.prioritize_network = QCheckBox("Prefer downloaded images over embedded cover art")
+        self.prioritize_network.setChecked(
+            bool(
+                self.config.cparser.value(
+                    "artistextras/prioritizenetworkart", type=bool, defaultValue=False
+                )
+            )
+        )
+        common_layout.addWidget(self.prioritize_network)
+
+        self.bio_dedup = QCheckBox("Deduplicate artist bios across services")
+        self.bio_dedup.setChecked(
+            bool(self.config.cparser.value("artistextras/bio_dedup", type=bool, defaultValue=True))
+        )
+        common_layout.addWidget(self.bio_dedup)
+
+        self.coverfornofanart = QCheckBox(
+            "Use cover art as fallback when no artist image is available"
+        )
+        self.coverfornofanart.setChecked(
+            bool(
+                self.config.cparser.value(
+                    "artistextras/coverfornofanart", type=bool, defaultValue=True
+                )
+            )
+        )
+        common_layout.addWidget(self.coverfornofanart)
+
+        common_group.setLayout(common_layout)
+        inner.addWidget(common_group)
+
+        inner.addStretch()
+        inner_widget.setLayout(inner)
+        scroll.setWidget(inner_widget)
+        outer.addWidget(scroll)
+        self.setLayout(outer)
+
+    def enabled_display_names(self) -> list[str]:
+        """Return display labels for all enabled services (for summary page)."""
+        names = []
+        for key in sorted(self.config.plugins.get("artistextras", {})):
+            module = self.config.plugins["artistextras"][key]
+            short_name = key.replace("nowplaying.artistextras.", "")
+            check = self.enable_checks.get(short_name)
+            if check and check.isChecked():
+                try:
+                    plugin_obj = module.Plugin(config=self.config)
+                    names.append(plugin_obj.displayname)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    names.append(short_name)
+        return names

--- a/nowplaying/installwizard/_artist_extras.py
+++ b/nowplaying/installwizard/_artist_extras.py
@@ -57,7 +57,7 @@ class _ArtistExtrasPage(QWizardPage):  # pylint: disable=too-few-public-methods
             try:
                 plugin_obj = module.Plugin(config=self.config)
             except Exception:  # pylint: disable=broad-exception-caught
-                logging.debug("wizard: could not load artistextras plugin %s", key)
+                logging.exception("wizard: could not load artistextras plugin %s", key)
                 continue
 
             display = plugin_obj.displayname
@@ -74,10 +74,9 @@ class _ArtistExtrasPage(QWizardPage):  # pylint: disable=too-few-public-methods
 
             if not needs_key:
                 check = QCheckBox(f"{display}  — free, no API key required")
-                check.setChecked(True)
             else:
                 check = QCheckBox(display)
-                check.setChecked(current_enabled)
+            check.setChecked(current_enabled)
 
             self.enable_checks[short_name] = check
             row_layout.addWidget(check)
@@ -154,5 +153,6 @@ class _ArtistExtrasPage(QWizardPage):  # pylint: disable=too-few-public-methods
                     plugin_obj = module.Plugin(config=self.config)
                     names.append(plugin_obj.displayname)
                 except Exception:  # pylint: disable=broad-exception-caught
+                    logging.exception("wizard: could not load artistextras plugin %s", key)
                     names.append(short_name)
         return names

--- a/nowplaying/installwizard/_configure_outputs.py
+++ b/nowplaying/installwizard/_configure_outputs.py
@@ -5,6 +5,7 @@
 
 from typing import TYPE_CHECKING
 
+from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (
     QFormLayout,
     QGroupBox,
@@ -41,6 +42,7 @@ class _ConfigureOutputsPage(QWizardPage):
 
         self.obsws_host = QLineEdit()
         self.obsws_port = QLineEdit()
+        self.obsws_port.setValidator(QIntValidator(1, 65535, self))
         self.obsws_secret = QLineEdit()
         self.twitch_channel = QLineEdit()
         self.twitch_clientid = QLineEdit()

--- a/nowplaying/installwizard/_configure_outputs.py
+++ b/nowplaying/installwizard/_configure_outputs.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Credentials configuration page for enabled outputs."""
+
+# pylint: disable=no-name-in-module,too-few-public-methods,too-many-instance-attributes,duplicate-code
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtWidgets import (
+    QFormLayout,
+    QGroupBox,
+    QLineEdit,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+    QWizardPage,
+)
+
+import nowplaying.config
+
+if TYPE_CHECKING:
+    from nowplaying.installwizard._outputs import _OutputsPage
+
+
+class _ConfigureOutputsPage(QWizardPage):
+    """Enter credentials for each enabled output that requires them."""
+
+    def __init__(
+        self,
+        outputs_page: "_OutputsPage",
+        config: nowplaying.config.ConfigFile,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._outputs_page = outputs_page
+        self.config = config
+        self.setTitle("Configure Outputs")
+        self.setSubTitle(
+            "Enter the credentials for each enabled output. "
+            "Leave a field blank to configure it later in Preferences."
+        )
+
+        self.obsws_host = QLineEdit()
+        self.obsws_port = QLineEdit()
+        self.obsws_secret = QLineEdit()
+        self.twitch_channel = QLineEdit()
+        self.twitch_clientid = QLineEdit()
+        self.twitch_secret = QLineEdit()
+        self.kick_channel = QLineEdit()
+        self.kick_clientid = QLineEdit()
+        self.kick_secret = QLineEdit()
+        self.discord_token = QLineEdit()
+
+        self._obsws_group: QGroupBox
+        self._twitch_group: QGroupBox
+        self._kick_group: QGroupBox
+        self._discord_group: QGroupBox
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout()
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        inner_widget = QWidget()
+        inner = QVBoxLayout()
+
+        self._obsws_group = self._make_obsws_group()
+        self._twitch_group = self._make_twitch_group()
+        self._kick_group = self._make_kick_group()
+        self._discord_group = self._make_discord_group()
+
+        inner.addWidget(self._obsws_group)
+        inner.addWidget(self._twitch_group)
+        inner.addWidget(self._kick_group)
+        inner.addWidget(self._discord_group)
+        inner.addStretch()
+
+        inner_widget.setLayout(inner)
+        scroll.setWidget(inner_widget)
+        outer.addWidget(scroll)
+        self.setLayout(outer)
+
+    def _make_obsws_group(self) -> QGroupBox:
+        group = QGroupBox("OBS WebSocket")
+        form = QFormLayout()
+        self.obsws_host.setPlaceholderText("localhost")
+        self.obsws_host.setText(
+            str(self.config.cparser.value("obsws/host", defaultValue="localhost") or "localhost")
+        )
+        self.obsws_port.setPlaceholderText("4455")
+        self.obsws_port.setText(
+            str(self.config.cparser.value("obsws/port", type=str, defaultValue="4455") or "4455")
+        )
+        self.obsws_secret.setPlaceholderText("WebSocket password (if set)")
+        self.obsws_secret.setEchoMode(QLineEdit.EchoMode.Password)
+        self.obsws_secret.setText(
+            str(self.config.cparser.value("obsws/secret", defaultValue="") or "")
+        )
+        form.addRow("Host:", self.obsws_host)
+        form.addRow("Port:", self.obsws_port)
+        form.addRow("Password:", self.obsws_secret)
+        group.setLayout(form)
+        return group
+
+    def _make_twitch_group(self) -> QGroupBox:
+        group = QGroupBox("Twitch Bot")
+        form = QFormLayout()
+        self.twitch_channel.setPlaceholderText("your_channel_name")
+        self.twitch_channel.setText(
+            str(self.config.cparser.value("twitchbot/channel", defaultValue="") or "")
+        )
+        self.twitch_clientid.setPlaceholderText("Client ID from dev.twitch.tv")
+        self.twitch_clientid.setText(
+            str(self.config.cparser.value("twitchbot/clientid", defaultValue="") or "")
+        )
+        self.twitch_secret.setPlaceholderText("Client secret")
+        self.twitch_secret.setEchoMode(QLineEdit.EchoMode.Password)
+        self.twitch_secret.setText(
+            str(self.config.cparser.value("twitchbot/secret", defaultValue="") or "")
+        )
+        form.addRow("Channel:", self.twitch_channel)
+        form.addRow("Client ID:", self.twitch_clientid)
+        form.addRow("Client Secret:", self.twitch_secret)
+        group.setLayout(form)
+        return group
+
+    def _make_kick_group(self) -> QGroupBox:
+        group = QGroupBox("Kick Bot")
+        form = QFormLayout()
+        self.kick_channel.setPlaceholderText("your_channel_name")
+        self.kick_channel.setText(
+            str(self.config.cparser.value("kick/channel", defaultValue="") or "")
+        )
+        self.kick_clientid.setPlaceholderText("Client ID")
+        self.kick_clientid.setText(
+            str(self.config.cparser.value("kick/clientid", defaultValue="") or "")
+        )
+        self.kick_secret.setPlaceholderText("Client secret")
+        self.kick_secret.setEchoMode(QLineEdit.EchoMode.Password)
+        self.kick_secret.setText(
+            str(self.config.cparser.value("kick/secret", defaultValue="") or "")
+        )
+        form.addRow("Channel:", self.kick_channel)
+        form.addRow("Client ID:", self.kick_clientid)
+        form.addRow("Client Secret:", self.kick_secret)
+        group.setLayout(form)
+        return group
+
+    def _make_discord_group(self) -> QGroupBox:
+        group = QGroupBox("Discord")
+        form = QFormLayout()
+        self.discord_token.setPlaceholderText("Bot token from discord.com/developers")
+        self.discord_token.setEchoMode(QLineEdit.EchoMode.Password)
+        self.discord_token.setText(
+            str(self.config.cparser.value("discord/token", defaultValue="") or "")
+        )
+        form.addRow("Bot Token:", self.discord_token)
+        group.setLayout(form)
+        return group
+
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Show only sections for outputs the user enabled on the previous page."""
+        op = self._outputs_page
+        self._obsws_group.setVisible(op.obsws_check.isChecked())
+        self._twitch_group.setVisible(op.twitch_check.isChecked())
+        self._kick_group.setVisible(op.kick_check.isChecked())
+        self._discord_group.setVisible(
+            op.discord_bot_check.isChecked() or op.discord_rp_check.isChecked()
+        )

--- a/nowplaying/installwizard/_constants.py
+++ b/nowplaying/installwizard/_constants.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Page ID constants for the installation wizard."""
+
+PAGE_WELCOME = 0
+PAGE_INPUT = 1
+PAGE_INPUT_CONFIG = 2  # dynamic: replaced per-plugin by _InputSourcePage
+PAGE_ARTISTEXTRAS = 3
+PAGE_OUTPUTS = 4
+PAGE_CONFIGURE_OUTPUTS = 5
+PAGE_FINISH = 6

--- a/nowplaying/installwizard/_finish.py
+++ b/nowplaying/installwizard/_finish.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Finish / summary page for the installation wizard."""
+
+# pylint: disable=no-name-in-module,too-few-public-methods
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget, QWizardPage
+
+
+class _FinishPage(QWizardPage):
+    """Confirmation page shown before committing settings."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setTitle("Setup Complete")
+        layout = QVBoxLayout()
+        self._summary = QLabel()
+        self._summary.setWordWrap(True)
+        self._summary.setAlignment(Qt.AlignmentFlag.AlignTop)
+        layout.addWidget(self._summary)
+        note = QLabel(
+            "\nAll settings can be adjusted later via the What's Now Playing Preferences menu."
+        )
+        note.setWordWrap(True)
+        layout.addWidget(note)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def set_summary(
+        self,
+        input_display: str,
+        extra_names: list[str],
+        output_names: list[str],
+    ) -> None:
+        """Populate the summary with chosen input, artist extras, and outputs."""
+        extras = ", ".join(extra_names) if extra_names else "none selected"
+        outputs = ", ".join(output_names) if output_names else "none selected"
+        self._summary.setText(
+            f"<b>Input source:</b>  {input_display}<br><br>"
+            f"<b>Artist information:</b>  {extras}<br><br>"
+            f"<b>Outputs:</b>  {outputs}<br><br>"
+            "Click <b>Finish</b> to save these settings and start "
+            "What's Now Playing."
+        )

--- a/nowplaying/installwizard/_input_source.py
+++ b/nowplaying/installwizard/_input_source.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Input source selection page for the installation wizard."""
+
+# pylint: disable=no-name-in-module,duplicate-code
+
+import logging
+
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QRadioButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+    QWizardPage,
+)
+
+import nowplaying.config
+from nowplaying.installwizard._constants import PAGE_ARTISTEXTRAS, PAGE_INPUT_CONFIG
+
+
+class _InputSourcePage(QWizardPage):
+    """Pick which DJ software What's Now Playing reads from."""
+
+    def __init__(
+        self, config: nowplaying.config.ConfigFile, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Select Your DJ Software")
+        self.setSubTitle(
+            "Choose the software What's Now Playing should read track "
+            "information from. Software detected on this computer is "
+            "marked with ✓."
+        )
+        # (radio_button, short_module_name, display_name)
+        self._entries: list[tuple[QRadioButton, str, str]] = []
+        self._button_group = QButtonGroup(self)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout()
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        inner_widget = QWidget()
+        inner = QVBoxLayout()
+
+        plugins = self.config.plugins.get("inputs", {})
+        first_detected: QRadioButton | None = None
+
+        for key in sorted(plugins):
+            module = plugins[key]
+            short_name = key.replace("nowplaying.inputs.", "")
+            try:
+                plugin_obj = module.Plugin(config=self.config)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.debug("wizard: could not load input plugin %s", key)
+                continue
+
+            display = plugin_obj.displayname
+            detected = False
+            try:
+                detected = bool(plugin_obj.install())
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.debug("wizard: install() failed for %s", key)
+
+            label = f"✓  {display}" if detected else f"    {display}"
+            btn = QRadioButton(label)
+            self._entries.append((btn, short_name, display))
+            self._button_group.addButton(btn)
+            inner.addWidget(btn)
+
+            if detected and first_detected is None:
+                first_detected = btn
+
+        inner.addStretch()
+        inner_widget.setLayout(inner)
+        scroll.setWidget(inner_widget)
+        outer.addWidget(scroll)
+        self.setLayout(outer)
+
+        if first_detected is not None:
+            first_detected.setChecked(True)
+        elif self._entries:
+            self._entries[0][0].setChecked(True)
+
+        self._button_group.buttonClicked.connect(self._on_selection_changed)
+
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Register the config page for whichever input is pre-selected on first show."""
+        self._on_selection_changed()
+
+    def _on_selection_changed(self) -> None:
+        """Rebuild the plugin-specific config page whenever the selection changes."""
+        wizard = self.wizard()
+        if wizard is None:
+            return
+        if PAGE_INPUT_CONFIG in wizard.pageIds():
+            wizard.removePage(PAGE_INPUT_CONFIG)
+        short_name = self.selected_short_name()
+        if not short_name:
+            return
+        module = self.config.plugins.get("inputs", {}).get(f"nowplaying.inputs.{short_name}")
+        if not module:
+            return
+        try:
+            plugin_obj = module.Plugin(config=self.config)
+            if plugin_obj.wizardpage is not None:
+                page = plugin_obj.wizardpage(config=self.config)
+                wizard.setPage(PAGE_INPUT_CONFIG, page)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.debug("wizard: no wizard page for %s", short_name)
+
+    def selected_short_name(self) -> str | None:
+        """Return the short module name of the selected input plugin."""
+        for btn, short_name, _ in self._entries:
+            if btn.isChecked():
+                return short_name
+        return None
+
+    def selected_display_name(self) -> str:
+        """Return the human-readable name of the selected input plugin."""
+        for btn, _, display in self._entries:
+            if btn.isChecked():
+                return display
+        return ""
+
+    def isComplete(self) -> bool:  # pylint: disable=invalid-name
+        """Page is complete when a radio button is selected."""
+        return self.selected_short_name() is not None
+
+    def nextId(self) -> int:  # pylint: disable=invalid-name
+        """Route to the plugin config page if one was registered, else artist extras."""
+        wizard = self.wizard()
+        if wizard and PAGE_INPUT_CONFIG in wizard.pageIds():
+            return PAGE_INPUT_CONFIG
+        return PAGE_ARTISTEXTRAS

--- a/nowplaying/installwizard/_input_source.py
+++ b/nowplaying/installwizard/_input_source.py
@@ -53,7 +53,7 @@ class _InputSourcePage(QWizardPage):
             try:
                 plugin_obj = module.Plugin(config=self.config)
             except Exception:  # pylint: disable=broad-exception-caught
-                logging.debug("wizard: could not load input plugin %s", key)
+                logging.exception("wizard: could not load input plugin %s", key)
                 continue
 
             display = plugin_obj.displayname
@@ -61,7 +61,7 @@ class _InputSourcePage(QWizardPage):
             try:
                 detected = bool(plugin_obj.install())
             except Exception:  # pylint: disable=broad-exception-caught
-                logging.debug("wizard: install() failed for %s", key)
+                logging.exception("wizard: install() failed for %s", key)
 
             label = f"✓  {display}" if detected else f"    {display}"
             btn = QRadioButton(label)
@@ -108,7 +108,7 @@ class _InputSourcePage(QWizardPage):
                 page = plugin_obj.wizardpage(config=self.config)
                 wizard.setPage(PAGE_INPUT_CONFIG, page)
         except Exception:  # pylint: disable=broad-exception-caught
-            logging.debug("wizard: no wizard page for %s", short_name)
+            logging.exception("wizard: no wizard page for %s", short_name)
 
     def selected_short_name(self) -> str | None:
         """Return the short module name of the selected input plugin."""

--- a/nowplaying/installwizard/_input_source.py
+++ b/nowplaying/installwizard/_input_source.py
@@ -86,7 +86,7 @@ class _InputSourcePage(QWizardPage):
         self._button_group.buttonClicked.connect(self._on_selection_changed)
 
     def initializePage(self) -> None:  # pylint: disable=invalid-name
-        """Register the config page for whichever input is pre-selected on first show."""
+        """Register the config page for whichever input is preselected on first show."""
         self._on_selection_changed()
 
     def _on_selection_changed(self) -> None:

--- a/nowplaying/installwizard/_outputs.py
+++ b/nowplaying/installwizard/_outputs.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Output selection page for the installation wizard."""
+
+# pylint: disable=no-name-in-module,too-few-public-methods
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+    QWizardPage,
+)
+
+import nowplaying.config
+from nowplaying.installwizard._constants import PAGE_CONFIGURE_OUTPUTS, PAGE_FINISH
+
+_ITEM_SPACING = 6
+
+
+def _add_item(layout: QVBoxLayout, check: QCheckBox, description: str) -> None:
+    """Add a checkbox + indented description label directly to layout."""
+    layout.addWidget(check)
+    desc = QLabel(description)
+    desc.setWordWrap(True)
+    desc.setIndent(20)
+    small_font = desc.font()
+    small_font.setPointSize(small_font.pointSize() - 1)
+    desc.setFont(small_font)
+    layout.addWidget(desc)
+    layout.addSpacing(_ITEM_SPACING)
+
+
+class _OutputsPage(QWizardPage):
+    """Select which output integrations to enable."""
+
+    def __init__(
+        self, config: nowplaying.config.ConfigFile, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Output Destinations")
+        self.setSubTitle(
+            "Choose where What's Now Playing should send track information. "
+            "All outputs can be enabled and configured later via Preferences."
+        )
+        self.weboverlay_check: QCheckBox
+        self.obsws_check: QCheckBox
+        self.twitch_check: QCheckBox
+        self.kick_check: QCheckBox
+        self.discord_bot_check: QCheckBox
+        self.discord_rp_check: QCheckBox
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout()
+        layout.setSpacing(0)
+
+        self.weboverlay_check = QCheckBox("Web Overlay")
+        self.weboverlay_check.setChecked(
+            bool(self.config.cparser.value("weboutput/httpenabled", type=bool, defaultValue=True))
+        )
+        _add_item(
+            layout,
+            self.weboverlay_check,
+            "Serves a browser-source page for OBS and streaming software "
+            "(http://localhost:8899 by default).",
+        )
+
+        self.obsws_check = QCheckBox("OBS WebSocket")
+        self.obsws_check.setChecked(
+            bool(self.config.cparser.value("obsws/enabled", type=bool, defaultValue=False))
+        )
+        _add_item(
+            layout,
+            self.obsws_check,
+            "Sends track data directly to OBS Studio via WebSocket. "
+            "Requires OBS 28+ with the WebSocket server enabled.",
+        )
+
+        self.twitch_check = QCheckBox("Twitch Bot")
+        self.twitch_check.setChecked(
+            bool(self.config.cparser.value("twitchbot/enabled", type=bool, defaultValue=False))
+        )
+        _add_item(
+            layout,
+            self.twitch_check,
+            "Posts now-playing announcements to your Twitch chat "
+            "and optionally updates your stream title.",
+        )
+
+        self.kick_check = QCheckBox("Kick Bot")
+        self.kick_check.setChecked(
+            bool(self.config.cparser.value("kick/enabled", type=bool, defaultValue=False))
+        )
+        _add_item(
+            layout,
+            self.kick_check,
+            "Posts now-playing announcements to your Kick chat.",
+        )
+
+        self.discord_bot_check = QCheckBox("Discord Bot")
+        self.discord_bot_check.setChecked(
+            bool(self.config.cparser.value("discord/bot_enabled", type=bool, defaultValue=False))
+        )
+        _add_item(
+            layout,
+            self.discord_bot_check,
+            "Posts now-playing updates to a Discord channel via a bot token.",
+        )
+
+        self.discord_rp_check = QCheckBox("Discord Rich Presence")
+        self.discord_rp_check.setChecked(
+            bool(
+                self.config.cparser.value(
+                    "discord/richpresence_enabled", type=bool, defaultValue=False
+                )
+            )
+        )
+        _add_item(
+            layout,
+            self.discord_rp_check,
+            "Shows now-playing information in your Discord profile status.",
+        )
+
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def needs_credentials(self) -> bool:
+        """True when at least one credential-needing output is enabled."""
+        return (
+            self.obsws_check.isChecked()
+            or self.twitch_check.isChecked()
+            or self.kick_check.isChecked()
+            or self.discord_bot_check.isChecked()
+            or self.discord_rp_check.isChecked()
+        )
+
+    def enabled_display_names(self) -> list[str]:
+        """Return human-readable names for all enabled outputs."""
+        names = []
+        if self.weboverlay_check.isChecked():
+            names.append("Web Overlay")
+        if self.obsws_check.isChecked():
+            names.append("OBS WebSocket")
+        if self.twitch_check.isChecked():
+            names.append("Twitch Bot")
+        if self.kick_check.isChecked():
+            names.append("Kick Bot")
+        if self.discord_bot_check.isChecked():
+            names.append("Discord Bot")
+        if self.discord_rp_check.isChecked():
+            names.append("Discord Rich Presence")
+        return names
+
+    def nextId(self) -> int:  # pylint: disable=invalid-name
+        """Skip credentials page when only Web Overlay (no credentials) is selected."""
+        if self.needs_credentials():
+            return PAGE_CONFIGURE_OUTPUTS
+        return PAGE_FINISH

--- a/nowplaying/installwizard/_welcome.py
+++ b/nowplaying/installwizard/_welcome.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Welcome page for the installation wizard."""
+
+# pylint: disable=no-name-in-module,too-few-public-methods
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget, QWizardPage
+
+
+class _WelcomePage(QWizardPage):
+    """Introductory page shown at wizard start."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setTitle("Welcome to What's Now Playing")
+        layout = QVBoxLayout()
+        intro = QLabel(
+            "This wizard will help you get started quickly.\n\n"
+            "You will choose your DJ software source, configure "
+            "artist information services, and select outputs. "
+            "Everything can be changed later via Preferences.\n\n"
+            "Click Next to begin."
+        )
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
+        layout.addStretch()
+        self.setLayout(layout)

--- a/nowplaying/plugin.py
+++ b/nowplaying/plugin.py
@@ -4,6 +4,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+import nowplaying.types
+
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
     from PySide6.QtWidgets import QWidget  # pylint: disable=import-error, no-name-in-module
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
     import nowplaying.config
 
 
-class WNPBasePlugin:
+class WNPBasePlugin:  # pylint: disable=too-many-instance-attributes
     """base class of plugins"""
 
     def __init__(
@@ -26,6 +28,7 @@ class WNPBasePlugin:
         self.uihelp: object | None = None
         self.displayname: str = ""
         self.priority: int = 0
+        self.wizardpage: type[nowplaying.types.WizardPage] | None = None
 
         if qsettings:
             self.defaults(qsettings)

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QSystemTrayIcon,
 )
 
+import nowplaying.installwizard
 import nowplaying.upgrade
 import nowplaying.upgrades
 import nowplaying.upgrades.background
@@ -190,6 +191,11 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             )
         nowplaying.utils.qt.focus_window(self._obs_export_dialog)
 
+    def _show_setup_wizard(self) -> None:
+        """Open the setup wizard, re-running it regardless of initialized state."""
+        wizard = nowplaying.installwizard.InstallWizard(self.config)
+        wizard.exec()
+
     def _show_settings(self) -> None:
         """Show settings window and bring it to the front."""
         if not self.settingswindow:
@@ -217,6 +223,10 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.settings_action = QAction("Settings")
         self.settings_action.triggered.connect(self._show_settings)
         self.menu.addAction(self.settings_action)
+
+        self.wizard_action = QAction("Setup Wizard...")
+        self.wizard_action.triggered.connect(self._show_setup_wizard)
+        self.menu.addAction(self.wizard_action)
 
         self.obs_export_action = QAction("Export for OBS...")
         self.obs_export_action.triggered.connect(self._show_obs_export)

--- a/nowplaying/types.py
+++ b/nowplaying/types.py
@@ -3,6 +3,8 @@
 
 from typing import TYPE_CHECKING, TypedDict
 
+from PySide6.QtWidgets import QWizardPage  # pylint: disable=no-name-in-module
+
 if TYPE_CHECKING:
     import nowplaying.artistextras
     import nowplaying.inputs
@@ -176,3 +178,15 @@ class TrackRequestSetting(TypedDict, total=False):
     displayname: str
     playlist: str
     userimage: bytes
+
+
+class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
+    """Base class for plugin-provided first-run wizard pages.
+
+    Plugin files define a subclass of WizardPage, then set
+    self.wizardpage = _TheirPageClass in Plugin.__init__().
+    The install wizard instantiates it as plugin.wizardpage(config=...).
+    """
+
+    def commit(self) -> None:
+        """Write this page's settings to QSettings. Called when wizard is accepted."""


### PR DESCRIPTION
6-page QWizard shown on fresh install: Welcome, Input Source (with auto-detection), Artist Extras, Outputs, Configure Outputs, Finish. Integrates into system tray as 'Setup Wizard' menu item.

WizardPage base class added to nowplaying/types.py; plugins expose self.wizardpage class attr that the wizard instantiates dynamically for plugin-specific config pages (PAGE_INPUT_CONFIG slot).

Includes: EarShot app detection fix, Traktor port type fix, and requires_apikey base attr on ArtistExtrasPlugin.

## Summary by Sourcery

Introduce a first-run setup wizard that guides users through input selection, artist info services, and output destinations, with tray menu access and persisted configuration.

New Features:
- Add a multi-page installation wizard for fresh installs, including input source, artist extras, outputs, and summary pages.
- Allow plugins to provide custom wizard configuration pages via a shared WizardPage base class.
- Expose a 'Setup Wizard' entry in the system tray menu and automatically launch the wizard on first run.

Bug Fixes:
- Fix EarShot input detection on macOS by checking for the WNP EarShot.app in /Applications.
- Correct Traktor input configuration to store the port value as a string.
- Clarify which artist extras plugins require an API key and mark free services accordingly.

Enhancements:
- Mark artistextras plugins with a requires_apikey attribute to drive wizard defaults and UI.