### PR TITLE
fix: detect Icecast port change and restart without WNP restart

### DIFF
--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -257,7 +257,7 @@ class _IcecastWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
         self.config.cparser.setValue("icecast/port", self._port_edit.text().strip() or "8000")
 
 
-class Plugin(InputPlugin):
+class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     """base class of input plugins"""
 
     def __init__(
@@ -318,6 +318,7 @@ class Plugin(InputPlugin):
         loop = asyncio.get_running_loop()
         logging.debug("Launching Icecast on %s", port)
         try:
+
             def protocol_factory() -> IcecastProtocol:
                 return IcecastProtocol(metadata_callback=self._metadata_callback)
 
@@ -328,7 +329,9 @@ class Plugin(InputPlugin):
 
     async def _restart_if_port_changed(self) -> None:
         """Restart the server if the configured port has changed since start."""
-        new_port: int = self.config.cparser.value(self._port_config_key, type=int, defaultValue=8000)  # type: ignore[union-attr]
+        new_port: int = self.config.cparser.value(
+            self._port_config_key, type=int, defaultValue=8000
+        )  # type: ignore[union-attr]
         if new_port == self.current_port:
             return
         # If the last bind attempt failed, back off 30s before retrying so a

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -269,6 +269,8 @@ class Plugin(InputPlugin):
         self.displayname: str = "Icecast"
         self.wizardpage = _IcecastWizardPage
         self.server: asyncio.Server | None = None
+        self.current_port: int | None = None
+        self._port_config_key: str = "icecast/port"
         self.mode: str | None = None
         self.lastmetadata: dict[str, str] = {}
         self._current_metadata: dict[str, str] = {}
@@ -304,10 +306,6 @@ class Plugin(InputPlugin):
 
     #### Data feed methods
 
-    async def getplayingtrack(self) -> TrackMetadata:
-        """give back the current metadata"""
-        return self._current_metadata.copy()  # type: ignore
-
     async def getrandomtrack(self, playlist: str) -> None:
         return None
 
@@ -315,17 +313,33 @@ class Plugin(InputPlugin):
 
     async def start_port(self, port: int) -> None:
         """start the icecast server on a particular port"""
-
         loop = asyncio.get_running_loop()
         logging.debug("Launching Icecast on %s", port)
         try:
-            # Create protocol factory that passes the metadata callback
             def protocol_factory() -> IcecastProtocol:
                 return IcecastProtocol(metadata_callback=self._metadata_callback)
 
             self.server = await loop.create_server(protocol_factory, "", port)
+            self.current_port = port
         except Exception as error:  # pylint: disable=broad-except
             logging.error("Failed to launch icecast: %s", error)
+
+    async def _restart_if_port_changed(self) -> None:
+        """Restart the server if the configured port has changed since start."""
+        new_port: int = self.config.cparser.value(self._port_config_key, type=int, defaultValue=8000)  # type: ignore[union-attr]
+        if new_port == self.current_port:
+            return
+        logging.info("Icecast port changed from %s to %s, restarting", self.current_port, new_port)
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()
+            self.server = None
+        await self.start_port(new_port)
+
+    async def getplayingtrack(self) -> TrackMetadata:
+        """give back the current metadata"""
+        await self._restart_if_port_changed()
+        return self._current_metadata.copy()  # type: ignore
 
     async def start(self) -> None:
         """any initialization before actual polling starts"""

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -8,6 +8,7 @@ import logging
 import logging.config
 import os
 import struct
+import time
 import urllib.parse
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -271,6 +272,7 @@ class Plugin(InputPlugin):
         self.server: asyncio.Server | None = None
         self.current_port: int | None = None
         self._port_config_key: str = "icecast/port"
+        self._port_retry_after: float = 0.0
         self.mode: str | None = None
         self.lastmetadata: dict[str, str] = {}
         self._current_metadata: dict[str, str] = {}
@@ -329,12 +331,18 @@ class Plugin(InputPlugin):
         new_port: int = self.config.cparser.value(self._port_config_key, type=int, defaultValue=8000)  # type: ignore[union-attr]
         if new_port == self.current_port:
             return
+        # If the last bind attempt failed, back off 30s before retrying so a
+        # port held by another app that is shutting down doesn't spam the log.
+        if self.server is None and time.monotonic() < self._port_retry_after:
+            return
         logging.info("Icecast port changed from %s to %s, restarting", self.current_port, new_port)
         if self.server:
             self.server.close()
             await self.server.wait_closed()
             self.server = None
         await self.start_port(new_port)
+        if self.server is None:
+            self._port_retry_after = time.monotonic() + 30.0
 
     async def getplayingtrack(self) -> TrackMetadata:
         """give back the current metadata"""
@@ -343,7 +351,7 @@ class Plugin(InputPlugin):
 
     async def start(self) -> None:
         """any initialization before actual polling starts"""
-        port: int = self.config.cparser.value("icecast/port", type=int, defaultValue=8000)
+        port: int = self.config.cparser.value(self._port_config_key, type=int, defaultValue=8000)
         await self.start_port(port)
 
     async def stop(self) -> None:

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -173,6 +173,7 @@ class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
         """no custom init"""
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "Traktor"
+        self._port_config_key = "traktor/port"
         self.wizardpage = _TraktorWizardPage
         self.databasefile = pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0]


### PR DESCRIPTION
When the user changes the Icecast/Traktor port in settings, the plugin now detects the change on the next getplayingtrack() poll cycle and restarts the asyncio server on the new port automatically.

Each plugin class sets _port_config_key in __init__ ("icecast/port" or "traktor/port") so the shared _restart_if_port_changed() helper reads the correct config key via self, without parameters.

## Summary by Sourcery

Detect Icecast/Traktor port changes from configuration and restart the respective asyncio servers on the new port during playback polling without requiring a full plugin restart.

New Features:
- Automatically restart the Icecast server on a new configured port when the port setting changes.
- Automatically restart the Traktor server on a new configured port when the port setting changes.

Enhancements:
- Track the currently bound port within Icecast input to support runtime port change detection.