### PR TITLE
feat: per-plugin first-run wizard configuration pages

### DIFF
--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -47,7 +47,15 @@ import threading
 import time
 from typing import TYPE_CHECKING
 
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
@@ -57,11 +65,11 @@ import nowplaying.djaypro.mediadb
 import nowplaying.utils.sqlite
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
+import nowplaying.types
 from nowplaying.types import TrackMetadata
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
     import nowplaying.uihelp
@@ -74,6 +82,46 @@ _ANALYZED_DATA_RETRY_DEFAULT = 0.5
 _COREDATA_EPOCH = datetime.datetime(2001, 1, 1, tzinfo=datetime.timezone.utc)
 
 
+class _DjayProWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for djay Pro library directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("djay Pro Setup")
+        self.setSubTitle("Confirm the location of your djay Pro media library.")
+
+        self._dir_edit = QLineEdit()
+        self._dir_edit.setPlaceholderText("djay Pro library directory…")
+        browse_btn = QPushButton("Browse…")
+        browse_btn.clicked.connect(self._browse)
+
+        row = QHBoxLayout()
+        row.addWidget(self._dir_edit)
+        row.addWidget(browse_btn)
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("djay Pro library directory:"))
+        layout.addLayout(row)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._dir_edit.setText(str(config.cparser.value("djaypro/directory", defaultValue="")))
+
+    def _browse(self) -> None:
+        start = self._dir_edit.text() or str(pathlib.Path.home())
+        directory = QFileDialog.getExistingDirectory(self, "Select djay Pro Library Folder", start)
+        if directory:
+            self._dir_edit.setText(directory)
+
+    def commit(self) -> None:
+        """Write the djay Pro library path to config."""
+        if directory := self._dir_edit.text().strip():
+            self.config.cparser.setValue("djaypro/directory", directory)
+
+
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     """handler for djay Pro"""
 
@@ -84,6 +132,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "djay Pro"
+        self.wizardpage = _DjayProWizardPage
         self.event_handler = None
         self.observer = None
         self.djaypro_dir = ""

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -40,7 +40,15 @@ import sqlite3
 from typing import TYPE_CHECKING
 
 import aiosqlite
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
@@ -48,14 +56,54 @@ from watchdog.observers.polling import PollingObserver
 import nowplaying.utils
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
+import nowplaying.types
 from nowplaying.types import TrackMetadata
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
     import nowplaying.uihelp
+
+
+class _DjucedWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for DJUCED library directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("DJUCED Setup")
+        self.setSubTitle("Confirm the location of your DJUCED library folder.")
+
+        self._dir_edit = QLineEdit()
+        self._dir_edit.setPlaceholderText("DJUCED library directory…")
+        browse_btn = QPushButton("Browse…")
+        browse_btn.clicked.connect(self._browse)
+
+        row = QHBoxLayout()
+        row.addWidget(self._dir_edit)
+        row.addWidget(browse_btn)
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("DJUCED library directory:"))
+        layout.addLayout(row)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._dir_edit.setText(str(config.cparser.value("djuced/directory", defaultValue="")))
+
+    def _browse(self) -> None:
+        start = self._dir_edit.text() or str(pathlib.Path.home())
+        directory = QFileDialog.getExistingDirectory(self, "Select DJUCED Library Folder", start)
+        if directory:
+            self._dir_edit.setText(directory)
+
+    def commit(self) -> None:
+        """Write the DJUCED library path to config."""
+        if directory := self._dir_edit.text().strip():
+            self.config.cparser.setValue("djuced/directory", directory)
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -71,6 +119,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "DJUCED"
+        self.wizardpage = _DjucedWizardPage
         self.mixmode = "newest"
         self.event_handler = None
         self.observer = None

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -12,9 +12,15 @@ import urllib.parse
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QFormLayout,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
 
@@ -30,6 +36,7 @@ logging.config.dictConfig(
 
 # from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
+import nowplaying.types
 from nowplaying.types import TrackMetadata
 
 METADATALIST: list[str] = ["artist", "title", "album", "key", "filename", "bpm"]
@@ -218,6 +225,40 @@ class IcecastProtocol(asyncio.Protocol):
             self.metadata_callback(self._current_metadata.copy())
 
 
+class _IcecastWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Icecast SOURCE protocol port configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Icecast / SOURCE Protocol")
+        self.setSubTitle(
+            "Set the port What's Now Playing will listen on for Icecast metadata. "
+            "Configure your DJ software to broadcast to this port."
+        )
+
+        self._port_edit = QLineEdit()
+        self._port_edit.setPlaceholderText("8000")
+        self._port_edit.setMaximumWidth(120)
+        self._port_edit.setText(
+            config.cparser.value("icecast/port", type=str, defaultValue="8000")
+        )
+
+        form = QFormLayout()
+        form.addRow("Icecast port:", self._port_edit)
+
+        layout = QVBoxLayout()
+        layout.addLayout(form)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def commit(self) -> None:
+        """Write the Icecast port to config."""
+        self.config.cparser.setValue("icecast/port", self._port_edit.text().strip() or "8000")
+
+
 class Plugin(InputPlugin):
     """base class of input plugins"""
 
@@ -229,6 +270,7 @@ class Plugin(InputPlugin):
         """no custom init"""
         super().__init__(config=config, qsettings=qsettings)
         self.displayname: str = "Icecast"
+        self.wizardpage = _IcecastWizardPage
         self.server: asyncio.Server | None = None
         self.mode: str | None = None
         self.lastmetadata: dict[str, str] = {}

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -10,15 +10,72 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 import lxml.etree
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from nowplaying.inputs import InputPlugin
+import nowplaying.types
 from nowplaying.types import TrackMetadata
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
+
+
+class _JRiverWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for JRiver Media Center connection configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("JRiver Media Center")
+        self.setSubTitle(
+            "Enter the address of your JRiver Media Center server. "
+            "Username and password are optional."
+        )
+
+        self._host_edit = QLineEdit()
+        self._host_edit.setPlaceholderText("localhost or IP address")
+        self._port_edit = QLineEdit()
+        self._port_edit.setPlaceholderText("52199")
+        self._port_edit.setMaximumWidth(100)
+        self._user_edit = QLineEdit()
+        self._user_edit.setPlaceholderText("optional")
+        self._pass_edit = QLineEdit()
+        self._pass_edit.setPlaceholderText("optional")
+        self._pass_edit.setEchoMode(QLineEdit.EchoMode.Password)
+
+        form = QFormLayout()
+        form.addRow("Host / IP:", self._host_edit)
+        form.addRow("Port:", self._port_edit)
+        form.addRow(QLabel(""))
+        form.addRow("Username:", self._user_edit)
+        form.addRow("Password:", self._pass_edit)
+
+        layout = QVBoxLayout()
+        layout.addLayout(form)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._host_edit.setText(str(config.cparser.value("jriver/host", defaultValue="")))
+        self._port_edit.setText(str(config.cparser.value("jriver/port", defaultValue="52199")))
+        self._user_edit.setText(str(config.cparser.value("jriver/username", defaultValue="")))
+        self._pass_edit.setText(str(config.cparser.value("jriver/password", defaultValue="")))
+
+    def commit(self) -> None:
+        """Write JRiver connection settings to config."""
+        self.config.cparser.setValue("jriver/host", self._host_edit.text().strip())
+        self.config.cparser.setValue("jriver/port", self._port_edit.text().strip() or "52199")
+        self.config.cparser.setValue("jriver/username", self._user_edit.text().strip())
+        self.config.cparser.setValue("jriver/password", self._pass_edit.text())
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -31,6 +88,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname: str = "JRiver"
+        self.wizardpage = _JRiverWizardPage
         self.host: str | None = None
         self.port: str | None = None
         self.username: str | None = None

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -7,14 +7,50 @@ import pathlib
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QWidget  # pylint: disable=import-error, no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 import nowplaying.db
 from nowplaying.inputs import InputPlugin
+import nowplaying.types
 from nowplaying.types import TrackMetadata
 
 if TYPE_CHECKING:
     import nowplaying.config
+
+
+class _RemoteWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """Informational wizard page for the Remote (multi-PC) input plugin."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Remote / Multi-PC Setup")
+        self.setSubTitle(
+            "What's Now Playing will receive track data from another PC "
+            "running WNP as the primary DJ system."
+        )
+        info = QLabel(
+            "No file path to configure here — the remote database is created "
+            "automatically.\n\n"
+            "On your primary DJ PC, install What's Now Playing, set it up with "
+            "your DJ software, and enable 'Remote Source' in its Outputs "
+            "settings to point it at this machine.\n\n"
+            "Click Next to continue."
+        )
+        info.setWordWrap(True)
+        layout = QVBoxLayout()
+        layout.addWidget(info)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def commit(self) -> None:
+        """Remote has no configurable paths — nothing to write."""
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -27,6 +63,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Remote"
+        self.wizardpage = _RemoteWizardPage
         if os.environ.get("WNP_REMOTEDB_TEST_FILE"):
             self.remotedbfile = pathlib.Path(os.environ["WNP_REMOTEDB_TEST_FILE"])
         else:

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -12,7 +12,15 @@ from typing import TYPE_CHECKING
 
 import aiosqlite  # pylint: disable=import-error
 from PySide6.QtCore import QStandardPaths  # pylint: disable=import-error, no-name-in-module
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=import-error, no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 logging.config.dictConfig(
     {
@@ -23,6 +31,7 @@ logging.config.dictConfig(
 
 # pylint: disable=wrong-import-position
 
+import nowplaying.types
 import nowplaying.utils.xml
 from nowplaying.db import LISTFIELDS
 from nowplaying.exceptions import PluginVerifyError
@@ -130,13 +139,56 @@ class TraktorSAXHandler(xml.sax.ContentHandler):
                 self.current_playlist = None
 
 
-class Plugin(IcecastPlugin):
+class _TraktorWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Traktor collection file configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Traktor Setup")
+        self.setSubTitle("Confirm the location of your Traktor collection file.")
+
+        self._path_edit = QLineEdit()
+        self._path_edit.setPlaceholderText("Path to collection.nml…")
+        browse_btn = QPushButton("Browse…")
+        browse_btn.clicked.connect(self._browse)
+
+        row = QHBoxLayout()
+        row.addWidget(self._path_edit)
+        row.addWidget(browse_btn)
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("Collection file (collection.nml):"))
+        layout.addLayout(row)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        existing = config.cparser.value("traktor/collections", defaultValue="")
+        if existing:
+            self._path_edit.setText(str(existing))
+
+    def _browse(self) -> None:
+        start = self._path_edit.text() or str(pathlib.Path.home())
+        filename, _ = QFileDialog.getOpenFileName(self, "Open Traktor Collection", start, "*.nml")
+        if filename:
+            self._path_edit.setText(filename)
+
+    def commit(self) -> None:
+        """Write the collection path to config."""
+        if path := self._path_edit.text().strip():
+            self.config.cparser.setValue("traktor/collections", path)
+
+
+class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
     """base class of input plugins"""
 
     def __init__(self, config: "nowplaying.config.ConfigFile | None" = None, qsettings=None):
         """no custom init"""
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Traktor"
+        self.wizardpage = _TraktorWizardPage
         self.databasefile = pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]
         ).joinpath("traktor", "traktor.db")
@@ -219,7 +271,9 @@ class Plugin(IcecastPlugin):
 
     def load_settingsui(self, qwidget):
         """load values from config and populate page"""
-        qwidget.port_lineedit.setText(self.config.cparser.value("traktor/port"))
+        qwidget.port_lineedit.setText(
+            self.config.cparser.value("traktor/port", type=str, defaultValue="8000")
+        )
         qwidget.traktor_collection_lineedit.setText(
             self.config.cparser.value("traktor/collections")
         )

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -12,8 +12,17 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
+import nowplaying.types
 import nowplaying.utils
 import nowplaying.utils.sqlite
 import nowplaying.utils.xml
@@ -160,6 +169,72 @@ class VirtualDJFolderSAXHandler(xml.sax.ContentHandler):
                 self.content.append(entry)
 
 
+class _VirtualDJWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for VirtualDJ directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("VirtualDJ Setup")
+        self.setSubTitle("Confirm the locations of your VirtualDJ history and playlists folders.")
+
+        self._history_edit = QLineEdit()
+        self._history_edit.setPlaceholderText("VirtualDJ history directory…")
+        history_btn = QPushButton("Browse…")
+        history_btn.clicked.connect(self._browse_history)
+
+        self._playlist_edit = QLineEdit()
+        self._playlist_edit.setPlaceholderText("VirtualDJ playlists directory…")
+        playlist_btn = QPushButton("Browse…")
+        playlist_btn.clicked.connect(self._browse_playlists)
+
+        history_row = QHBoxLayout()
+        history_row.addWidget(self._history_edit)
+        history_row.addWidget(history_btn)
+
+        playlist_row = QHBoxLayout()
+        playlist_row.addWidget(self._playlist_edit)
+        playlist_row.addWidget(playlist_btn)
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("History directory:"))
+        layout.addLayout(history_row)
+        layout.addWidget(QLabel("Playlists directory:"))
+        layout.addLayout(playlist_row)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._history_edit.setText(str(config.cparser.value("virtualdj/history", defaultValue="")))
+        self._playlist_edit.setText(
+            str(config.cparser.value("virtualdj/playlists", defaultValue=""))
+        )
+
+    def _browse_history(self) -> None:
+        start = self._history_edit.text() or str(pathlib.Path.home())
+        directory = QFileDialog.getExistingDirectory(
+            self, "Select VirtualDJ History Folder", start
+        )
+        if directory:
+            self._history_edit.setText(directory)
+
+    def _browse_playlists(self) -> None:
+        start = self._playlist_edit.text() or str(pathlib.Path.home())
+        directory = QFileDialog.getExistingDirectory(
+            self, "Select VirtualDJ Playlists Folder", start
+        )
+        if directory:
+            self._playlist_edit.setText(directory)
+
+    def commit(self) -> None:
+        """Write the VirtualDJ directory paths to config."""
+        if hist := self._history_edit.text().strip():
+            self.config.cparser.setValue("virtualdj/history", hist)
+        if plists := self._playlist_edit.text().strip():
+            self.config.cparser.setValue("virtualdj/playlists", plists)
+
+
 class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """handler for NowPlaying"""
 
@@ -168,6 +243,7 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
     ):
         super().__init__(config=config, m3udir=m3udir, qsettings=qsettings)
         self.displayname = "VirtualDJ"
+        self.wizardpage = _VirtualDJWizardPage
         # Separate databases for different data sources
         self.songs_databasefile = pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -16,8 +16,17 @@ from typing import TYPE_CHECKING
 import aiohttp
 import aiosqlite
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QButtonGroup,
+    QLabel,
+    QLineEdit,
+    QRadioButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 import nowplaying.inputs
+import nowplaying.types
 import nowplaying.utils.sqlite
 from nowplaying.types import TrackMetadata
 
@@ -27,9 +36,63 @@ from .remote import SeratoRemoteHandler
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
+
+
+class _SeratoWizardPage(nowplaying.types.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Serato DJ local/remote mode configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Serato DJ Setup")
+        self.setSubTitle(
+            "Choose whether What's Now Playing reads from Serato on this "
+            "computer or from a remote Serato Live Playlists URL."
+        )
+
+        self._local_radio = QRadioButton("Local — read from this computer's Serato library")
+        self._remote_radio = QRadioButton("Remote — use Serato Live Playlists URL")
+
+        self._button_group = QButtonGroup(self)
+        self._button_group.addButton(self._local_radio)
+        self._button_group.addButton(self._remote_radio)
+
+        self._url_label = QLabel("Live Playlists URL:")
+        self._url_edit = QLineEdit()
+        self._url_edit.setPlaceholderText("https://serato.com/playlists/…")
+
+        self._local_radio.toggled.connect(self._on_mode_changed)
+
+        local_mode = config.cparser.value("serato4/local", type=bool, defaultValue=True)
+        if local_mode:
+            self._local_radio.setChecked(True)
+        else:
+            self._remote_radio.setChecked(True)
+        self._url_edit.setText(str(config.cparser.value("serato4/url", defaultValue="")))
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._local_radio)
+        layout.addWidget(self._remote_radio)
+        layout.addSpacing(8)
+        layout.addWidget(self._url_label)
+        layout.addWidget(self._url_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+        self._on_mode_changed()
+
+    def _on_mode_changed(self) -> None:
+        remote = self._remote_radio.isChecked()
+        self._url_label.setVisible(remote)
+        self._url_edit.setVisible(remote)
+
+    def commit(self) -> None:
+        """Write Serato mode and URL to config."""
+        self.config.cparser.setValue("serato4/local", self._local_radio.isChecked())
+        self.config.cparser.setValue("serato4/url", self._url_edit.text().strip())
 
 
 class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -43,6 +106,7 @@ class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instanc
         super().__init__(config=config, qsettings=qsettings)
 
         self.displayname = "Serato DJ"
+        self.wizardpage = _SeratoWizardPage
         self.handler: Serato4Handler | None = None
         self.remote_handler: SeratoRemoteHandler | None = None
         self.serato_lib_path: pathlib.Path | None = None


### PR DESCRIPTION
Adds _XxxWizardPage classes to all key input plugins. The install wizard dynamically inserts the page for whichever input the user selects on the Input Source page.

Traktor: .nml collection path picker
Icecast: port number field
Remote: informational-only (no configurable paths)
VirtualDJ: history + playlists directory pickers
DJUCED: library directory picker
djay Pro: media library directory picker
JRiver: host / port / username / password form
Serato: local/remote radio toggle + Live Playlists URL field

## Summary by Sourcery

Add first-run configuration wizard pages for key input plugins so users can set paths and connection details when selecting an input source.

New Features:
- Introduce first-run wizard pages for VirtualDJ, Traktor, djay Pro, DJUCED, JRiver, Icecast, Serato DJ, and Remote input plugins to capture plugin-specific configuration.
- Allow users to configure Traktor collection file, VirtualDJ history/playlists directories, djay Pro and DJUCED library directories, and JRiver host/port/credentials during the install wizard.
- Add wizard-driven setup for Icecast SOURCE port and Serato DJ local vs remote mode including Serato Live Playlists URL.
- Provide an informational-only wizard page for the Remote input explaining multi-PC setup without requiring path configuration.

Enhancements:
- Set a default Icecast and Traktor port value when editing settings to reduce manual configuration.