### PR TITLE
feat: per-plugin wizard pages with PathEdit helper

### DIFF
--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -92,6 +92,7 @@ class _DjayProWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
         self._dir_edit = nowplaying.wizard.WizardPage.PathEdit(
             "Select djay Pro Library Folder",
             placeholder="djay Pro library directory…",
+            startdir=config.userdocs.parent.joinpath("Music", "djay"),
         )
 
         layout = QVBoxLayout()

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -47,7 +47,11 @@ import threading
 import time
 from typing import TYPE_CHECKING
 
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
@@ -58,10 +62,10 @@ import nowplaying.utils.sqlite
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
+import nowplaying.wizard
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
     import nowplaying.uihelp
@@ -74,6 +78,35 @@ _ANALYZED_DATA_RETRY_DEFAULT = 0.5
 _COREDATA_EPOCH = datetime.datetime(2001, 1, 1, tzinfo=datetime.timezone.utc)
 
 
+class _DjayProWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for djay Pro library directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("djay Pro Setup")
+        self.setSubTitle("Confirm the location of your djay Pro media library.")
+
+        self._dir_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Select djay Pro Library Folder",
+            placeholder="djay Pro library directory…",
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("djay Pro library directory:"))
+        layout.addWidget(self._dir_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._dir_edit.setText(str(config.cparser.value("djaypro/directory", defaultValue="")))
+
+    def commit(self) -> None:
+        """Write the djay Pro library path to config."""
+        self.config.cparser.setValue("djaypro/directory", self._dir_edit.text().strip())
+
+
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     """handler for djay Pro"""
 
@@ -84,6 +117,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "djay Pro"
+        self.wizardpage = _DjayProWizardPage
         self.event_handler = None
         self.observer = None
         self.djaypro_dir = ""
@@ -833,10 +867,8 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     def on_djaypro_dir_button(self):
         """open file browser to set djay Pro directory"""
-        startdir = self.config.cparser.value("djaypro/directory")
-        if not startdir:
-            # Use same base path as defaults() and install(): Music/djay
-            music_dir = self.config.userdocs.parent.joinpath("Music")
-            startdir = str(music_dir.joinpath("djay"))
-        if dirname := QFileDialog.getExistingDirectory(self.qwidget, "Select directory", startdir):
-            self.qwidget.dir_lineedit.setText(dirname)
+        music_dir = self.config.userdocs.parent.joinpath("Music")
+        self.uihelp.dir_picker_lineedit(
+            self.qwidget.dir_lineedit,
+            startdir=music_dir.joinpath("djay"),
+        )

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -40,7 +40,11 @@ import sqlite3
 from typing import TYPE_CHECKING
 
 import aiosqlite
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
@@ -49,13 +53,42 @@ import nowplaying.utils
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
+import nowplaying.wizard
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
     import nowplaying.uihelp
+
+
+class _DjucedWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for DJUCED library directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("DJUCED Setup")
+        self.setSubTitle("Confirm the location of your DJUCED library folder.")
+
+        self._dir_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Select DJUCED Library Folder",
+            placeholder="DJUCED library directory…",
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("DJUCED library directory:"))
+        layout.addWidget(self._dir_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._dir_edit.setText(str(config.cparser.value("djuced/directory", defaultValue="")))
+
+    def commit(self) -> None:
+        """Write the DJUCED library path to config."""
+        self.config.cparser.setValue("djuced/directory", self._dir_edit.text().strip())
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -71,6 +104,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "DJUCED"
+        self.wizardpage = _DjucedWizardPage
         self.mixmode = "newest"
         self.event_handler = None
         self.observer = None
@@ -524,12 +558,10 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     def on_djuced_dir_button(self):
         """filename button clicked action"""
-        if self.qwidget.dir_lineedit.text():
-            startdir = self.qwidget.dir_lineedit.text()
-        else:
-            startdir = str(self.config.userdocs.joinpath("DJUCED"))
-        if dirname := QFileDialog.getExistingDirectory(self.qwidget, "Select directory", startdir):
-            self.qwidget.dir_lineedit.setText(dirname)
+        self.uihelp.dir_picker_lineedit(
+            self.qwidget.dir_lineedit,
+            startdir=self.config.userdocs.joinpath("DJUCED"),
+        )
 
     def defaults(self, qsettings: "QSettings"):
         """(re-)set the default configuration values for this plugin"""

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -76,6 +76,7 @@ class _DjucedWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-fe
         self._dir_edit = nowplaying.wizard.WizardPage.PathEdit(
             "Select DJUCED Library Folder",
             placeholder="DJUCED library directory…",
+            startdir=config.userdocs.joinpath("DJUCED"),
         )
 
         layout = QVBoxLayout()

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -12,9 +12,16 @@ import urllib.parse
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QFormLayout,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
 
@@ -31,6 +38,7 @@ logging.config.dictConfig(
 # from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
+import nowplaying.wizard
 
 METADATALIST: list[str] = ["artist", "title", "album", "key", "filename", "bpm"]
 
@@ -218,6 +226,41 @@ class IcecastProtocol(asyncio.Protocol):
             self.metadata_callback(self._current_metadata.copy())
 
 
+class _IcecastWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Icecast SOURCE protocol port configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Icecast / SOURCE Protocol")
+        self.setSubTitle(
+            "Set the port What's Now Playing will listen on for Icecast metadata. "
+            "Configure your DJ software to broadcast to this port."
+        )
+
+        self._port_edit = QLineEdit()
+        self._port_edit.setPlaceholderText("8000")
+        self._port_edit.setMaximumWidth(120)
+        self._port_edit.setValidator(QIntValidator(1, 65535, self))
+        self._port_edit.setText(
+            config.cparser.value("icecast/port", type=str, defaultValue="8000")
+        )
+
+        form = QFormLayout()
+        form.addRow("Icecast port:", self._port_edit)
+
+        layout = QVBoxLayout()
+        layout.addLayout(form)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def commit(self) -> None:
+        """Write the Icecast port to config."""
+        self.config.cparser.setValue("icecast/port", self._port_edit.text().strip() or "8000")
+
+
 class Plugin(InputPlugin):
     """base class of input plugins"""
 
@@ -229,6 +272,7 @@ class Plugin(InputPlugin):
         """no custom init"""
         super().__init__(config=config, qsettings=qsettings)
         self.displayname: str = "Icecast"
+        self.wizardpage = _IcecastWizardPage
         self.server: asyncio.Server | None = None
         self.mode: str | None = None
         self.lastmetadata: dict[str, str] = {}

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -12,10 +12,8 @@ import urllib.parse
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
     QFormLayout,
-    QLineEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -240,10 +238,7 @@ class _IcecastWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
             "Configure your DJ software to broadcast to this port."
         )
 
-        self._port_edit = QLineEdit()
-        self._port_edit.setPlaceholderText("8000")
-        self._port_edit.setMaximumWidth(120)
-        self._port_edit.setValidator(QIntValidator(1, 65535, self))
+        self._port_edit = nowplaying.wizard.WizardPage.port_edit("8000")
         self._port_edit.setText(
             config.cparser.value("icecast/port", type=str, defaultValue="8000")
         )

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -10,15 +10,74 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 import lxml.etree
+from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
+import nowplaying.wizard
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
+
+
+class _JRiverWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for JRiver Media Center connection configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("JRiver Media Center")
+        self.setSubTitle(
+            "Enter the address of your JRiver Media Center server. "
+            "Username and password are optional."
+        )
+
+        self._host_edit = QLineEdit()
+        self._host_edit.setPlaceholderText("localhost or IP address")
+        self._port_edit = QLineEdit()
+        self._port_edit.setPlaceholderText("52199")
+        self._port_edit.setMaximumWidth(100)
+        self._port_edit.setValidator(QIntValidator(1, 65535, self))
+        self._user_edit = QLineEdit()
+        self._user_edit.setPlaceholderText("optional")
+        self._pass_edit = QLineEdit()
+        self._pass_edit.setPlaceholderText("optional")
+        self._pass_edit.setEchoMode(QLineEdit.EchoMode.Password)
+
+        form = QFormLayout()
+        form.addRow("Host / IP:", self._host_edit)
+        form.addRow("Port:", self._port_edit)
+        form.addRow(QLabel(""))
+        form.addRow("Username:", self._user_edit)
+        form.addRow("Password:", self._pass_edit)
+
+        layout = QVBoxLayout()
+        layout.addLayout(form)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._host_edit.setText(str(config.cparser.value("jriver/host", defaultValue="")))
+        self._port_edit.setText(str(config.cparser.value("jriver/port", defaultValue="52199")))
+        self._user_edit.setText(str(config.cparser.value("jriver/username", defaultValue="")))
+        self._pass_edit.setText(str(config.cparser.value("jriver/password", defaultValue="")))
+
+    def commit(self) -> None:
+        """Write JRiver connection settings to config."""
+        self.config.cparser.setValue("jriver/host", self._host_edit.text().strip())
+        self.config.cparser.setValue("jriver/port", self._port_edit.text().strip() or "52199")
+        self.config.cparser.setValue("jriver/username", self._user_edit.text().strip())
+        self.config.cparser.setValue("jriver/password", self._pass_edit.text())
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -31,6 +90,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname: str = "JRiver"
+        self.wizardpage = _JRiverWizardPage
         self.host: str | None = None
         self.port: str | None = None
         self.username: str | None = None

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 import lxml.etree
-from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QFormLayout,
     QLabel,
@@ -45,10 +44,7 @@ class _JRiverWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-fe
 
         self._host_edit = QLineEdit()
         self._host_edit.setPlaceholderText("localhost or IP address")
-        self._port_edit = QLineEdit()
-        self._port_edit.setPlaceholderText("52199")
-        self._port_edit.setMaximumWidth(100)
-        self._port_edit.setValidator(QIntValidator(1, 65535, self))
+        self._port_edit = nowplaying.wizard.WizardPage.port_edit("52199", width=100)
         self._user_edit = QLineEdit()
         self._user_edit.setPlaceholderText("optional")
         self._pass_edit = QLineEdit()

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -7,14 +7,50 @@ import pathlib
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QWidget  # pylint: disable=import-error, no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 import nowplaying.db
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
+import nowplaying.wizard
 
 if TYPE_CHECKING:
     import nowplaying.config
+
+
+class _RemoteWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """Informational wizard page for the Remote (multi-PC) input plugin."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Remote / Multi-PC Setup")
+        self.setSubTitle(
+            "What's Now Playing will receive track data from another PC "
+            "running WNP as the primary DJ system."
+        )
+        info = QLabel(
+            "No file path to configure here — the remote database is created "
+            "automatically.\n\n"
+            "On your primary DJ PC, install What's Now Playing, set it up with "
+            "your DJ software, and enable 'Remote Source' in its Outputs "
+            "settings to point it at this machine.\n\n"
+            "Click Next to continue."
+        )
+        info.setWordWrap(True)
+        layout = QVBoxLayout()
+        layout.addWidget(info)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def commit(self) -> None:
+        """Remote has no configurable paths — nothing to write."""
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -27,6 +63,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Remote"
+        self.wizardpage = _RemoteWizardPage
         if os.environ.get("WNP_REMOTEDB_TEST_FILE"):
             self.remotedbfile = pathlib.Path(os.environ["WNP_REMOTEDB_TEST_FILE"])
         else:

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -26,10 +26,11 @@ class _RemoteWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-fe
     """Informational wizard page for the Remote (multi-PC) input plugin."""
 
     def __init__(
-        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+        self,
+        config: "nowplaying.config.ConfigFile",  # pylint: disable=unused-argument
+        parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
-        self.config = config
         self.setTitle("Remote / Multi-PC Setup")
         self.setSubTitle(
             "What's Now Playing will receive track data from another PC "

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -150,6 +150,7 @@ class _TraktorWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
             "Open Traktor Collection",
             placeholder="Path to collection.nml…",
             file_filter="*.nml",
+            startdir=config.userdocs.joinpath("Native Instruments"),
         )
 
         layout = QVBoxLayout()

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING
 
 import aiosqlite  # pylint: disable=import-error
 from PySide6.QtCore import QStandardPaths  # pylint: disable=import-error, no-name-in-module
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=import-error, no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 logging.config.dictConfig(
     {
@@ -24,6 +28,7 @@ logging.config.dictConfig(
 # pylint: disable=wrong-import-position
 
 import nowplaying.utils.xml
+import nowplaying.wizard
 from nowplaying.db import LISTFIELDS
 from nowplaying.exceptions import PluginVerifyError
 
@@ -130,13 +135,44 @@ class TraktorSAXHandler(xml.sax.ContentHandler):
                 self.current_playlist = None
 
 
-class Plugin(IcecastPlugin):
+class _TraktorWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Traktor collection file configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Traktor Setup")
+        self.setSubTitle("Confirm the location of your Traktor collection file.")
+
+        self._path_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Open Traktor Collection",
+            placeholder="Path to collection.nml…",
+            file_filter="*.nml",
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("Collection file (collection.nml):"))
+        layout.addWidget(self._path_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._path_edit.setText(str(config.cparser.value("traktor/collections", defaultValue="")))
+
+    def commit(self) -> None:
+        """Write the collection path to config."""
+        self.config.cparser.setValue("traktor/collections", self._path_edit.text().strip())
+
+
+class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
     """base class of input plugins"""
 
     def __init__(self, config: "nowplaying.config.ConfigFile | None" = None, qsettings=None):
         """no custom init"""
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Traktor"
+        self.wizardpage = _TraktorWizardPage
         self.databasefile = pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]
         ).joinpath("traktor", "traktor.db")
@@ -204,13 +240,12 @@ class Plugin(IcecastPlugin):
 
     def _on_traktor_browse_button(self):
         """user clicked traktor browse button"""
-        startdir = self.qwidget.traktor_collection_lineedit.text() or str(
-            self.config.userdocs.joinpath("Native Instruments")
+        self.uihelp.file_picker_lineedit(
+            self.qwidget.traktor_collection_lineedit,
+            title="Open collection file",
+            limit="*.nml",
+            startdir=self.config.userdocs.joinpath("Native Instruments"),
         )
-        if filename := QFileDialog.getOpenFileName(
-            self.qwidget, "Open collection file", startdir, "*.nml"
-        ):
-            self.qwidget.traktor_collection_lineedit.setText(filename[0])
 
     def _on_traktor_rebuild_button(self):
         """user clicked re-read collections - trigger background refresh"""
@@ -219,7 +254,9 @@ class Plugin(IcecastPlugin):
 
     def load_settingsui(self, qwidget):
         """load values from config and populate page"""
-        qwidget.port_lineedit.setText(self.config.cparser.value("traktor/port"))
+        qwidget.port_lineedit.setText(
+            self.config.cparser.value("traktor/port", type=str, defaultValue="8000")
+        )
         qwidget.traktor_collection_lineedit.setText(
             self.config.cparser.value("traktor/collections")
         )

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -179,10 +179,12 @@ class _VirtualDJWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too
         self._history_edit = nowplaying.wizard.WizardPage.PathEdit(
             "Select VirtualDJ History Folder",
             placeholder="VirtualDJ history directory…",
+            startdir=config.userdocs.joinpath("VirtualDJ", "History"),
         )
         self._playlist_edit = nowplaying.wizard.WizardPage.PathEdit(
             "Select VirtualDJ Playlists Folder",
             placeholder="VirtualDJ playlists directory…",
+            startdir=config.userdocs.joinpath("VirtualDJ"),
         )
 
         layout = QVBoxLayout()

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -12,9 +12,14 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 import nowplaying.utils
+import nowplaying.wizard
 import nowplaying.utils.sqlite
 import nowplaying.utils.xml
 from nowplaying.db import LISTFIELDS
@@ -160,6 +165,45 @@ class VirtualDJFolderSAXHandler(xml.sax.ContentHandler):
                 self.content.append(entry)
 
 
+class _VirtualDJWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for VirtualDJ directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("VirtualDJ Setup")
+        self.setSubTitle("Confirm the locations of your VirtualDJ history and playlists folders.")
+
+        self._history_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Select VirtualDJ History Folder",
+            placeholder="VirtualDJ history directory…",
+        )
+        self._playlist_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Select VirtualDJ Playlists Folder",
+            placeholder="VirtualDJ playlists directory…",
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("History directory:"))
+        layout.addWidget(self._history_edit)
+        layout.addWidget(QLabel("Playlists directory:"))
+        layout.addWidget(self._playlist_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._history_edit.setText(str(config.cparser.value("virtualdj/history", defaultValue="")))
+        self._playlist_edit.setText(
+            str(config.cparser.value("virtualdj/playlists", defaultValue=""))
+        )
+
+    def commit(self) -> None:
+        """Write the VirtualDJ directory paths to config."""
+        self.config.cparser.setValue("virtualdj/history", self._history_edit.text().strip())
+        self.config.cparser.setValue("virtualdj/playlists", self._playlist_edit.text().strip())
+
+
 class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """handler for NowPlaying"""
 
@@ -168,6 +212,7 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
     ):
         super().__init__(config=config, m3udir=m3udir, qsettings=qsettings)
         self.displayname = "VirtualDJ"
+        self.wizardpage = _VirtualDJWizardPage
         # Separate databases for different data sources
         self.songs_databasefile = pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]
@@ -758,22 +803,17 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
 
     def on_playlistdir_button(self):
         """filename button clicked action"""
-        startdir = self.qwidget.playlistdir_lineedit.text() or str(
-            self.config.userdocs.joinpath("VirtualDJ")
+        self.uihelp.dir_picker_lineedit(
+            self.qwidget.playlistdir_lineedit,
+            startdir=self.config.userdocs.joinpath("VirtualDJ"),
         )
-        if filename := QFileDialog.getExistingDirectory(
-            self.qwidget, "Select directory", startdir
-        ):
-            self.qwidget.playlistdir_lineedit.setText(filename)
 
     def on_history_dir_button(self):
         """filename button clicked action"""
-        if self.qwidget.historydir_lineedit.text():
-            startdir = self.qwidget.historydir_lineedit.text()
-        else:
-            startdir = str(self.config.userdocs.joinpath("VirtualDJ", "History"))
-        if dirname := QFileDialog.getExistingDirectory(self.qwidget, "Select directory", startdir):
-            self.qwidget.historydir_lineedit.setText(dirname)
+        self.uihelp.dir_picker_lineedit(
+            self.qwidget.historydir_lineedit,
+            startdir=self.config.userdocs.joinpath("VirtualDJ", "History"),
+        )
 
     def connect_settingsui(self, qwidget, uihelp):
         """connect m3u button to filename picker"""

--- a/nowplaying/plugin.py
+++ b/nowplaying/plugin.py
@@ -4,7 +4,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-import nowplaying.types
+import nowplaying.wizard
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
@@ -28,7 +28,7 @@ class WNPBasePlugin:  # pylint: disable=too-many-instance-attributes
         self.uihelp: object | None = None
         self.displayname: str = ""
         self.priority: int = 0
-        self.wizardpage: type[nowplaying.types.WizardPage] | None = None
+        self.wizardpage: type[nowplaying.wizard.WizardPage] | None = None
 
         if qsettings:
             self.defaults(qsettings)

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -16,10 +16,19 @@ from typing import TYPE_CHECKING
 import aiohttp
 import aiosqlite
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QButtonGroup,
+    QLabel,
+    QLineEdit,
+    QRadioButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 import nowplaying.inputs
 import nowplaying.utils.sqlite
 from nowplaying.types import TrackMetadata
+import nowplaying.wizard
 
 from .handler import Serato4Handler
 from .reader import Serato4RootReader
@@ -27,9 +36,63 @@ from .remote import SeratoRemoteHandler
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
+
+
+class _SeratoWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Serato DJ local/remote mode configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Serato DJ Setup")
+        self.setSubTitle(
+            "Choose whether What's Now Playing reads from Serato on this "
+            "computer or from a remote Serato Live Playlists URL."
+        )
+
+        self._local_radio = QRadioButton("Local — read from this computer's Serato library")
+        self._remote_radio = QRadioButton("Remote — use Serato Live Playlists URL")
+
+        self._button_group = QButtonGroup(self)
+        self._button_group.addButton(self._local_radio)
+        self._button_group.addButton(self._remote_radio)
+
+        self._url_label = QLabel("Live Playlists URL:")
+        self._url_edit = QLineEdit()
+        self._url_edit.setPlaceholderText("https://serato.com/playlists/…")
+
+        self._local_radio.toggled.connect(self._on_mode_changed)
+
+        local_mode = config.cparser.value("serato4/local", type=bool, defaultValue=True)
+        if local_mode:
+            self._local_radio.setChecked(True)
+        else:
+            self._remote_radio.setChecked(True)
+        self._url_edit.setText(str(config.cparser.value("serato4/url", defaultValue="")))
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._local_radio)
+        layout.addWidget(self._remote_radio)
+        layout.addSpacing(8)
+        layout.addWidget(self._url_label)
+        layout.addWidget(self._url_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+        self._on_mode_changed()
+
+    def _on_mode_changed(self) -> None:
+        remote = self._remote_radio.isChecked()
+        self._url_label.setVisible(remote)
+        self._url_edit.setVisible(remote)
+
+    def commit(self) -> None:
+        """Write Serato mode and URL to config."""
+        self.config.cparser.setValue("serato4/local", self._local_radio.isChecked())
+        self.config.cparser.setValue("serato4/url", self._url_edit.text().strip())
 
 
 class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -43,6 +106,7 @@ class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instanc
         super().__init__(config=config, qsettings=qsettings)
 
         self.displayname = "Serato DJ"
+        self.wizardpage = _SeratoWizardPage
         self.handler: Serato4Handler | None = None
         self.remote_handler: SeratoRemoteHandler | None = None
         self.serato_lib_path: pathlib.Path | None = None

--- a/nowplaying/types.py
+++ b/nowplaying/types.py
@@ -3,8 +3,6 @@
 
 from typing import TYPE_CHECKING, TypedDict
 
-from PySide6.QtWidgets import QWizardPage  # pylint: disable=no-name-in-module
-
 if TYPE_CHECKING:
     import nowplaying.artistextras
     import nowplaying.inputs
@@ -178,15 +176,3 @@ class TrackRequestSetting(TypedDict, total=False):
     displayname: str
     playlist: str
     userimage: bytes
-
-
-class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
-    """Base class for plugin-provided first-run wizard pages.
-
-    Plugin files define a subclass of WizardPage, then set
-    self.wizardpage = _TheirPageClass in Plugin.__init__().
-    The install wizard instantiates it as plugin.wizardpage(config=...).
-    """
-
-    def commit(self) -> None:
-        """Write this page's settings to QSettings. Called when wizard is accepted."""

--- a/nowplaying/uihelp.py
+++ b/nowplaying/uihelp.py
@@ -30,9 +30,7 @@ class UIHelp:
             startdir = os.path.dirname(startfile)
         elif not startdir:
             startdir = str(self.config.templatedir)
-        if filename := QFileDialog.getOpenFileName(self.qtui, "Open file", startdir, limit):
-            return filename[0]
-        return None
+        return UIHelp.open_file_dialog(self.qtui, "Open file", startdir, limit) or None
 
     def template_picker_lineedit(self, qwidget, limit="*.txt"):
         """generic code to pick a template file"""
@@ -61,15 +59,25 @@ class UIHelp:
     def file_picker_lineedit(self, qwidget, title="Open file", limit="*", startdir=None):
         """Pick a file and set the result in a QLineEdit widget."""
         start = qwidget.text() or (str(startdir) if startdir else ".")
-        result, _ = QFileDialog.getOpenFileName(self.qtui, title, start, limit)
-        if result:
+        if result := UIHelp.open_file_dialog(self.qtui, title, start, limit):
             qwidget.setText(result)
 
     def dir_picker_lineedit(self, qwidget, title="Select directory", startdir=None):
         """Pick a directory and set the result in a QLineEdit widget."""
         start = qwidget.text() or (str(startdir) if startdir else ".")
-        if dirname := QFileDialog.getExistingDirectory(self.qtui, title, start):
-            qwidget.setText(dirname)
+        if result := UIHelp.open_dir_dialog(self.qtui, title, start):
+            qwidget.setText(result)
+
+    @staticmethod
+    def open_file_dialog(parent: "QWidget", title: str, startdir: str, limit: str = "*") -> str:
+        """Open a file-picker dialog; return the chosen path or empty string."""
+        result, _ = QFileDialog.getOpenFileName(parent, title, startdir, limit)
+        return result
+
+    @staticmethod
+    def open_dir_dialog(parent: "QWidget", title: str, startdir: str) -> str:
+        """Open a directory-picker dialog; return the chosen path or empty string."""
+        return QFileDialog.getExistingDirectory(parent, title, startdir)
 
     @staticmethod
     def find_widget_in_tabs(widget_container: "QWidget", widget_name: str) -> "QWidget | None":

--- a/nowplaying/uihelp.py
+++ b/nowplaying/uihelp.py
@@ -58,6 +58,19 @@ class UIHelp:
         ):
             qwidget.setText(filename)
 
+    def file_picker_lineedit(self, qwidget, title="Open file", limit="*", startdir=None):
+        """Pick a file and set the result in a QLineEdit widget."""
+        start = qwidget.text() or (str(startdir) if startdir else ".")
+        result, _ = QFileDialog.getOpenFileName(self.qtui, title, start, limit)
+        if result:
+            qwidget.setText(result)
+
+    def dir_picker_lineedit(self, qwidget, title="Select directory", startdir=None):
+        """Pick a directory and set the result in a QLineEdit widget."""
+        start = qwidget.text() or (str(startdir) if startdir else ".")
+        if dirname := QFileDialog.getExistingDirectory(self.qtui, title, start):
+            qwidget.setText(dirname)
+
     @staticmethod
     def find_widget_in_tabs(widget_container: "QWidget", widget_name: str) -> "QWidget | None":
         """Find a widget by name across tabs or in a single widget

--- a/nowplaying/wizard.py
+++ b/nowplaying/wizard.py
@@ -3,6 +3,7 @@
 
 import pathlib
 
+from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QHBoxLayout,
     QLineEdit,
@@ -65,14 +66,24 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
 
         def _browse(self) -> None:
             start = self._edit.text() or self._startdir or str(pathlib.Path.home())
+            parent = self.window() or self
             if self._file_filter:
                 result = nowplaying.uihelp.UIHelp.open_file_dialog(
-                    self, self._title, start, self._file_filter
+                    parent, self._title, start, self._file_filter
                 )
             else:
-                result = nowplaying.uihelp.UIHelp.open_dir_dialog(self, self._title, start)
+                result = nowplaying.uihelp.UIHelp.open_dir_dialog(parent, self._title, start)
             if result:
                 self._edit.setText(result)
+
+    @staticmethod
+    def port_edit(placeholder: str = "", width: int = 120) -> QLineEdit:
+        """Return a QLineEdit pre-validated for TCP port numbers (1–65535)."""
+        edit = QLineEdit()
+        edit.setPlaceholderText(placeholder)
+        edit.setMaximumWidth(width)
+        edit.setValidator(QIntValidator(1, 65535))
+        return edit
 
     def commit(self) -> None:
         """Write this page's settings to QSettings. Called when wizard is accepted."""

--- a/nowplaying/wizard.py
+++ b/nowplaying/wizard.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Wizard infrastructure shared between the install wizard and input plugins."""
+
+import pathlib
+
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QFileDialog,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QWidget,
+    QWizardPage,
+)
+
+
+class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
+    """Base class for plugin-provided first-run wizard pages.
+
+    Plugin files define a subclass, then assign:
+        self.wizardpage = _TheirPageClass
+    in Plugin.__init__().  The install wizard instantiates it as:
+        plugin.wizardpage(config=...)
+    """
+
+    class PathEdit(QWidget):
+        """QLineEdit + Browse button for file or directory pickers.
+
+        Pass file_filter (e.g. '*.nml') for a file picker; omit it (or pass '')
+        for a directory picker.
+        """
+
+        def __init__(
+            self,
+            title: str,
+            placeholder: str = "",
+            file_filter: str = "",
+            parent: "QWidget | None" = None,
+        ) -> None:
+            super().__init__(parent)
+            self._title = title
+            self._file_filter = file_filter
+
+            self._edit = QLineEdit()
+            self._edit.setPlaceholderText(placeholder)
+
+            browse_btn = QPushButton("Browse…")
+            browse_btn.clicked.connect(self._browse)
+
+            layout = QHBoxLayout(self)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.addWidget(self._edit)
+            layout.addWidget(browse_btn)
+
+        def text(self) -> str:
+            """Return the current path text."""
+            return self._edit.text()
+
+        def setText(self, text: str) -> None:  # pylint: disable=invalid-name
+            """Set the path text."""
+            self._edit.setText(text)
+
+        def _browse(self) -> None:
+            start = self._edit.text() or str(pathlib.Path.home())
+            if self._file_filter:
+                result, _ = QFileDialog.getOpenFileName(
+                    self, self._title, start, self._file_filter
+                )
+            else:
+                result = QFileDialog.getExistingDirectory(self, self._title, start)
+            if result:
+                self._edit.setText(result)
+
+    def commit(self) -> None:
+        """Write this page's settings to QSettings. Called when wizard is accepted."""

--- a/nowplaying/wizard.py
+++ b/nowplaying/wizard.py
@@ -4,13 +4,14 @@
 import pathlib
 
 from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
-    QFileDialog,
     QHBoxLayout,
     QLineEdit,
     QPushButton,
     QWidget,
     QWizardPage,
 )
+
+import nowplaying.uihelp
 
 
 class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
@@ -26,7 +27,8 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
         """QLineEdit + Browse button for file or directory pickers.
 
         Pass file_filter (e.g. '*.nml') for a file picker; omit it (or pass '')
-        for a directory picker.
+        for a directory picker.  Pass startdir for a smarter initial browse
+        location when the field is empty.
         """
 
         def __init__(
@@ -34,11 +36,13 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
             title: str,
             placeholder: str = "",
             file_filter: str = "",
+            startdir: "pathlib.Path | str | None" = None,
             parent: "QWidget | None" = None,
         ) -> None:
             super().__init__(parent)
             self._title = title
             self._file_filter = file_filter
+            self._startdir = str(startdir) if startdir is not None else None
 
             self._edit = QLineEdit()
             self._edit.setPlaceholderText(placeholder)
@@ -60,13 +64,13 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
             self._edit.setText(text)
 
         def _browse(self) -> None:
-            start = self._edit.text() or str(pathlib.Path.home())
+            start = self._edit.text() or self._startdir or str(pathlib.Path.home())
             if self._file_filter:
-                result, _ = QFileDialog.getOpenFileName(
+                result = nowplaying.uihelp.UIHelp.open_file_dialog(
                     self, self._title, start, self._file_filter
                 )
             else:
-                result = QFileDialog.getExistingDirectory(self, self._title, start)
+                result = nowplaying.uihelp.UIHelp.open_dir_dialog(self, self._title, start)
             if result:
                 self._edit.setText(result)
 


### PR DESCRIPTION
Add first-run wizard config pages for all 8 input plugins (Traktor, Icecast, Remote, VirtualDJ, DJUCED, JRiver, djay Pro, Serato).

Infrastructure:
- nowplaying/wizard.py: WizardPage base class with nested PathEdit widget (QLineEdit + Browse) that encapsulates QFileDialog so individual plugin files need not import it
- UIHelp.file_picker_lineedit() / dir_picker_lineedit() for settings UI browse buttons, keeping QFileDialog in one place

Per-plugin pages:
- Traktor: collection.nml file picker, always-write commit()
- Icecast/JRiver: port field with QIntValidator(1-65535)
- VirtualDJ: history + playlists dir pickers, always-write commit()
- DJUCED/djay Pro: library dir picker, always-write commit()
- Remote: informational page only (no config to write)
- Serato: local vs remote-URL radio buttons

## Summary by Sourcery

Introduce shared wizard infrastructure and per-plugin first-run configuration pages, along with centralized file/directory picker helpers for the settings UI.

New Features:
- Add a WizardPage base class with reusable PathEdit widget for file and directory selection in first-run setup flows.
- Provide dedicated first-run wizard pages for Traktor, Icecast, Remote, VirtualDJ, DJUCED, JRiver, djay Pro, and Serato input plugins to capture initial configuration settings.

Enhancements:
- Centralize file and directory picker logic in UIHelp, replacing direct QFileDialog usage in individual plugins.
- Wire input plugins to expose their wizard page classes via the common Plugin.wizardpage attribute to integrate with the install wizard.