### PR TITLE
refactor: streamline and complete install wizard

### DIFF
--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -93,6 +93,7 @@ class _DjayProWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
             "Select djay Pro Library Folder",
             placeholder="djay Pro library directory…",
             startdir=config.userdocs.parent.joinpath("Music", "djay"),
+            allow_bundles=True,
         )
 
         layout = QVBoxLayout()
@@ -872,4 +873,5 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self.uihelp.dir_picker_lineedit(
             self.qwidget.dir_lineedit,
             startdir=music_dir.joinpath("djay"),
+            allow_bundles=True,
         )

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -68,6 +68,12 @@ class _JRiverWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-fe
         self._user_edit.setText(str(config.cparser.value("jriver/username", defaultValue="")))
         self._pass_edit.setText(str(config.cparser.value("jriver/password", defaultValue="")))
 
+        self._host_edit.textChanged.connect(self.completeChanged)
+
+    def isComplete(self) -> bool:  # pylint: disable=invalid-name
+        """Require a host before allowing Next."""
+        return bool(self._host_edit.text().strip())
+
     def commit(self) -> None:
         """Write JRiver connection settings to config."""
         self.config.cparser.setValue("jriver/host", self._host_edit.text().strip())

--- a/nowplaying/inputs/m3u.py
+++ b/nowplaying/inputs/m3u.py
@@ -6,16 +6,20 @@ import logging
 import os
 import pathlib
 import re
+from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QDir  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget  # pylint: disable=no-name-in-module
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
 import nowplaying.utils
+import nowplaying.wizard
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
+
+if TYPE_CHECKING:
+    import nowplaying.config
 
 # VDJ Extension lines that matter
 EXTVDJ_TITLE_RE = re.compile(r".*<title>(.+)</title>.*")
@@ -25,12 +29,44 @@ EXTVDJ_REMIX_RE = re.compile(r".*<remix>(.+)</remix>.*")
 # https://datatracker.ietf.org/doc/html/rfc8216
 
 
+class _M3UWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for M3U directory configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("M3U Setup")
+        self.setSubTitle(
+            "Select the directory where What's Now Playing should watch for M3U playlist files."
+        )
+
+        self._dir_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Select M3U Directory",
+            placeholder="Directory containing .m3u files…",
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("M3U playlist directory:"))
+        layout.addWidget(self._dir_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self._dir_edit.setText(str(config.cparser.value("m3u/directory", defaultValue="")))
+
+    def commit(self) -> None:
+        """Write the M3U directory path to config."""
+        self.config.cparser.setValue("m3u/directory", self._dir_edit.text().strip())
+
+
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     """handler for NowPlaying"""
 
     def __init__(self, config=None, m3udir: str | None = None, qsettings=None):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "M3U"
+        self.wizardpage = _M3UWizardPage
         self.m3udir: str | None = None
         if m3udir and os.path.exists(m3udir):
             self.m3udir = m3udir
@@ -235,12 +271,10 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     def on_m3u_dir_button(self):
         """filename button clicked action"""
-        if self.qwidget.dir_lineedit.text():
-            startdir = self.qwidget.dir_lineedit.text()
-        else:
-            startdir = QDir.homePath()
-        if dirname := QFileDialog.getExistingDirectory(self.qwidget, "Select directory", startdir):
-            self.qwidget.dir_lineedit.setText(dirname)
+        self.uihelp.dir_picker_lineedit(
+            self.qwidget.dir_lineedit,
+            startdir=pathlib.Path.home(),
+        )
 
     def connect_settingsui(self, qwidget, uihelp):
         """connect m3u button to filename picker"""

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QFormLayout,
     QLabel,
+    QLineEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -23,35 +25,49 @@ if TYPE_CHECKING:
 
 
 class _RemoteWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
-    """Informational wizard page for the Remote (multi-PC) input plugin."""
+    """Wizard page for the Remote (multi-PC) input plugin."""
 
     def __init__(
         self,
-        config: "nowplaying.config.ConfigFile",  # pylint: disable=unused-argument
+        config: "nowplaying.config.ConfigFile",
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
+        self.config = config
         self.setTitle("Remote / Multi-PC Setup")
         self.setSubTitle(
-            "What's Now Playing will receive track data from another PC "
-            "running WNP as the primary DJ system."
+            "What's Now Playing will receive track data from another source — "
+            "a second PC running WNP, or the EarShot app."
         )
+
         info = QLabel(
-            "No file path to configure here — the remote database is created "
-            "automatically.\n\n"
-            "On your primary DJ PC, install What's Now Playing, set it up with "
-            "your DJ software, and enable 'Remote Source' in its Outputs "
+            "The remote database is created automatically — no path to configure.\n\n"
+            "Multi-PC: on your primary DJ PC, install What's Now Playing, set it up "
+            "with your DJ software, and enable 'Remote Source' in its Outputs "
             "settings to point it at this machine.\n\n"
-            "Click Next to continue."
+            "EarShot: install the WNP EarShot app and it will push identified "
+            "tracks to this machine automatically."
         )
         info.setWordWrap(True)
+
+        self._secret_edit = QLineEdit()
+        self._secret_edit.setPlaceholderText("leave blank for no authentication")
+        self._secret_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self._secret_edit.setText(str(config.cparser.value("remote/remote_key", defaultValue="")))
+
+        form = QFormLayout()
+        form.addRow("Shared secret (optional):", self._secret_edit)
+
         layout = QVBoxLayout()
         layout.addWidget(info)
+        layout.addSpacing(12)
+        layout.addLayout(form)
         layout.addStretch()
         self.setLayout(layout)
 
     def commit(self) -> None:
-        """Remote has no configurable paths — nothing to write."""
+        """Write the shared secret to config."""
+        self.config.cparser.setValue("remote/remote_key", self._secret_edit.text().strip())
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -184,9 +184,8 @@ class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
     def get_path_keys(cls) -> frozenset[str]:
         return frozenset({"traktor/collections"})
 
-    def install(self):
-        """auto-install for Traktor"""
-        # Check multiple possible Native Instruments locations
+    def _find_best_collection(self) -> pathlib.Path | None:
+        """Return the most-recently-modified collection.nml across all NI locations, or None."""
         possible_locations = [
             # Traditional Documents/Native Instruments location
             self.config.userdocs.joinpath("Native Instruments"),
@@ -195,19 +194,24 @@ class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
                 QStandardPaths.standardLocations(QStandardPaths.AppLocalDataLocation)[0]
             ).parent.joinpath("Native Instruments"),
         ]
-
+        all_collections = []
         for nidir in possible_locations:
             if nidir.exists():
-                for entry in os.scandir(nidir):
-                    if entry.is_dir() and "Traktor" in entry.name:
-                        cmlpath = pathlib.Path(entry).joinpath("collection.nml")
-                        if cmlpath.exists():
-                            self.config.cparser.setValue("traktor/collections", str(cmlpath))
-                            self.config.cparser.setValue("settings/input", "traktor")
-                            self.config.cparser.setValue("traktor/port", "8000")
-                            return True
+                all_collections.extend(nidir.glob("**/collection.nml"))
+        if not all_collections:
+            return None
+        all_collections.sort(key=lambda p: p.stat().st_mtime)
+        return all_collections[-1]
 
-        return False
+    def install(self):
+        """auto-install for Traktor; picks most-recently-used version when multiple installed"""
+        best = self._find_best_collection()
+        if best is None:
+            return False
+        self.config.cparser.setValue("traktor/collections", str(best))
+        self.config.cparser.setValue("settings/input", "traktor")
+        self.config.cparser.setValue("traktor/port", "8000")
+        return True
 
     def defaults(self, qsettings):
         """(re-)set the default configuration values for this plugin"""
@@ -215,22 +219,8 @@ class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
         qsettings.setValue("traktor/max_age_days", 7)
         qsettings.setValue("traktor/artist_query_scope", "entire_library")
         qsettings.setValue("traktor/selected_playlists", "")
-        # Check multiple possible Native Instruments locations for defaults
-        possible_locations = [
-            self.config.userdocs.joinpath("Native Instruments"),
-            pathlib.Path(
-                QStandardPaths.standardLocations(QStandardPaths.AppLocalDataLocation)[0]
-            ).parent.joinpath("Native Instruments"),
-        ]
-
-        all_collections = []
-        for nidir in possible_locations:
-            if nidir.exists():
-                all_collections.extend(list(nidir.glob("**/collection.nml")))
-
-        if all_collections:
-            all_collections.sort(key=lambda x: x.stat().st_mtime)
-            qsettings.setValue("traktor/collections", str(all_collections[-1]))
+        if best := self._find_best_collection():
+            qsettings.setValue("traktor/collections", str(best))
 
     def connect_settingsui(self, qwidget, uihelp):
         """connect any UI elements such as buttons"""

--- a/nowplaying/installwizard/__init__.py
+++ b/nowplaying/installwizard/__init__.py
@@ -4,8 +4,9 @@
 # pylint: disable=no-name-in-module
 
 import logging
+import sys
 
-from PySide6.QtWidgets import QWidget, QWizard
+from PySide6.QtWidgets import QDialog, QWidget, QWizard
 
 import nowplaying.config
 from nowplaying.installwizard._artist_extras import _ArtistExtrasPage
@@ -130,8 +131,11 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
                 cparser.setValue("kick/channel", cp.kick_channel.text().strip())
                 cparser.setValue("kick/clientid", cp.kick_clientid.text().strip())
                 cparser.setValue("kick/secret", cp.kick_secret.text())
-            if op.discord_bot_check.isChecked() or op.discord_rp_check.isChecked():
+            if op.discord_bot_check.isChecked():
                 cparser.setValue("discord/token", cp.discord_token.text().strip())
+                cparser.setValue("discord/channel_id", cp.discord_channel_id.text().strip())
+            if op.discord_rp_check.isChecked():
+                cparser.setValue("discord/clientid", cp.discord_clientid.text().strip())
 
         self.config.initialized = True
         self.config.save()
@@ -139,8 +143,14 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
 
 
 def maybe_show_wizard(config: nowplaying.config.ConfigFile) -> None:
-    """Show the setup wizard for a fresh install; no-op if already initialized."""
+    """Show the setup wizard for a fresh install; no-op if already initialized.
+
+    Exits the process if the user cancels a first-run wizard — an unconfigured
+    app has nothing useful to do.
+    """
     if config.initialized:
         return
     wizard = InstallWizard(config)
-    wizard.exec()
+    if wizard.exec() != QDialog.DialogCode.Accepted:
+        logging.info("First-run wizard cancelled — exiting")
+        sys.exit(0)

--- a/nowplaying/installwizard/_configure_outputs.py
+++ b/nowplaying/installwizard/_configure_outputs.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Credentials configuration page for enabled outputs."""
 
-# pylint: disable=no-name-in-module,too-few-public-methods,too-many-instance-attributes,duplicate-code
+# pylint: disable=no-name-in-module,too-few-public-methods,too-many-instance-attributes
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QIntValidator  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (
     QFormLayout,
     QGroupBox,
@@ -17,6 +16,7 @@ from PySide6.QtWidgets import (
 )
 
 import nowplaying.config
+import nowplaying.wizard
 
 if TYPE_CHECKING:
     from nowplaying.installwizard._outputs import _OutputsPage
@@ -37,12 +37,11 @@ class _ConfigureOutputsPage(QWizardPage):
         self.setTitle("Configure Outputs")
         self.setSubTitle(
             "Enter the credentials for each enabled output. "
-            "Leave a field blank to configure it later in Preferences."
+            "Leave a field blank to configure it later in Settings."
         )
 
         self.obsws_host = QLineEdit()
-        self.obsws_port = QLineEdit()
-        self.obsws_port.setValidator(QIntValidator(1, 65535, self))
+        self.obsws_port = nowplaying.wizard.WizardPage.port_edit("4455")
         self.obsws_secret = QLineEdit()
         self.twitch_channel = QLineEdit()
         self.twitch_clientid = QLineEdit()
@@ -51,11 +50,14 @@ class _ConfigureOutputsPage(QWizardPage):
         self.kick_clientid = QLineEdit()
         self.kick_secret = QLineEdit()
         self.discord_token = QLineEdit()
+        self.discord_channel_id = QLineEdit()
+        self.discord_clientid = QLineEdit()
 
         self._obsws_group: QGroupBox
         self._twitch_group: QGroupBox
         self._kick_group: QGroupBox
         self._discord_group: QGroupBox
+        self._discord_form: QFormLayout
 
         self._setup_ui()
 
@@ -89,7 +91,6 @@ class _ConfigureOutputsPage(QWizardPage):
         self.obsws_host.setText(
             str(self.config.cparser.value("obsws/host", defaultValue="localhost") or "localhost")
         )
-        self.obsws_port.setPlaceholderText("4455")
         self.obsws_port.setText(
             str(self.config.cparser.value("obsws/port", type=str, defaultValue="4455") or "4455")
         )
@@ -151,12 +152,27 @@ class _ConfigureOutputsPage(QWizardPage):
     def _make_discord_group(self) -> QGroupBox:
         group = QGroupBox("Discord")
         form = QFormLayout()
+
         self.discord_token.setPlaceholderText("Bot token from discord.com/developers")
         self.discord_token.setEchoMode(QLineEdit.EchoMode.Password)
         self.discord_token.setText(
             str(self.config.cparser.value("discord/token", defaultValue="") or "")
         )
         form.addRow("Bot Token:", self.discord_token)
+
+        self.discord_channel_id.setPlaceholderText("Channel ID (enable Developer Mode to copy)")
+        self.discord_channel_id.setText(
+            str(self.config.cparser.value("discord/channel_id", defaultValue="") or "")
+        )
+        form.addRow("Channel ID:", self.discord_channel_id)
+
+        self.discord_clientid.setPlaceholderText("Application ID from discord.com/developers")
+        self.discord_clientid.setText(
+            str(self.config.cparser.value("discord/clientid", defaultValue="") or "")
+        )
+        form.addRow("Client ID:", self.discord_clientid)
+
+        self._discord_form = form
         group.setLayout(form)
         return group
 
@@ -166,6 +182,10 @@ class _ConfigureOutputsPage(QWizardPage):
         self._obsws_group.setVisible(op.obsws_check.isChecked())
         self._twitch_group.setVisible(op.twitch_check.isChecked())
         self._kick_group.setVisible(op.kick_check.isChecked())
-        self._discord_group.setVisible(
-            op.discord_bot_check.isChecked() or op.discord_rp_check.isChecked()
-        )
+
+        bot = op.discord_bot_check.isChecked()
+        rp = op.discord_rp_check.isChecked()
+        self._discord_group.setVisible(bot or rp)
+        self._discord_form.setRowVisible(self.discord_token, bot)
+        self._discord_form.setRowVisible(self.discord_channel_id, bot)
+        self._discord_form.setRowVisible(self.discord_clientid, rp)

--- a/nowplaying/installwizard/_finish.py
+++ b/nowplaying/installwizard/_finish.py
@@ -19,7 +19,7 @@ class _FinishPage(QWizardPage):
         self._summary.setAlignment(Qt.AlignmentFlag.AlignTop)
         layout.addWidget(self._summary)
         note = QLabel(
-            "\nAll settings can be adjusted later via the What's Now Playing Preferences menu."
+            "\nAll settings can be adjusted later via the What's Now Playing Settings menu."
         )
         note.setWordWrap(True)
         layout.addWidget(note)

--- a/nowplaying/installwizard/_input_source.py
+++ b/nowplaying/installwizard/_input_source.py
@@ -90,7 +90,11 @@ class _InputSourcePage(QWizardPage):
         self._on_selection_changed()
 
     def _on_selection_changed(self) -> None:
-        """Rebuild the plugin-specific config page whenever the selection changes."""
+        """Rebuild the plugin-specific config page whenever the selection changes.
+
+        A fresh page instance is constructed on each call, so loading from config
+        in __init__ is correct — there is no stale-instance risk.
+        """
         wizard = self.wizard()
         if wizard is None:
             return
@@ -108,7 +112,7 @@ class _InputSourcePage(QWizardPage):
                 page = plugin_obj.wizardpage(config=self.config)
                 wizard.setPage(PAGE_INPUT_CONFIG, page)
         except Exception:  # pylint: disable=broad-exception-caught
-            logging.exception("wizard: no wizard page for %s", short_name)
+            logging.exception("wizard: failed to load plugin page for %s", short_name)
 
     def selected_short_name(self) -> str | None:
         """Return the short module name of the selected input plugin."""

--- a/nowplaying/installwizard/_outputs.py
+++ b/nowplaying/installwizard/_outputs.py
@@ -41,7 +41,7 @@ class _OutputsPage(QWizardPage):
         self.setTitle("Output Destinations")
         self.setSubTitle(
             "Choose where What's Now Playing should send track information. "
-            "All outputs can be enabled and configured later via Preferences."
+            "All outputs can be enabled and configured later via Settings."
         )
         self.weboverlay_check: QCheckBox
         self.obsws_check: QCheckBox

--- a/nowplaying/installwizard/_welcome.py
+++ b/nowplaying/installwizard/_welcome.py
@@ -17,7 +17,7 @@ class _WelcomePage(QWizardPage):
             "This wizard will help you get started quickly.\n\n"
             "You will choose your DJ software source, configure "
             "artist information services, and select outputs. "
-            "Everything can be changed later via Preferences.\n\n"
+            "Everything can be changed later via Settings.\n\n"
             "Click Next to begin."
         )
         intro.setWordWrap(True)

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -16,9 +16,18 @@ import struct
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QFileDialog  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QButtonGroup,
+    QLabel,
+    QLineEdit,
+    QRadioButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 import nowplaying.serato.plugin
+import nowplaying.uihelp
+import nowplaying.wizard
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
 
@@ -29,10 +38,79 @@ from .smart_crate import SeratoSmartCrateReader
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-    from PySide6.QtWidgets import QWidget
 
     import nowplaying.config
-    import nowplaying.uihelp
+
+
+class _SeratoLegacyWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+    """First-run wizard page for Serato Legacy (≤3) local/remote mode configuration."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setTitle("Serato DJ Setup")
+        self.setSubTitle(
+            "Choose whether What's Now Playing reads from Serato on this "
+            "computer or from a remote Serato Live Playlists URL."
+        )
+
+        self._local_radio = QRadioButton("Local — read from this computer's Serato library")
+        self._remote_radio = QRadioButton("Remote — use Serato Live Playlists URL")
+
+        self._button_group = QButtonGroup(self)
+        self._button_group.addButton(self._local_radio)
+        self._button_group.addButton(self._remote_radio)
+
+        music_dir = pathlib.Path(
+            QStandardPaths.standardLocations(QStandardPaths.StandardLocation.MusicLocation)[0]
+        )
+        self._dir_label = QLabel("Serato library directory:")
+        self._dir_edit = nowplaying.wizard.WizardPage.PathEdit(
+            "Select Serato Library Folder",
+            placeholder="_Serato_ directory…",
+            startdir=music_dir,
+        )
+
+        self._url_label = QLabel("Live Playlists URL:")
+        self._url_edit = QLineEdit()
+        self._url_edit.setPlaceholderText("https://serato.com/playlists/…")
+
+        self._local_radio.toggled.connect(self._on_mode_changed)
+
+        local_mode = config.cparser.value("serato/local", type=bool, defaultValue=True)
+        if local_mode:
+            self._local_radio.setChecked(True)
+        else:
+            self._remote_radio.setChecked(True)
+        self._dir_edit.setText(str(config.cparser.value("serato/libpath", defaultValue="")))
+        self._url_edit.setText(str(config.cparser.value("serato/url", defaultValue="")))
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._local_radio)
+        layout.addWidget(self._remote_radio)
+        layout.addSpacing(8)
+        layout.addWidget(self._dir_label)
+        layout.addWidget(self._dir_edit)
+        layout.addWidget(self._url_label)
+        layout.addWidget(self._url_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+        self._on_mode_changed()
+
+    def _on_mode_changed(self) -> None:
+        local = self._local_radio.isChecked()
+        self._dir_label.setVisible(local)
+        self._dir_edit.setVisible(local)
+        self._url_label.setVisible(not local)
+        self._url_edit.setVisible(not local)
+
+    def commit(self) -> None:
+        """Write Serato mode, library path, and URL to config."""
+        self.config.cparser.setValue("serato/local", self._local_radio.isChecked())
+        self.config.cparser.setValue("serato/libpath", self._dir_edit.text().strip())
+        self.config.cparser.setValue("serato/url", self._url_edit.text().strip())
 
 
 class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -45,6 +123,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     ):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Serato (Legacy)"
+        self.wizardpage = _SeratoLegacyWizardPage
         self.url: str | None = None
         self.libpath = None
         self.local = True
@@ -525,23 +604,21 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def on_serato_lib_button(self):
         """lib button clicked action"""
         connection_widgets = self.uihelp.find_tab_by_identifier(self.qwidget, "local_button")
-        startdir = connection_widgets.local_dir_lineedit.text() or str(pathlib.Path.home())
-        if libdir := QFileDialog.getExistingDirectory(self.qwidget, "Select directory", startdir):
-            connection_widgets.local_dir_lineedit.setText(libdir)
+        self.uihelp.dir_picker_lineedit(
+            connection_widgets.local_dir_lineedit,
+            startdir=pathlib.Path.home(),
+        )
 
     def on_add_additional_lib_button(self):
         """add additional library button clicked action"""
         library_widgets = self.uihelp.find_tab_by_identifier(
             self.qwidget, "serato_artist_scope_combo"
         )
-        startdir = str(pathlib.Path.home())
-        if libdir := QFileDialog.getExistingDirectory(
-            self.qwidget, "Select additional Serato library directory", startdir
+        if libdir := nowplaying.uihelp.UIHelp.open_dir_dialog(
+            self.qwidget, "Select additional Serato library directory", str(pathlib.Path.home())
         ):
-            if current_text := library_widgets.additional_libs_textedit.toPlainText().strip():
-                new_text = current_text + "\n" + libdir
-            else:
-                new_text = libdir
+            current_text = library_widgets.additional_libs_textedit.toPlainText().strip()
+            new_text = current_text + "\n" + libdir if current_text else libdir
             library_widgets.additional_libs_textedit.setPlainText(new_text)
 
     def connect_settingsui(self, qwidget: "QWidget", uihelp: "nowplaying.uihelp.UIHelp"):

--- a/nowplaying/uihelp.py
+++ b/nowplaying/uihelp.py
@@ -62,10 +62,12 @@ class UIHelp:
         if result := UIHelp.open_file_dialog(self.qtui, title, start, limit):
             qwidget.setText(result)
 
-    def dir_picker_lineedit(self, qwidget, title="Select directory", startdir=None):
+    def dir_picker_lineedit(
+        self, qwidget, title="Select directory", startdir=None, allow_bundles: bool = False
+    ):
         """Pick a directory and set the result in a QLineEdit widget."""
         start = qwidget.text() or (str(startdir) if startdir else ".")
-        if result := UIHelp.open_dir_dialog(self.qtui, title, start):
+        if result := UIHelp.open_dir_dialog(self.qtui, title, start, allow_bundles=allow_bundles):
             qwidget.setText(result)
 
     @staticmethod
@@ -75,9 +77,20 @@ class UIHelp:
         return result
 
     @staticmethod
-    def open_dir_dialog(parent: "QWidget", title: str, startdir: str) -> str:
-        """Open a directory-picker dialog; return the chosen path or empty string."""
-        return QFileDialog.getExistingDirectory(parent, title, startdir)
+    def open_dir_dialog(
+        parent: "QWidget", title: str, startdir: str, allow_bundles: bool = False
+    ) -> str:
+        """Open a directory-picker dialog; return the chosen path or empty string.
+
+        Pass allow_bundles=True on macOS when the target directory has a bundle
+        extension (.djayMediaLibrary, .app, etc.) — the native picker treats those
+        as files.  DontUseNativeDialog makes Qt show its own picker, which exposes
+        them as plain directories.
+        """
+        opts = QFileDialog.Option.ShowDirsOnly
+        if allow_bundles:
+            opts |= QFileDialog.Option.DontUseNativeDialog
+        return QFileDialog.getExistingDirectory(parent, title, startdir, opts)
 
     @staticmethod
     def find_widget_in_tabs(widget_container: "QWidget", widget_name: str) -> "QWidget | None":

--- a/nowplaying/wizard.py
+++ b/nowplaying/wizard.py
@@ -32,18 +32,20 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
         location when the field is empty.
         """
 
-        def __init__(
+        def __init__(  # pylint: disable=too-many-arguments
             self,
             title: str,
             placeholder: str = "",
             file_filter: str = "",
             startdir: "pathlib.Path | str | None" = None,
+            allow_bundles: bool = False,
             parent: "QWidget | None" = None,
         ) -> None:
             super().__init__(parent)
             self._title = title
             self._file_filter = file_filter
             self._startdir = str(startdir) if startdir is not None else None
+            self._allow_bundles = allow_bundles
 
             self._edit = QLineEdit()
             self._edit.setPlaceholderText(placeholder)
@@ -72,7 +74,9 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
                     parent, self._title, start, self._file_filter
                 )
             else:
-                result = nowplaying.uihelp.UIHelp.open_dir_dialog(parent, self._title, start)
+                result = nowplaying.uihelp.UIHelp.open_dir_dialog(
+                    parent, self._title, start, allow_bundles=self._allow_bundles
+                )
             if result:
                 self._edit.setText(result)
 


### PR DESCRIPTION
- Add wizard pages for Serato Legacy (serato3), M3U, and Remote plugins
- Add missing Discord channel_id and clientid fields; gate visibility with QFormLayout.setRowVisible() per bot/rich-presence selection
- Fix fresh-install cancel: wizard.exec() != Accepted → sys.exit(0)
- Fix djay Pro directory picker on macOS (allow_bundles bypasses native dialog treating .djayMediaLibrary as a bundle)
- Traktor: pick newest collection.nml by mtime across all versions
- JRiver wizard: require host via isComplete() / completeChanged
- Deduplicate port validation in _configure_outputs via port_edit()
- Fix misleading exception message in _on_selection_changed
- Replace "Preferences" with "Settings" throughout wizard UI text

## Summary by Sourcery

Streamline the first-run install wizard by adding configuration pages for additional input plugins, tightening validation and behavior, and improving terminology and directory selection handling.

New Features:
- Add a Serato Legacy wizard page to configure local vs remote library mode and paths.
- Add an M3U input wizard page to configure the watched playlist directory.
- Extend the Remote input wizard page to support an optional shared secret for multi-PC and EarShot setups.

Bug Fixes:
- Ensure cancelling the first-run wizard on a fresh install exits the application cleanly.
- Fix djay Pro library directory selection on macOS by allowing bundle-style directories to be picked.
- Select the most recently used Traktor collection.nml file when multiple versions are installed.
- Require a JRiver host to be entered before the wizard allows continuation.
- Correct the install wizard logging message when plugin page creation fails.

Enhancements:
- Centralize directory picker behavior via UIHelp and PathEdit, including support for non-native dialogs on bundle directories.
- Deduplicate and standardize output port validation using a shared port_edit helper.
- Expand Discord output configuration to include channel ID and client ID with visibility tied to bot vs rich presence options.
- Update wizard copy to consistently refer to Settings instead of Preferences.