### PR TITLE
feat: Twitch OAuth2 implicit grant for bundled client ID

### DIFF
--- a/nowplaying/authwizard.py
+++ b/nowplaying/authwizard.py
@@ -50,8 +50,8 @@ class _TwitchBroadcasterPage(QWizardPage):
         )
 
         port = config.cparser.value("weboutput/httpport", type=int, defaultValue=8899)
-        has_custom_id = bool(config.cparser.value("twitchbot/clientid", defaultValue=""))
-        if port == 8899 and not has_custom_id:
+        self._has_custom_id = bool(config.cparser.value("twitchbot/clientid", defaultValue=""))
+        if port == 8899 and not self._has_custom_id:
             app_note = "✅ Using the bundled WNP Twitch app — no Client ID or Secret required."
         else:
             app_note = (
@@ -94,16 +94,22 @@ class _TwitchBroadcasterPage(QWizardPage):
                     "your broadcaster account is logged in, then authorize WNP."
                 )
             else:
-                self._status.setText(
-                    "Could not generate URL — check that your Client ID and "
-                    "Client Secret are saved in Settings."
-                )
+                if self._has_custom_id:
+                    self._status.setText(
+                        "Could not generate URL — check that your Client ID and "
+                        "Client Secret are saved in Settings."
+                    )
+                else:
+                    self._status.setText(
+                        "Could not generate URL — please try again, or check Settings "
+                        "if you have configured a custom Client ID."
+                    )
         except Exception:  # pylint: disable=broad-exception-caught
             logging.exception("authwizard: failed to generate Twitch broadcaster URL")
             self._status.setText("Error generating URL — see log for details.")
 
     def _poll(self) -> None:
-        self._config.cparser.sync()
+        self._config.get()
         if self._config.cparser.value("twitchbot/accesstoken"):
             username = str(self._config.cparser.value(BROADCASTER_USERNAME_KEY, defaultValue=""))
             label = f"✅ Authorized{' as ' + username if username else ''}."
@@ -112,7 +118,7 @@ class _TwitchBroadcasterPage(QWizardPage):
             self.completeChanged.emit()
 
     def isComplete(self) -> bool:  # pylint: disable=invalid-name
-        self._config.cparser.sync()
+        self._config.get()
         return bool(self._config.cparser.value("twitchbot/accesstoken"))
 
 
@@ -173,7 +179,7 @@ class _TwitchChatPage(QWizardPage):
             self._status.setText("Error generating URL — see log for details.")
 
     def _poll(self) -> None:
-        self._config.cparser.sync()
+        self._config.get()
         if self._config.cparser.value("twitchbot/chattoken"):
             username = str(self._config.cparser.value(CHAT_USERNAME_KEY, defaultValue=""))
             label = f"✅ Bot authorized{' as ' + username if username else ''}."
@@ -237,7 +243,7 @@ class _KickPage(QWizardPage):
             self._status.setText("Error opening browser — see log for details.")
 
     def _poll(self) -> None:
-        self._config.cparser.sync()
+        self._config.get()
         if self._config.cparser.value("kick/accesstoken"):
             self._status.setText("✅ Kick authorized.")
             self._auth_btn.setEnabled(False)
@@ -245,7 +251,7 @@ class _KickPage(QWizardPage):
             self.completeChanged.emit()
 
     def isComplete(self) -> bool:  # pylint: disable=invalid-name
-        self._config.cparser.sync()
+        self._config.get()
         return bool(self._config.cparser.value("kick/accesstoken"))
 
 

--- a/nowplaying/authwizard.py
+++ b/nowplaying/authwizard.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Guided OAuth authentication wizard for Twitch and Kick.
+
+Launched automatically after first-run setup when platforms requiring OAuth
+were configured, and accessible from Settings for re-authentication.
+"""
+
+import logging
+import webbrowser
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QTimer  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QApplication,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    QWizard,
+    QWizardPage,
+)
+
+import nowplaying.kick.oauth2
+import nowplaying.twitch.oauth2
+from nowplaying.twitch.constants import (
+    BROADCASTER_USERNAME_KEY,
+    CHAT_USERNAME_KEY,
+)
+
+if TYPE_CHECKING:
+    import nowplaying.config
+
+
+class _TwitchBroadcasterPage(QWizardPage):
+    """Guides the user through authorizing the broadcaster Twitch account."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._poll)
+
+        self.setTitle("Authorize Twitch — Broadcaster Account")
+        self.setSubTitle(
+            "This lets WNP post track info to your chat and update your stream title. "
+            "Your broadcaster and bot accounts may be in different browsers — "
+            "paste this URL into whichever browser is logged in as your broadcaster."
+        )
+
+        port = config.cparser.value("weboutput/httpport", type=int, defaultValue=8899)
+        has_custom_id = bool(config.cparser.value("twitchbot/clientid", defaultValue=""))
+        if port == 8899 and not has_custom_id:
+            app_note = "✅ Using the bundled WNP Twitch app — no Client ID or Secret required."
+        else:
+            app_note = (
+                "ℹ️  You are not on port 8899 or have a custom Client ID configured. "
+                "Make sure your Client ID and Client Secret are saved in Settings "
+                "before authorizing."
+            )
+        self._app_note = QLabel(app_note)
+        self._app_note.setWordWrap(True)
+
+        self._copy_btn = QPushButton("Copy Broadcaster Auth URL")
+        self._copy_btn.clicked.connect(self._copy_url)
+        self._status = QLabel("Not yet authorized.")
+        self._status.setWordWrap(True)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._app_note)
+        layout.addSpacing(8)
+        layout.addWidget(self._copy_btn)
+        layout.addSpacing(8)
+        layout.addWidget(self._status)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        self._poll()
+        self._timer.start(1000)
+
+    def cleanupPage(self) -> None:  # pylint: disable=invalid-name
+        self._timer.stop()
+
+    def _copy_url(self) -> None:
+        try:
+            oauth = nowplaying.twitch.oauth2.TwitchOAuth2(config=self._config)
+            url = oauth.get_auth_url("broadcaster")
+            if url:
+                QApplication.clipboard().setText(url)
+                self._status.setText(
+                    "URL copied to clipboard. Paste it into the browser where "
+                    "your broadcaster account is logged in, then authorize WNP."
+                )
+            else:
+                self._status.setText(
+                    "Could not generate URL — check that your Client ID and "
+                    "Client Secret are saved in Settings."
+                )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("authwizard: failed to generate Twitch broadcaster URL")
+            self._status.setText("Error generating URL — see log for details.")
+
+    def _poll(self) -> None:
+        self._config.cparser.sync()
+        if self._config.cparser.value("twitchbot/accesstoken"):
+            username = str(self._config.cparser.value(BROADCASTER_USERNAME_KEY, defaultValue=""))
+            label = f"✅ Authorized{' as ' + username if username else ''}."
+            self._status.setText(label)
+            self._timer.stop()
+            self.completeChanged.emit()
+
+    def isComplete(self) -> bool:  # pylint: disable=invalid-name
+        self._config.cparser.sync()
+        return bool(self._config.cparser.value("twitchbot/accesstoken"))
+
+
+class _TwitchChatPage(QWizardPage):
+    """Guides the user through authorizing a separate Twitch bot/chat account (optional)."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._poll)
+
+        self.setTitle("Authorize Twitch — Bot Account (Optional)")
+        self.setSubTitle(
+            "If you use a separate account for chat messages, paste this URL into "
+            "the browser where that bot account is logged in. "
+            "Click Next to skip if your broadcaster account handles chat."
+        )
+
+        self._copy_btn = QPushButton("Copy Bot Auth URL")
+        self._copy_btn.clicked.connect(self._copy_url)
+        self._status = QLabel("Not yet authorized (optional — you can skip this).")
+        self._status.setWordWrap(True)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._copy_btn)
+        layout.addSpacing(8)
+        layout.addWidget(self._status)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        self._poll()
+        self._timer.start(1000)
+
+    def cleanupPage(self) -> None:  # pylint: disable=invalid-name
+        self._timer.stop()
+
+    def _copy_url(self) -> None:
+        try:
+            oauth = nowplaying.twitch.oauth2.TwitchOAuth2(config=self._config)
+            url = oauth.get_auth_url("chat")
+            if url:
+                QApplication.clipboard().setText(url)
+                self._status.setText(
+                    "URL copied to clipboard. Paste it into the browser where "
+                    "your bot account is logged in, then authorize WNP."
+                )
+            else:
+                self._status.setText(
+                    "Could not generate URL — check that your Client ID and "
+                    "Client Secret are saved in Settings."
+                )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("authwizard: failed to generate Twitch chat URL")
+            self._status.setText("Error generating URL — see log for details.")
+
+    def _poll(self) -> None:
+        self._config.cparser.sync()
+        if self._config.cparser.value("twitchbot/chattoken"):
+            username = str(self._config.cparser.value(CHAT_USERNAME_KEY, defaultValue=""))
+            label = f"✅ Bot authorized{' as ' + username if username else ''}."
+            self._status.setText(label)
+            self._timer.stop()
+
+
+class _KickPage(QWizardPage):
+    """Guides the user through authorizing Kick."""
+
+    def __init__(
+        self, config: "nowplaying.config.ConfigFile", parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._poll)
+
+        self.setTitle("Authorize Kick")
+        self.setSubTitle(
+            "WNP will open your browser to authorize with Kick. "
+            "Complete the login and this page will update automatically."
+        )
+
+        self._auth_btn = QPushButton("Open Browser to Authorize Kick")
+        self._auth_btn.clicked.connect(self._open_browser)
+        self._status = QLabel("Not yet authorized.")
+        self._status.setWordWrap(True)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._auth_btn)
+        layout.addSpacing(8)
+        layout.addWidget(self._status)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        self._poll()
+        self._timer.start(1000)
+
+    def cleanupPage(self) -> None:  # pylint: disable=invalid-name
+        self._timer.stop()
+
+    def _open_browser(self) -> None:
+        try:
+            oauth = nowplaying.kick.oauth2.KickOAuth2(config=self._config)
+            # get_auth_url() sets redirect_uri and generates PKCE in one shot;
+            # open_browser_for_auth() would regenerate PKCE, causing a state mismatch.
+            url = oauth.get_auth_url()
+            if not url:
+                self._status.setText(
+                    "Could not generate auth URL — check that your Client ID and "
+                    "Client Secret are saved in Settings."
+                )
+                return
+            webbrowser.open(url)
+            self._status.setText("Browser opened — complete authorization on the Kick website.")
+            self._auth_btn.setEnabled(False)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("authwizard: failed to open Kick auth browser")
+            self._status.setText("Error opening browser — see log for details.")
+
+    def _poll(self) -> None:
+        self._config.cparser.sync()
+        if self._config.cparser.value("kick/accesstoken"):
+            self._status.setText("✅ Kick authorized.")
+            self._auth_btn.setEnabled(False)
+            self._timer.stop()
+            self.completeChanged.emit()
+
+    def isComplete(self) -> bool:  # pylint: disable=invalid-name
+        self._config.cparser.sync()
+        return bool(self._config.cparser.value("kick/accesstoken"))
+
+
+class _FinishPage(QWizardPage):
+    """Final page confirming authentication is complete."""
+
+    def __init__(self, platforms: list[str], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setTitle("Authentication Complete")
+        names = {"twitch": "Twitch", "kick": "Kick"}
+        joined = " and ".join(names.get(p, p.title()) for p in platforms)
+        body = QLabel(
+            f"{joined} {'is' if len(platforms) == 1 else 'are'} now authorized. "
+            "What's Now Playing will use these credentials when it runs.\n\n"
+            "You can re-authorize at any time from Settings."
+        )
+        body.setWordWrap(True)
+        layout = QVBoxLayout()
+        layout.addWidget(body)
+        layout.addStretch()
+        self.setLayout(layout)
+
+
+class AuthWizard(QWizard):
+    """Step-by-step OAuth authorization wizard for Twitch and/or Kick.
+
+    Pass ``platforms`` as a list containing 'twitch', 'kick', or both.
+    """
+
+    def __init__(
+        self,
+        config: "nowplaying.config.ConfigFile",
+        platforms: list[str],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Complete Authentication")
+        self.setModal(True)
+        self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage)
+
+        if "twitch" in platforms:
+            self.addPage(_TwitchBroadcasterPage(config))
+            self.addPage(_TwitchChatPage(config))
+        if "kick" in platforms:
+            self.addPage(_KickPage(config))
+        self.addPage(_FinishPage(platforms))

--- a/nowplaying/authwizard.py
+++ b/nowplaying/authwizard.py
@@ -77,10 +77,12 @@ class _TwitchBroadcasterPage(QWizardPage):
         self.setLayout(layout)
 
     def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Start polling when the page is shown."""
         self._poll()
         self._timer.start(1000)
 
     def cleanupPage(self) -> None:  # pylint: disable=invalid-name
+        """Stop polling when the user navigates away."""
         self._timer.stop()
 
     def _copy_url(self) -> None:
@@ -118,6 +120,7 @@ class _TwitchBroadcasterPage(QWizardPage):
             self.completeChanged.emit()
 
     def isComplete(self) -> bool:  # pylint: disable=invalid-name
+        """Return True once a broadcaster access token has been saved."""
         self._config.get()
         return bool(self._config.cparser.value("twitchbot/accesstoken"))
 
@@ -153,10 +156,12 @@ class _TwitchChatPage(QWizardPage):
         self.setLayout(layout)
 
     def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Start polling when the page is shown."""
         self._poll()
         self._timer.start(1000)
 
     def cleanupPage(self) -> None:  # pylint: disable=invalid-name
+        """Stop polling when the user navigates away."""
         self._timer.stop()
 
     def _copy_url(self) -> None:
@@ -217,10 +222,12 @@ class _KickPage(QWizardPage):
         self.setLayout(layout)
 
     def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Start polling when the page is shown."""
         self._poll()
         self._timer.start(1000)
 
     def cleanupPage(self) -> None:  # pylint: disable=invalid-name
+        """Stop polling when the user navigates away."""
         self._timer.stop()
 
     def _open_browser(self) -> None:
@@ -251,11 +258,12 @@ class _KickPage(QWizardPage):
             self.completeChanged.emit()
 
     def isComplete(self) -> bool:  # pylint: disable=invalid-name
+        """Return True once a Kick access token has been saved."""
         self._config.get()
         return bool(self._config.cparser.value("kick/accesstoken"))
 
 
-class _FinishPage(QWizardPage):
+class _FinishPage(QWizardPage):  # pylint: disable=too-few-public-methods
     """Final page confirming authentication is complete."""
 
     def __init__(self, platforms: list[str], parent: QWidget | None = None) -> None:
@@ -275,7 +283,7 @@ class _FinishPage(QWizardPage):
         self.setLayout(layout)
 
 
-class AuthWizard(QWizard):
+class AuthWizard(QWizard):  # pylint: disable=too-few-public-methods
     """Step-by-step OAuth authorization wizard for Twitch and/or Kick.
 
     Pass ``platforms`` as a list containing 'twitch', 'kick', or both.

--- a/nowplaying/installwizard/__init__.py
+++ b/nowplaying/installwizard/__init__.py
@@ -137,6 +137,14 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
             if op.discord_rp_check.isChecked():
                 cparser.setValue("discord/clientid", cp.discord_clientid.text().strip())
 
+        pending_oauth = []
+        if op.twitch_check.isChecked():
+            pending_oauth.append("twitch")
+        if op.kick_check.isChecked():
+            pending_oauth.append("kick")
+        if pending_oauth:
+            cparser.setValue("settings/pending_oauth", ",".join(pending_oauth))
+
         self.config.initialized = True
         self.config.save()
         logging.info("wizard: first-run setup complete")

--- a/nowplaying/installwizard/__init__.py
+++ b/nowplaying/installwizard/__init__.py
@@ -77,7 +77,7 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
                 self._outputs_page.enabled_display_names(),
             )
 
-    def _commit(self) -> None:
+    def _commit(self) -> None:  # pylint: disable=too-many-branches,too-many-statements
         """Persist all wizard choices to QSettings and mark initialized."""
         cparser = self.config.cparser
 

--- a/nowplaying/installwizard/_configure_outputs.py
+++ b/nowplaying/installwizard/_configure_outputs.py
@@ -112,11 +112,13 @@ class _ConfigureOutputsPage(QWizardPage):
         self.twitch_channel.setText(
             str(self.config.cparser.value("twitchbot/channel", defaultValue="") or "")
         )
-        self.twitch_clientid.setPlaceholderText("Client ID from dev.twitch.tv")
+        self.twitch_clientid.setPlaceholderText(
+            "Optional — leave blank to use bundled app (port 8899)"
+        )
         self.twitch_clientid.setText(
             str(self.config.cparser.value("twitchbot/clientid", defaultValue="") or "")
         )
-        self.twitch_secret.setPlaceholderText("Client secret")
+        self.twitch_secret.setPlaceholderText("Optional — not required for public client apps")
         self.twitch_secret.setEchoMode(QLineEdit.EchoMode.Password)
         self.twitch_secret.setText(
             str(self.config.cparser.value("twitchbot/secret", defaultValue="") or "")

--- a/nowplaying/kick/settings.py
+++ b/nowplaying/kick/settings.py
@@ -9,6 +9,7 @@ from typing import Any
 from PySide6.QtCore import QObject, QTimer, Slot  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QCheckBox, QTableWidgetItem  # pylint: disable=no-name-in-module
 
+import nowplaying.authwizard
 import nowplaying.config
 import nowplaying.kick.oauth2
 import nowplaying.kick.utils
@@ -35,7 +36,7 @@ class KickSettings:
     def connect(self, uihelp: Any, widget: Any) -> None:  # pylint: disable=unused-argument
         """connect kick"""
         self.widget = widget
-        widget.authenticate_button.clicked.connect(self.authenticate_oauth)
+        widget.authenticate_button.clicked.connect(self._launch_auth_wizard)
         widget.clientid_lineedit.editingFinished.connect(self.update_oauth_status)
         widget.secret_lineedit.editingFinished.connect(self.update_oauth_status)
 
@@ -107,44 +108,13 @@ class KickSettings:
 
         # Note: redirect URI validation removed - it's auto-generated and not user-configurable
 
-    def authenticate_oauth(self) -> None:
-        """initiate OAuth2 authentication flow"""
+    def _launch_auth_wizard(self) -> None:
+        """Open the authentication wizard for Kick."""
         if not self.oauth:
-            logging.error("OAuth2 handler not initialized")
             return
-
-        # Update config with current form values
-        if self.widget:
-            self.oauth.client_id = self.widget.clientid_lineedit.text().strip()
-            self.oauth.client_secret = self.widget.secret_lineedit.text().strip()
-            # Redirect URI is set dynamically by webserver, not stored here
-            self.oauth.redirect_uri = self.widget.redirecturi_label.text().strip()
-
-        # Validate required fields
-        if not self.oauth.client_id:
-            self.widget.oauth_status_label.setText("Error: Client ID required")
-            return
-        if not self.oauth.client_secret:
-            self.widget.oauth_status_label.setText("Error: Client Secret required")
-            return
-        # Note: redirect URI is always valid since it's auto-generated
-
-        try:
-            # Open browser for authentication
-            if self.oauth.open_browser_for_auth():
-                self.widget.oauth_status_label.setText("Browser opened - complete authentication")
-                self.widget.authenticate_button.setText("Authentication in progress...")
-                self.widget.authenticate_button.setEnabled(False)
-
-                # Start checking for authentication completion
-                # Note: In a real implementation, you'd want to monitor the webserver
-                # for the OAuth callback and automatically update the status
-                logging.info("Kick OAuth2 authentication initiated")
-            else:
-                self.widget.oauth_status_label.setText("Failed to open browser")
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.error("Kick OAuth2 authentication error: %s", error)
-            self.widget.oauth_status_label.setText(f"Authentication error: {error}")
+        wizard = nowplaying.authwizard.AuthWizard(self.oauth.config, ["kick"])
+        wizard.exec()
+        self.update_oauth_status()
 
     def start_status_timer(self) -> None:
         """Start periodic status updates to catch automatic token refresh"""
@@ -182,11 +152,11 @@ class KickSettings:
         has_token = bool(cparser.value(ACCESS_TOKEN_KEY, defaultValue=""))
         if status == OAUTH_STATUS_AUTHENTICATED:
             self.widget.oauth_status_label.setText("Authenticated")
-            self.widget.authenticate_button.setText("Re-authenticate")
+            self.widget.authenticate_button.setText("Re-authenticate...")
             self.widget.authenticate_button.setEnabled(True)
         elif status == OAUTH_STATUS_EXPIRED:
             self.widget.oauth_status_label.setText("Token expired — re-authenticate")
-            self.widget.authenticate_button.setText("Authenticate with Kick")
+            self.widget.authenticate_button.setText("Auth Wizard...")
             self.widget.authenticate_button.setEnabled(True)
         elif has_token:
             self.widget.oauth_status_label.setText("Connecting...")
@@ -194,7 +164,7 @@ class KickSettings:
             self.widget.authenticate_button.setEnabled(False)
         else:
             self.widget.oauth_status_label.setText("Not authenticated")
-            self.widget.authenticate_button.setText("Authenticate with Kick")
+            self.widget.authenticate_button.setText("Auth Wizard...")
             self.widget.authenticate_button.setEnabled(True)
 
     def clear_authentication(self) -> None:

--- a/nowplaying/oauth2.py
+++ b/nowplaying/oauth2.py
@@ -34,6 +34,9 @@ class ServiceConfig(TypedDict):
     authorize_endpoint: str  # e.g., '/oauth/authorize' for Kick, '/oauth2/authorize' for Twitch
     revoke_endpoint: NotRequired[str]  # e.g., '/oauth/revoke' (optional)
     validate_endpoint: NotRequired[str]  # e.g., '/oauth2/validate' for Twitch (optional)
+    token_params_in_url: NotRequired[
+        bool
+    ]  # Send token params as URL query string (Twitch requires this)
 
 
 class OAuth2Client:  # pylint: disable=too-many-instance-attributes
@@ -64,6 +67,7 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
         self.authorize_endpoint = service_config["authorize_endpoint"]
         self.revoke_endpoint = service_config.get("revoke_endpoint")
         self.validate_endpoint = service_config.get("validate_endpoint")
+        self.token_params_in_url: bool = service_config.get("token_params_in_url", False)
 
         # Read service-specific config
         self.client_id: str = self.config.cparser.value(f"{self.config_prefix}/clientid")
@@ -187,6 +191,44 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
         logging.info("Generated OAuth2 authorization URL for %s", self.config_prefix)
         return auth_url
 
+    def get_implicit_auth_url(
+        self, scopes: list[str] | None = None, state_key: str | None = None
+    ) -> str:
+        """Generate auth URL for OAuth2 implicit grant flow (response_type=token).
+
+        Used when no client_secret is available. The access token is returned in the
+        URL fragment and must be extracted client-side via JavaScript. No refresh token
+        is issued; the token is valid until revoked.
+
+        Args:
+            scopes: OAuth scopes to request (defaults to service default_scopes)
+            state_key: Config key for storing the CSRF state value. Defaults to
+                ``{config_prefix}/implicit_state``. Callers should use distinct keys
+                when multiple implicit flows (e.g. broadcaster + chat) share a prefix.
+        """
+        validated_client_id = self.validate_client_id(self.client_id)
+        if not self.redirect_uri:
+            raise ValueError("Redirect URI is required")
+        if scopes is None:
+            scopes = self.default_scopes
+
+        state = secrets.token_urlsafe(32)
+        stored_key = state_key or f"{self.config_prefix}/implicit_state"
+        self.config.cparser.setValue(stored_key, state)
+        self.config.save()
+
+        params: dict[str, str] = {
+            "client_id": validated_client_id,
+            "response_type": "token",
+            "redirect_uri": self.redirect_uri,
+            "scope": " ".join(scopes),
+            "state": state,
+        }
+        params |= self._get_additional_auth_params()
+
+        logging.info("Generated OAuth2 implicit grant URL for %s", self.config_prefix)
+        return f"{self.oauth_host}{self.authorize_endpoint}?{urllib.parse.urlencode(params)}"
+
     def open_browser_for_auth(self, scopes: list[str] | None = None) -> bool:
         """Open browser to initiate OAuth2 flow"""
         auth_url = self.get_authorization_url(scopes)
@@ -245,28 +287,31 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
         token_data = {
             "grant_type": "authorization_code",
             "client_id": self.client_id,
-            "client_secret": self.client_secret,
             "code": authorization_code,
             "redirect_uri": self.redirect_uri,
             "code_verifier": self.code_verifier,
         }
+        if self.client_secret:
+            token_data["client_secret"] = self.client_secret
 
-        logging.debug(
-            "%s token exchange using redirect_uri: %s", self.config_prefix, self.redirect_uri
-        )
-
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        }
+        token_url = f"{self.oauth_host}{self.token_endpoint}"
+        if self.token_params_in_url:
+            # Twitch requires params as URL query string (not POST body)
+            headers = {"Accept": "application/json"}
+            post_kwargs: dict = {"params": token_data, "headers": headers}
+        else:
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            }
+            post_kwargs = {"data": token_data, "headers": headers}
 
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
-                    f"{self.oauth_host}{self.token_endpoint}",
-                    data=token_data,
-                    headers=headers,
+                    token_url,
                     timeout=aiohttp.ClientTimeout(total=30),
+                    **post_kwargs,
                 ) as response:
                     if response.status == 200:
                         token_response: dict[str, Any] = await response.json()
@@ -313,9 +358,10 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
         token_data = {
             "grant_type": "refresh_token",
             "client_id": self.client_id,
-            "client_secret": self.client_secret,
             "refresh_token": refresh_token,
         }
+        if self.client_secret:
+            token_data["client_secret"] = self.client_secret
 
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
@@ -510,8 +556,8 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
     def get_auth_url(self, token_type: str = "main") -> str | None:  # pylint: disable=unused-argument
         """Generate OAuth authentication URL for specified token type"""
         # Validate configuration
-        if not self.client_id or not self.client_secret:
-            logging.error("OAuth2 configuration incomplete")
+        if not self.client_id:
+            logging.error("OAuth2 configuration incomplete: client_id missing")
             return None
 
         # Set appropriate redirect URI based on token type
@@ -529,7 +575,7 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
 
     def is_configuration_complete(self) -> bool:
         """Check if OAuth configuration is complete"""
-        return bool(self.client_id and self.client_secret)
+        return bool(self.client_id)
 
     def get_redirect_uri(self, token_type: str = "main") -> str:  # pylint: disable=unused-argument
         """Get the redirect URI for the specified token type"""

--- a/nowplaying/oauth2.py
+++ b/nowplaying/oauth2.py
@@ -226,7 +226,7 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
         }
         params |= self._get_additional_auth_params()
 
-        logging.info("Generated OAuth2 implicit grant URL for %s", self.config_prefix)
+        logging.debug("Generated OAuth2 implicit grant URL for %s", self.config_prefix)
         return f"{self.oauth_host}{self.authorize_endpoint}?{urllib.parse.urlencode(params)}"
 
     def open_browser_for_auth(self, scopes: list[str] | None = None) -> bool:

--- a/nowplaying/oauth2.py
+++ b/nowplaying/oauth2.py
@@ -241,7 +241,7 @@ class OAuth2Client:  # pylint: disable=too-many-instance-attributes
             logging.error("Failed to open browser for %s OAuth2: %s", self.config_prefix, error)
             return False
 
-    async def exchange_code_for_token(
+    async def exchange_code_for_token(  # pylint: disable=too-many-locals
         self, authorization_code: str, received_state: str | None = None
     ) -> dict[str, Any]:
         """Exchange authorization code for access token"""

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -571,9 +571,10 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         return web.Response(content_type="text/html", text=html)
 
     @staticmethod
-    async def _handle_implicit_token(
+    async def _handle_implicit_token(  # pylint: disable=too-many-arguments
         request: web.Request,
         token_key: str,
+        refresh_key: str,
         state_config_key: str,
         service_name: str,
         template_prefix: str,
@@ -626,9 +627,6 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         config.cparser.remove(state_config_key)
         config.cparser.setValue(token_key, access_token)
         # Implicit flow has no refresh token; clear any stale one from a prior auth code flow
-        refresh_key = token_key.replace("accesstoken", "refreshtoken").replace(
-            "chattoken", "chatrefreshtoken"
-        )
         config.cparser.remove(refresh_key)
         config.save()
         logging.info("%s implicit: access token saved", service_name)
@@ -685,6 +683,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         return await self._handle_implicit_token(
             request,
             token_key="twitchbot/accesstoken",
+            refresh_key="twitchbot/refreshtoken",
             state_config_key="twitchbot/implicit_state_broadcaster",
             service_name="Twitch OAuth2",
             template_prefix="twitch_oauth",
@@ -695,6 +694,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         return await self._handle_implicit_token(
             request,
             token_key="twitchbot/chattoken",
+            refresh_key="twitchbot/chatrefreshtoken",
             state_config_key="twitchbot/implicit_state_chat",
             service_name="Twitch Chat OAuth2",
             template_prefix="twitch_oauth",

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -571,7 +571,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         return web.Response(content_type="text/html", text=html)
 
     @staticmethod
-    async def _handle_implicit_token(  # pylint: disable=too-many-arguments
+    async def _handle_implicit_token(  # pylint: disable=too-many-arguments,too-many-locals
         request: web.Request,
         token_key: str,
         refresh_key: str,

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -556,8 +556,93 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             },
         )
 
+    @staticmethod
+    async def _serve_twitch_implicit_extract(
+        request: web.Request, token_path: str
+    ) -> web.Response:
+        """Serve the JS fragment-extraction page for Twitch implicit grant flow."""
+        jinja2_env = request.app[JINJA2_KEY]
+        try:
+            template = jinja2_env.get_template("oauth/twitch_oauth_implicit_extract.htm")
+            html = template.render(token_path=token_path)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Failed to render implicit extract template")
+            html = "<html><body><h1>Template Error</h1></body></html>"
+        return web.Response(content_type="text/html", text=html)
+
+    @staticmethod
+    async def _handle_implicit_token(
+        request: web.Request,
+        token_key: str,
+        state_config_key: str,
+        service_name: str,
+        template_prefix: str,
+        success_template: str | None = None,
+    ) -> web.Response:
+        """Store an access token received from the implicit grant flow JS redirect."""
+        config = request.app[CONFIG_KEY]
+        jinja2_env = request.app[JINJA2_KEY]
+        config.get()
+        params = dict(request.query)
+
+        def load_tmpl(name: str, **kwargs) -> str:
+            try:
+                return jinja2_env.get_template(f"oauth/{name}").render(**kwargs)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.exception("Template error: %s", name)
+                return "<html><body><h1>Template Error</h1></body></html>"
+
+        if error_code := params.get("error"):
+            error_description = params.get("error_description", "No description provided")
+            logging.warning(
+                "%s implicit error: %s - %s", service_name, error_code, error_description
+            )
+            html = load_tmpl(
+                f"{template_prefix}_error.htm",
+                error_code=error_code,
+                error_description=error_description,
+                service_name=service_name,
+            )
+            return web.Response(content_type="text/html", text=html)
+
+        access_token = params.get("access_token")
+        if not access_token:
+            logging.warning("%s implicit: no access_token received", service_name)
+            html = load_tmpl(f"{template_prefix}_no_code.htm", service_name=service_name)
+            return web.Response(content_type="text/html", text=html)
+
+        # CSRF state validation — fail closed: reject if either side is absent
+        expected_state = config.cparser.value(state_config_key)
+        received_state = params.get("state", "")
+        if (
+            not expected_state
+            or not received_state
+            or not secrets.compare_digest(received_state, str(expected_state))
+        ):
+            logging.warning("%s implicit: state mismatch/missing, possible CSRF", service_name)
+            html = load_tmpl(f"{template_prefix}_csrf_error.htm", service_name=service_name)
+            return web.Response(content_type="text/html", text=html, status=400)
+
+        config.cparser.remove(state_config_key)
+        config.cparser.setValue(token_key, access_token)
+        # Implicit flow has no refresh token; clear any stale one from a prior auth code flow
+        refresh_key = token_key.replace("accesstoken", "refreshtoken").replace(
+            "chattoken", "chatrefreshtoken"
+        )
+        config.cparser.remove(refresh_key)
+        config.save()
+        logging.info("%s implicit: access token saved", service_name)
+
+        tmpl_name = success_template or f"{template_prefix}_success.htm"
+        html = load_tmpl(tmpl_name, service_name=service_name)
+        return web.Response(content_type="text/html", text=html)
+
     async def twitchredirect_handler(self, request: web.Request):  # pylint: disable=no-self-use
         """handle oauth2 redirect callbacks for Twitch broadcaster tokens"""
+        # Implicit grant: Twitch sends the token in the URL fragment, which browsers
+        # never include in HTTP requests, so the server sees no query params at all.
+        if not request.query.get("code") and not request.query.get("error"):
+            return await self._serve_twitch_implicit_extract(request, "twitchredirect_implicit")
         return await self._handle_oauth_redirect(
             request,
             {
@@ -575,6 +660,10 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
 
     async def twitchchatredirect_handler(self, request: web.Request):  # pylint: disable=no-self-use
         """handle oauth2 redirect callbacks for Twitch chat tokens"""
+        if not request.query.get("code") and not request.query.get("error"):
+            return await self._serve_twitch_implicit_extract(
+                request, "twitchchatredirect_implicit"
+            )
         return await self._handle_oauth_redirect(
             request,
             {
@@ -589,6 +678,27 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                 },
                 "success_template": "twitch_chat_oauth_success.htm",
             },
+        )
+
+    async def twitchredirect_implicit_handler(self, request: web.Request):  # pylint: disable=no-self-use
+        """Receive implicit grant token for Twitch broadcaster (forwarded by JS)."""
+        return await self._handle_implicit_token(
+            request,
+            token_key="twitchbot/accesstoken",
+            state_config_key="twitchbot/implicit_state_broadcaster",
+            service_name="Twitch OAuth2",
+            template_prefix="twitch_oauth",
+        )
+
+    async def twitchchatredirect_implicit_handler(self, request: web.Request):  # pylint: disable=no-self-use
+        """Receive implicit grant token for Twitch chat (forwarded by JS)."""
+        return await self._handle_implicit_token(
+            request,
+            token_key="twitchbot/chattoken",
+            state_config_key="twitchbot/implicit_state_chat",
+            service_name="Twitch Chat OAuth2",
+            template_prefix="twitch_oauth",
+            success_template="twitch_chat_oauth_success.htm",
         )
 
     def create_runner(self):
@@ -621,7 +731,9 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                 web.get("/index.txt", self.static_handler.indextxt_handler),
                 web.get("/kickredirect", self.kickredirect_handler),
                 web.get("/twitchredirect", self.twitchredirect_handler),
+                web.get("/twitchredirect_implicit", self.twitchredirect_implicit_handler),
                 web.get("/twitchchatredirect", self.twitchchatredirect_handler),
+                web.get("/twitchchatredirect_implicit", self.twitchchatredirect_implicit_handler),
                 web.get("/request.htm", self.static_handler.requesterlaunch_htm_handler),
                 web.get("/internals", self.internals),
                 web.get("/v1/status", self.status),

--- a/nowplaying/resources/ui/kick.ui
+++ b/nowplaying/resources/ui/kick.ui
@@ -133,7 +133,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Authenticate with Kick</string>
+         <string>Auth Wizard...</string>
         </property>
        </widget>
       </item>

--- a/nowplaying/resources/ui/twitch.ui
+++ b/nowplaying/resources/ui/twitch.ui
@@ -68,6 +68,9 @@
         <property name="enabled">
          <bool>false</bool>
         </property>
+        <property name="placeholderText">
+         <string>Optional — leave blank to use bundled app (port 8899 only)</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
@@ -76,7 +79,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Secret *</string>
+         <string>Client Secret</string>
         </property>
        </widget>
       </item>
@@ -88,6 +91,9 @@
         <property name="echoMode">
          <enum>QLineEdit::Password</enum>
         </property>
+        <property name="placeholderText">
+         <string>Optional — not required for public client apps</string>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">
@@ -96,7 +102,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>OAuth Status</string>
+         <string>Broadcaster</string>
         </property>
        </widget>
       </item>
@@ -110,53 +116,36 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <layout class="QHBoxLayout" name="auth_buttons_layout">
-        <item>
-         <widget class="QPushButton" name="copy_broadcaster_auth_button">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Copy Broadcaster Auth URL</string>
-          </property>
-          <property name="toolTip">
-           <string>Copy broadcaster authentication URL to clipboard. Use this for your main streaming account that will handle channel points redemptions and API access.</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="copy_chat_auth_button">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Copy Chat Bot Auth URL</string>
-          </property>
-          <property name="toolTip">
-           <string>Copy chat bot authentication URL to clipboard. Use this for a separate bot account that will only handle chat messages. Optional - leave empty to use broadcaster account for chat.</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="chatbot_username_label">
+      <item row="4" column="0">
+       <widget class="QLabel" name="chat_label">
         <property name="enabled">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="text">
-         <string>Account Name</string>
+         <string>Chat Bot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="chat_status_label">
+        <property name="text">
+         <string>Using broadcaster account</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
         </property>
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="QLabel" name="chatbot_username_line">
-        <property name="text">
-         <string>autodetermined bot username</string>
+       <widget class="QPushButton" name="authenticate_button">
+        <property name="enabled">
+         <bool>false</bool>
         </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
+        <property name="text">
+         <string>Auth Wizard...</string>
+        </property>
+        <property name="toolTip">
+         <string>Opens the wizard to authorize your Twitch accounts. Step 1: broadcaster account (required). Step 2: separate chat bot account (optional — skip to use the broadcaster account for chat).</string>
         </property>
        </widget>
       </item>
@@ -221,16 +210,10 @@ li.unchecked::marker { content: &quot;\2610&quot;; }
 li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body&gt;
 &lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;&lt;span style=&quot;font-weight: 700&quot;&gt;Twitch.tv Integration Setup:&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;1. Create a Twitch application at &lt;span style=&quot;font-weight: 700&quot;&gt;https://dev.twitch.tv/console&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;2. Copy the &lt;span style=&quot;font-weight: 700&quot;&gt;Client ID&lt;/span&gt; and &lt;span style=&quot;font-weight: 700&quot;&gt;Client Secret&lt;/span&gt; from your application&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;3. Set redirect URIs in your Twitch application to: &lt;span style=&quot;font-weight: 700&quot;&gt;http://localhost:8899/twitchredirect&lt;/span&gt; and &lt;span style=&quot;font-weight: 700&quot;&gt;http://localhost:8899/twitchchatredirect&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;4. Enter your channel name (username where you want to monitor/send messages)&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;5. Choose your authentication method:&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;&lt;span style=&quot;font-weight: 700&quot;&gt;Option A (Recommended):&lt;/span&gt; Use only &lt;span style=&quot;font-weight: 700&quot;&gt;Copy Broadcaster Auth URL&lt;/span&gt; for all features&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;&lt;span style=&quot;font-weight: 700&quot;&gt;Option B (Advanced):&lt;/span&gt; Use both buttons for separate bot/broadcaster accounts&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;6. Open each URL in your browser and complete the authorization&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;&lt;span style=&quot;font-weight: 700; color: #d32f2f&quot;&gt;⚠️ IMPORTANT:&lt;/span&gt;&lt;span style=&quot;color: #d32f2f&quot;&gt; For Option B, make sure you are logged into the correct account before using each URL: your main streaming account for broadcaster auth, and your bot account for chat auth.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;OAuth2 provides secure authentication. The broadcaster token handles channel points and API access, while the optional chat token is only for chat messages.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;1. Enter your Twitch channel name (your streaming username).&lt;/p&gt;
+&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;2. Click &lt;span style=&quot;font-weight: 700&quot;&gt;Auth Wizard&lt;/span&gt; and follow the steps to authorize your accounts.&lt;/p&gt;
+&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;The wizard has two steps: &lt;span style=&quot;font-weight: 700&quot;&gt;Broadcaster&lt;/span&gt; (required — handles chat, channel points, and stream title) and &lt;span style=&quot;font-weight: 700&quot;&gt;Chat Bot&lt;/span&gt; (optional — only needed if you want a separate bot account posting in chat).&lt;/p&gt;
+&lt;p style=&quot;margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px&quot;&gt;&lt;span style=&quot;font-weight: 700&quot;&gt;Advanced:&lt;/span&gt; Client ID and Secret are only needed if you are running WNP on a port other than 8899 and need your own Twitch application. Leave blank to use the built-in WNP application.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -247,25 +230,13 @@ li.checked::marker { content: &quot;\2612&quot;; }
   <connection>
    <sender>enable_checkbox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>clientid_label</receiver>
-   <slot>setEnabled(bool)</slot>
-  </connection>
-  <connection>
-   <sender>enable_checkbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>secret_lineedit</receiver>
-   <slot>setEnabled(bool)</slot>
-  </connection>
-  <connection>
-   <sender>enable_checkbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>secret_label</receiver>
-   <slot>setEnabled(bool)</slot>
-  </connection>
-  <connection>
-   <sender>enable_checkbox</sender>
-   <signal>toggled(bool)</signal>
    <receiver>channel_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>clientid_label</receiver>
    <slot>setEnabled(bool)</slot>
   </connection>
   <connection>
@@ -277,19 +248,31 @@ li.checked::marker { content: &quot;\2612&quot;; }
   <connection>
    <sender>enable_checkbox</sender>
    <signal>toggled(bool)</signal>
+   <receiver>secret_label</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>secret_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
    <receiver>oauth_label</receiver>
    <slot>setEnabled(bool)</slot>
   </connection>
   <connection>
    <sender>enable_checkbox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>copy_broadcaster_auth_button</receiver>
+   <receiver>chat_label</receiver>
    <slot>setEnabled(bool)</slot>
   </connection>
   <connection>
    <sender>enable_checkbox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>copy_chat_auth_button</receiver>
+   <receiver>authenticate_button</receiver>
    <slot>setEnabled(bool)</slot>
   </connection>
   <connection>

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -338,8 +338,9 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         if not pending:
             return
         port = int(str(self.config.cparser.value("weboutput/httpport", defaultValue="8899")))
-        self._oauth_poller = _WebserverPollThread(port, parent=None)
+        self._oauth_poller = _WebserverPollThread(port, parent=self.tray)
         self._oauth_poller.ready.connect(self._handle_pending_oauth)
+        self._oauth_poller.finished.connect(self._on_oauth_poller_finished)
         self._oauth_poller.start()
 
     def _handle_pending_oauth(self) -> None:
@@ -353,6 +354,10 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             return
         wizard = nowplaying.authwizard.AuthWizard(self.config, platforms)
         wizard.exec()
+
+    def _on_oauth_poller_finished(self) -> None:
+        """Drop our reference to the OAuth poller thread once it finishes."""
+        self._oauth_poller = None
 
     def _handle_installer_dialogs(self) -> None:
         """Handle installer dialogs that may require window hiding."""

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -73,6 +73,7 @@ class _WebserverPollThread(QThread):  # pylint: disable=too-few-public-methods
         self._port = port
 
     def run(self) -> None:
+        """Poll the webserver port until it accepts connections, then emit ready."""
         for _ in range(60):
             try:
                 with socket.create_connection(("localhost", self._port), timeout=1.0):

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -2,6 +2,7 @@
 """system tray"""
 
 import logging
+import socket
 import sqlite3
 
 from PySide6.QtCore import (  # pylint: disable=no-name-in-module
@@ -20,6 +21,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QSystemTrayIcon,
 )
 
+import nowplaying.authwizard
 import nowplaying.installwizard
 import nowplaying.upgrade
 import nowplaying.upgrades
@@ -61,6 +63,26 @@ class _VacuumThread(QThread):  # pylint: disable=too-few-public-methods
         logging.debug("Background database vacuum complete")
 
 
+class _WebserverPollThread(QThread):  # pylint: disable=too-few-public-methods
+    """Polls the local webserver port until it accepts connections, then emits ready."""
+
+    ready = Signal()
+
+    def __init__(self, port: int, parent=None) -> None:
+        super().__init__(parent)
+        self._port = port
+
+    def run(self) -> None:
+        for _ in range(60):
+            try:
+                with socket.create_connection(("localhost", self._port), timeout=1.0):
+                    self.ready.emit()
+                    return
+            except OSError:
+                self.sleep(1)
+        logging.warning("wizard: webserver did not start within 60s; skipping OAuth prompt")
+
+
 class Tray:  # pylint: disable=too-many-instance-attributes
     """System Tray object"""
 
@@ -78,6 +100,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.link_thread = None  # QThread for Twitch account linking
         self.vacuum_thread = None  # QThread for background database vacuum
         self._prefetch_worker = None  # QThread for background update pre-fetch
+        self._oauth_poller: _WebserverPollThread | None = None
         self._obs_export_dialog = None
 
         # Core initialization
@@ -304,6 +327,32 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         # Pre-fetch the next update archive in the background so the next
         # launch can skip the download step and install immediately.
         self._start_background_prefetch()
+
+        # If the first-run wizard configured Twitch/Kick, wait for the webserver
+        # to be ready, then prompt the user to complete OAuth.
+        self._schedule_oauth_prompt()
+
+    def _schedule_oauth_prompt(self) -> None:
+        """Start webserver polling if first-run wizard left a pending OAuth flag."""
+        pending = str(self.config.cparser.value("settings/pending_oauth", defaultValue=""))
+        if not pending:
+            return
+        port = int(str(self.config.cparser.value("weboutput/httpport", defaultValue="8899")))
+        self._oauth_poller = _WebserverPollThread(port, parent=None)
+        self._oauth_poller.ready.connect(self._handle_pending_oauth)
+        self._oauth_poller.start()
+
+    def _handle_pending_oauth(self) -> None:
+        """Launch the auth wizard for platforms configured during first-run setup."""
+        pending = str(self.config.cparser.value("settings/pending_oauth", defaultValue=""))
+        if not pending:
+            return
+        self.config.cparser.remove("settings/pending_oauth")
+        platforms = [p.strip() for p in pending.split(",") if p.strip()]
+        if not platforms:
+            return
+        wizard = nowplaying.authwizard.AuthWizard(self.config, platforms)
+        wizard.exec()
 
     def _handle_installer_dialogs(self) -> None:
         """Handle installer dialogs that may require window hiding."""

--- a/nowplaying/templates/oauth/twitch_oauth_implicit_extract.htm
+++ b/nowplaying/templates/oauth/twitch_oauth_implicit_extract.htm
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Completing Twitch Authorization...</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; background: white; padding: 30px;
+                     border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .info { color: #9146ff; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2 class="info">Completing Twitch authorization...</h2>
+        <p id="status">Extracting token, please wait.</p>
+    </div>
+    <script>
+        // The access token arrives in the URL fragment (#...) which is never sent
+        // to the server. Extract it here and forward it as a query parameter.
+        var fragment = window.location.hash.substring(1);
+        var params = new URLSearchParams(fragment);
+        var token = params.get('access_token');
+        var state = params.get('state');
+        var error = params.get('error');
+
+        if (error) {
+            var q = new URLSearchParams({error: error});
+            var desc = params.get('error_description');
+            if (desc) q.set('error_description', desc);
+            if (state) q.set('state', state);
+            window.location.replace('/{{ token_path }}?' + q.toString());
+        } else if (token) {
+            var q2 = new URLSearchParams({access_token: token});
+            if (state) q2.set('state', state);
+            window.location.replace('/{{ token_path }}?' + q2.toString());
+        } else {
+            document.getElementById('status').textContent =
+                'Error: no token received from Twitch. You may close this window and try again.';
+        }
+    </script>
+</body>
+</html>

--- a/nowplaying/twitch/constants.py
+++ b/nowplaying/twitch/constants.py
@@ -6,21 +6,28 @@ from twitchAPI.type import AuthScope
 
 import nowplaying.oauth2
 
+# Bundled WNP Twitch application (public client — no secret, PKCE only)
+TWITCH_BUNDLED_CLIENT_ID = "l89y18ioij2pk7zgk7tzbenc39z2xn"
+
 # OAuth and API endpoints
 OAUTH_HOST = "https://id.twitch.tv"
 API_HOST = "https://api.twitch.tv/helix"
 
 # OAuth scopes - AuthScope enums for TwitchAPI library
 
-# Chat bot scopes (minimal permissions for dedicated bot accounts)
-CHAT_BOT_AUTH_SCOPES: list[AuthScope] = [
+# Common chat scopes needed by both broadcaster and bot accounts
+_CHAT_BASE_SCOPES: list[AuthScope] = [
     AuthScope.CHAT_READ,
     AuthScope.CHAT_EDIT,
+]
+
+# Chat bot scopes — USER_BOT allows a channel to designate this account as a trusted bot
+CHAT_BOT_AUTH_SCOPES: list[AuthScope] = _CHAT_BASE_SCOPES + [
     AuthScope.USER_BOT,
 ]
 
-# Broadcaster scopes (chat scopes + additional broadcaster permissions)
-BROADCASTER_AUTH_SCOPES: list[AuthScope] = CHAT_BOT_AUTH_SCOPES + [
+# Broadcaster scopes — chat read/send + broadcast management; no USER_BOT (wrong for own account)
+BROADCASTER_AUTH_SCOPES: list[AuthScope] = _CHAT_BASE_SCOPES + [
     AuthScope.CHANNEL_READ_REDEMPTIONS,
     AuthScope.CHANNEL_MANAGE_BROADCAST,
 ]

--- a/nowplaying/twitch/constants.py
+++ b/nowplaying/twitch/constants.py
@@ -6,7 +6,10 @@ from twitchAPI.type import AuthScope
 
 import nowplaying.oauth2
 
-# Bundled WNP Twitch application (public client — no secret, PKCE only)
+# Public OAuth2 client identifier for the bundled WNP Twitch application.
+# This is NOT a secret — Twitch client IDs are public by design (analogous to
+# an app's bundle ID). The implicit grant flow used here has no client secret;
+# security comes from CSRF state validation and Twitch's redirect-URI allowlist.
 TWITCH_BUNDLED_CLIENT_ID = "l89y18ioij2pk7zgk7tzbenc39z2xn"
 
 # OAuth and API endpoints

--- a/nowplaying/twitch/oauth2.py
+++ b/nowplaying/twitch/oauth2.py
@@ -9,7 +9,11 @@ import requests
 
 import nowplaying.config
 import nowplaying.oauth2
-from nowplaying.twitch.constants import CHAT_BOT_SCOPE_STRINGS, TWITCH_SERVICE_CONFIG
+from nowplaying.twitch.constants import (
+    CHAT_BOT_SCOPE_STRINGS,
+    TWITCH_BUNDLED_CLIENT_ID,
+    TWITCH_SERVICE_CONFIG,
+)
 
 
 class TwitchOAuth2(nowplaying.oauth2.OAuth2Client):
@@ -17,6 +21,8 @@ class TwitchOAuth2(nowplaying.oauth2.OAuth2Client):
 
     def __init__(self, config: nowplaying.config.ConfigFile | None = None) -> None:
         super().__init__(config, TWITCH_SERVICE_CONFIG)
+        if not self.client_id:
+            self.client_id = TWITCH_BUNDLED_CLIENT_ID
 
     def _get_additional_auth_params(self) -> dict[str, str]:
         """Add Twitch-specific authorization parameters"""
@@ -66,24 +72,37 @@ class TwitchOAuth2(nowplaying.oauth2.OAuth2Client):
         }
 
     def get_auth_url(self, token_type: str = "broadcaster") -> str | None:
-        """Generate OAuth authentication URL for specified token type"""
-        # Validate configuration
-        if not self.client_id or not self.client_secret:
+        """Generate OAuth authentication URL for specified token type.
+
+        Uses implicit grant flow when no client_secret is configured (bundled app),
+        or auth code + PKCE flow when the user has provided their own credentials.
+        Existing setups with a client_secret are unaffected.
+        """
+        if not self.client_id:
             logging.error("OAuth2 configuration incomplete")
             return None
 
-        # Set appropriate redirect URI based on token type
         port = self.config.cparser.value("weboutput/httpport", type=int)
         if token_type == "chat":
             self.redirect_uri = f"http://localhost:{port}/twitchchatredirect"
+            scopes: list[str] | None = CHAT_BOT_SCOPE_STRINGS
         else:
             self.redirect_uri = f"http://localhost:{port}/twitchredirect"
+            scopes = None  # uses default broadcaster scopes
+
+        # Distinct config keys so broadcaster and chat states never collide
+        implicit_state_key = (
+            "twitchbot/implicit_state_chat"
+            if token_type == "chat"
+            else "twitchbot/implicit_state_broadcaster"
+        )
 
         try:
-            # Generate the auth URL with appropriate scopes
-            if token_type == "chat":
-                return self.get_authorization_url(CHAT_BOT_SCOPE_STRINGS)
-            return self.get_authorization_url()  # Uses broadcaster scopes by default
+            if self.client_secret:
+                # User provided their own credentials → auth code + PKCE (unchanged)
+                return self.get_authorization_url(scopes)
+            # Bundled app (no secret) → implicit grant; token arrives in URL fragment
+            return self.get_implicit_auth_url(scopes, state_key=implicit_state_key)
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.error("Failed to generate %s auth URL: %s", token_type, error)
             return None
@@ -155,16 +174,7 @@ class TwitchOAuth2(nowplaying.oauth2.OAuth2Client):
 
 async def main() -> None:
     """Example usage of TwitchOAuth2"""
-    # Initialize with config (will read twitchbot/clientid, twitchbot/secret from config)
     oauth = TwitchOAuth2()
-
-    # Check if configuration is present
-    if not oauth.client_id:
-        print("Error: twitchbot/clientid not configured")
-        return
-    if not oauth.client_secret:
-        print("Error: twitchbot/secret not configured")
-        return
 
     # Set redirect URI dynamically (required for authorization)
     port = oauth.config.cparser.value("weboutput/httpport", type=int)

--- a/nowplaying/twitch/redemptions.py
+++ b/nowplaying/twitch/redemptions.py
@@ -110,11 +110,19 @@ class TwitchRedemptions:  # pylint: disable=too-many-instance-attributes
 
             await asyncio.sleep(4)
 
+            # Reload config so tokens saved by the webserver process are visible here
+            if self.config:
+                self.config.get()
+
             try:
                 if await self._setup_eventsub_connection():
                     loggedin = True
                 else:
-                    await asyncio.sleep(60)
+                    # Short retry if no token yet; longer back-off for connection failures
+                    has_token = bool(
+                        self.config and self.config.cparser.value("twitchbot/accesstoken")
+                    )
+                    await asyncio.sleep(10 if not has_token else 60)
             except Exception:  # pylint: disable=broad-except
                 for line in traceback.format_exc().splitlines():
                     logging.error(line)

--- a/nowplaying/twitch/settings.py
+++ b/nowplaying/twitch/settings.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """twitch settings"""
 
-import logging
 import pathlib
 import time
 

--- a/nowplaying/twitch/settings.py
+++ b/nowplaying/twitch/settings.py
@@ -6,8 +6,8 @@ import pathlib
 import time
 
 from PySide6.QtCore import QTimer, Slot  # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QApplication, QMessageBox  # pylint: disable=no-name-in-module
 
+import nowplaying.authwizard
 import nowplaying.preview.textwindow
 import nowplaying.twitch.oauth2
 import nowplaying.utils.qt
@@ -39,9 +39,7 @@ class TwitchSettings:
         self.widget = widget
         self.uihelp = uihelp
 
-        # Connect OAuth buttons
-        widget.copy_broadcaster_auth_button.clicked.connect(self._copy_broadcaster_auth_link)
-        widget.copy_chat_auth_button.clicked.connect(self._copy_chat_auth_link)
+        widget.authenticate_button.clicked.connect(self._launch_auth_wizard)
         widget.clientid_lineedit.editingFinished.connect(self.update_oauth_status)
         widget.secret_lineedit.editingFinished.connect(self.update_oauth_status)
 
@@ -54,9 +52,9 @@ class TwitchSettings:
         """load the settings window"""
         self.widget = widget
         widget.enable_checkbox.setChecked(config.cparser.value("twitchbot/enabled", type=bool))
-        widget.clientid_lineedit.setText(config.cparser.value("twitchbot/clientid"))
         widget.channel_lineedit.setText(config.cparser.value("twitchbot/channel"))
-        widget.secret_lineedit.setText(config.cparser.value("twitchbot/secret"))
+        widget.clientid_lineedit.setText(config.cparser.value("twitchbot/clientid") or "")
+        widget.secret_lineedit.setText(config.cparser.value("twitchbot/secret") or "")
 
         streamtitle_enabled = config.cparser.value("twitchbot/streamtitle_enabled", type=bool)
         widget.streamtitle_checkbox.setChecked(streamtitle_enabled)
@@ -84,7 +82,7 @@ class TwitchSettings:
         oldchannel = config.cparser.value("twitchbot/channel")
         newchannel = widget.channel_lineedit.text()
         oldclientid = config.cparser.value("twitchbot/clientid")
-        newclientid = widget.clientid_lineedit.text()
+        newclientid = widget.clientid_lineedit.text().strip()
         oldsecret = config.cparser.value("twitchbot/secret")
         newsecret = widget.secret_lineedit.text()
 
@@ -99,15 +97,10 @@ class TwitchSettings:
             "twitchbot/streamtitle", widget.streamtitle_lineedit.text().strip()
         )
 
-        # Redirect URI is dynamically generated, not stored in config
-
-        # Note: Chat token changes don't require restart - chat.py handles token changes dynamically
         if (oldchannel != newchannel) or (oldclientid != newclientid) or (oldsecret != newsecret):
             subprocesses.stop_twitchbot()
-            # Clean up old token storage
             config.cparser.remove("twitchbot/oldusertoken")
             config.cparser.remove("twitchbot/oldrefreshtoken")
-            # Keep OAuth2 tokens (don't remove accesstoken/refreshtoken)
             config.cparser.sync()
             time.sleep(5)
             subprocesses.start_twitchbot()
@@ -118,28 +111,33 @@ class TwitchSettings:
         if not widget.enable_checkbox.isChecked():
             return
 
-        # Check required fields
-        if not widget.clientid_lineedit.text().strip():
-            raise PluginVerifyError("Twitch Client ID is required")
-
-        if not widget.secret_lineedit.text().strip():
-            raise PluginVerifyError("Twitch Client Secret is required")
-
-        # Redirect URI is dynamically generated - no validation needed
-
         if not widget.channel_lineedit.text().strip():
             raise PluginVerifyError("Twitch Channel is required")
+        # Client ID and Secret are optional — blank uses the bundled WNP app (port 8899 only)
 
     @staticmethod
-    def _token_label(status: str, name: str, has_token: bool = False) -> str:
-        """Return a display label for a single token status."""
+    def _broadcaster_status_text(status: str, username: str, has_token: bool) -> str:
+        if username:
+            return username
         if status == OAUTH_STATUS_AUTHENTICATED:
-            return f"{name} authenticated"
+            return "authenticated"
         if status == OAUTH_STATUS_EXPIRED:
-            return f"{name} token expired"
+            return "token expired — re-authenticate"
         if has_token:
-            return f"{name} connecting..."
-        return ""
+            return "connecting..."
+        return "Not authenticated"
+
+    @staticmethod
+    def _chat_status_text(status: str, username: str, has_token: bool) -> str:
+        if username:
+            return username
+        if status == OAUTH_STATUS_AUTHENTICATED:
+            return "authenticated"
+        if status == OAUTH_STATUS_EXPIRED:
+            return "token expired — re-authenticate"
+        if has_token:
+            return "connecting..."
+        return "Using broadcaster account"
 
     def _read_token_statuses(self) -> tuple[str, str, bool, bool]:
         """Read broadcaster and chat token statuses and token presence from cparser."""
@@ -150,72 +148,33 @@ class TwitchSettings:
         has_chat = bool(cparser.value("twitchbot/chattoken", defaultValue=""))
         return broadcaster, chat, has_broadcaster, has_chat
 
-    def update_token_name(self):
-        """update the account name display based on stored usernames"""
-        if not self.oauth or not self.oauth.config:
-            self.widget.chatbot_username_line.setText("Not authenticated")
-            return
-
-        cparser = self.oauth.config.cparser
-        broadcaster_name = str(cparser.value(BROADCASTER_USERNAME_KEY, defaultValue=""))
-        chat_name = str(cparser.value(CHAT_USERNAME_KEY, defaultValue=""))
-        _, _, has_broadcaster, has_chat = self._read_token_statuses()
-
-        parts = []
-        if broadcaster_name:
-            parts.append(f"{broadcaster_name} (Broadcaster)")
-        elif has_broadcaster:
-            parts.append("Broadcaster connecting...")
-        if chat_name:
-            parts.append(f"{chat_name} (Chat Bot)")
-        elif has_chat:
-            parts.append("Chat Bot connecting...")
-
-        self.widget.chatbot_username_line.setText(" | ".join(parts) or "Not authenticated")
-
     def update_oauth_status(self):
         """update the OAuth status display from cached cparser values"""
         if not self.oauth or not self.oauth.config or not self.widget:
             return
 
-        self.oauth.client_id = self.widget.clientid_lineedit.text().strip()
+        # Update client_id/secret from UI in case user changed them
+        self.oauth.client_id = self.widget.clientid_lineedit.text().strip() or self.oauth.client_id
         self.oauth.client_secret = self.widget.secret_lineedit.text().strip()
 
-        if not self.oauth.is_configuration_complete():
-            self.widget.oauth_status_label.setText("Configuration incomplete")
-            self._set_auth_buttons_enabled(False)
-            return
+        cparser = self.oauth.config.cparser
+        broadcaster_status, chat_status, has_broadcaster, has_chat = self._read_token_statuses()
+        broadcaster_name = str(cparser.value(BROADCASTER_USERNAME_KEY, defaultValue=""))
+        chat_name = str(cparser.value(CHAT_USERNAME_KEY, defaultValue=""))
 
-        broadcaster, chat, has_broadcaster, has_chat = self._read_token_statuses()
-        parts = [
-            self._token_label(broadcaster, "Broadcaster", has_broadcaster),
-            self._token_label(chat, "Chat Bot", has_chat),
-        ]
-        text = " | ".join(p for p in parts if p) or "Not authenticated"
-        self.widget.oauth_status_label.setText(text)
+        self.widget.oauth_status_label.setText(
+            self._broadcaster_status_text(broadcaster_status, broadcaster_name, has_broadcaster)
+        )
+        self.widget.chat_status_label.setText(
+            self._chat_status_text(chat_status, chat_name, has_chat)
+        )
 
-        self._update_auth_button_states(broadcaster, chat)
-        self.update_token_name()
-
-    def _set_auth_buttons_enabled(self, enabled: bool) -> None:
-        """Enable or disable authentication buttons"""
-        self.widget.copy_broadcaster_auth_button.setEnabled(enabled)
-        self.widget.copy_chat_auth_button.setEnabled(enabled)
-
-    def _update_auth_button_states(self, broadcaster: str, chat: str) -> None:
-        """Update authentication button text and states"""
-
-        if broadcaster == OAUTH_STATUS_AUTHENTICATED:
-            self.widget.copy_broadcaster_auth_button.setText("✅ Broadcaster Authenticated")
-        else:
-            self.widget.copy_broadcaster_auth_button.setText("Copy Broadcaster Auth URL")
-        self.widget.copy_broadcaster_auth_button.setEnabled(True)
-
-        if chat == OAUTH_STATUS_AUTHENTICATED:
-            self.widget.copy_chat_auth_button.setText("✅ Chat Bot Authenticated")
-        else:
-            self.widget.copy_chat_auth_button.setText("Copy Chat Bot Auth URL")
-        self.widget.copy_chat_auth_button.setEnabled(True)
+        btn_text = (
+            "Re-authenticate..."
+            if broadcaster_status == OAUTH_STATUS_AUTHENTICATED
+            else "Auth Wizard..."
+        )
+        self.widget.authenticate_button.setText(btn_text)
 
     def start_status_timer(self):
         """Start periodic status updates to catch automatic token refresh"""
@@ -281,111 +240,10 @@ class TwitchSettings:
             self.oauth.clear_all_authentication()
         self.update_oauth_status()
 
-    def _copy_auth_link(self):
-        """generate and copy authentication URL to clipboard (backward compatibility)"""
-        self._copy_auth_link_with_message(
-            token_type="broadcaster",
-            success_title="Authentication URL Copied",
-            success_message=(
-                "The authentication URL has been copied to your clipboard.\n\n"
-                "Next steps:\n"
-                "1. Open your browser\n"
-                "2. IMPORTANT: Make sure you are logged into the correct Twitch account\n"
-                "   (If you want a bot account, log into that account first)\n"
-                "3. Paste and visit the copied URL\n"
-                "4. Complete the authorization\n"
-                "5. The token will be automatically saved"
-            ),
-        )
-
-    def _copy_broadcaster_auth_link(self):
-        """generate and copy broadcaster authentication URL to clipboard"""
-        self._copy_auth_link_with_message(
-            token_type="broadcaster",
-            success_title="Broadcaster Authentication URL Copied",
-            success_message=(
-                "The broadcaster authentication URL has been copied to your clipboard.\n\n"
-                "This will authenticate your main streaming account for:\n"
-                "• Channel Points redemptions\n"
-                "• API access\n"
-                "• Chat (if no separate bot account is configured)\n\n"
-                "Next steps:\n"
-                "1. Open your browser\n"
-                "2. IMPORTANT: Make sure you are logged into your MAIN STREAMING ACCOUNT\n"
-                "3. Paste and visit the copied URL\n"
-                "4. Complete the authorization\n"
-                "5. The token will be automatically saved"
-            ),
-        )
-
-    def _copy_chat_auth_link(self):
-        """generate and copy chat bot authentication URL to clipboard"""
-        self._copy_auth_link_with_message(
-            token_type="chat",
-            success_title="Chat Bot Authentication URL Copied",
-            success_message=(
-                "The chat bot authentication URL has been copied to your clipboard.\n\n"
-                "This will authenticate a separate bot account for:\n"
-                "• Chat messages only\n"
-                "• Commands and responses\n\n"
-                "Next steps:\n"
-                "1. Open your browser\n"
-                "2. IMPORTANT: Make sure you are logged into your BOT ACCOUNT\n"
-                "   (Not your main streaming account!)\n"
-                "3. Paste and visit the copied URL\n"
-                "4. Complete the authorization\n"
-                "5. The token will be automatically saved\n\n"
-                "Note: If you don't want a separate bot account, you can skip this\n"
-                "and use only the broadcaster authentication."
-            ),
-        )
-
-    def _copy_auth_link_with_message(
-        self, token_type="broadcaster", success_title="", success_message=""
-    ):
-        """generate and copy authentication URL with custom message"""
-        if not self.oauth or not self.widget:
-            logging.error("OAuth2 handler not initialized")
+    def _launch_auth_wizard(self) -> None:
+        """Open the authentication wizard for Twitch."""
+        if not self.oauth:
             return
-
-        # Update OAuth client with current form values
-        self.oauth.client_id = self.widget.clientid_lineedit.text().strip()
-        self.oauth.client_secret = self.widget.secret_lineedit.text().strip()
-
-        # Validate configuration
-        if not self.oauth.is_configuration_complete():
-            self.widget.oauth_status_label.setText("Error: Configuration incomplete")
-            return
-
-        try:
-            # Generate the auth URL using OAuth service
-            auth_url = self.oauth.get_auth_url(token_type)
-            if not auth_url:
-                self.widget.oauth_status_label.setText(f"Error generating {token_type} URL")
-                return
-
-            # Copy to clipboard
-            clipboard = QApplication.clipboard()
-            clipboard.setText(auth_url)
-
-            self.widget.oauth_status_label.setText(
-                f"{token_type.title()} auth URL copied to clipboard"
-            )
-
-            # Show success dialog with the URL
-            if self.uihelp:
-                msgbox = QMessageBox(self.uihelp.qtui)
-                msgbox.setWindowTitle(success_title)
-                msgbox.setIcon(QMessageBox.Icon.Information)
-                msgbox.setText(f"✅ {success_title}")
-                msgbox.setInformativeText(
-                    f"{success_message}\n\n"
-                    f"URL: {auth_url[:60]}{'...' if len(auth_url) > 60 else ''}"
-                )
-                msgbox.exec()
-
-            logging.info("Twitch %s OAuth2 authentication URL copied to clipboard", token_type)
-
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.error("Failed to generate %s auth URL: %s", token_type, error)
-            self.widget.oauth_status_label.setText(f"Error generating {token_type} URL: {error}")
+        wizard = nowplaying.authwizard.AuthWizard(self.oauth.config, ["twitch"])
+        wizard.exec()
+        self.update_oauth_status()

--- a/nowplaying/twitch/utils.py
+++ b/nowplaying/twitch/utils.py
@@ -283,6 +283,12 @@ class TwitchLogin:
                     session_timeout=timeout,
                 )
 
+                # Implicit grant tokens have no refresh token; disable auto-refresh
+                # so the library doesn't reject the missing refresh_token.
+                # The token is valid for ~4 hours; re-auth is needed after expiry.
+                if not oauth_client.refresh_token:
+                    twitch.auto_refresh_auth = False
+
                 await twitch.set_user_authentication(
                     token=oauth_client.access_token,
                     refresh_token=oauth_client.refresh_token,
@@ -290,8 +296,9 @@ class TwitchLogin:
                     validate=False,
                 )
 
-                # Set up callback to save automatically refreshed tokens
-                twitch.user_auth_refresh_callback = self.save_refreshed_tokens
+                # Set up callback to save automatically refreshed tokens (auth code flow only)
+                if oauth_client.refresh_token:
+                    twitch.user_auth_refresh_callback = self.save_refreshed_tokens
 
                 return twitch
 

--- a/tests/twitch/test_twitch_oauth2.py
+++ b/tests/twitch/test_twitch_oauth2.py
@@ -10,7 +10,7 @@ import pytest
 from aioresponses import aioresponses
 
 import nowplaying.twitch.oauth2  # pylint: disable=import-error,no-name-in-module
-from nowplaying.twitch.constants import API_HOST, OAUTH_HOST
+from nowplaying.twitch.constants import API_HOST, OAUTH_HOST, TWITCH_BUNDLED_CLIENT_ID
 
 # pylint: disable=redefined-outer-name, too-many-arguments, unused-argument
 
@@ -114,8 +114,9 @@ def test_generate_pkce_parameters(configured_oauth):  # pylint: disable=redefine
 @pytest.mark.parametrize(
     "client_id,redirect_uri,expected_error",
     [
-        (None, "http://localhost:8899", "Client ID is required"),
-        ("", "http://localhost:8899", "Client ID is required"),  # Empty string
+        # None/empty → falls back to bundled client ID, so auth URL succeeds
+        (None, "http://localhost:8899", None),
+        ("", "http://localhost:8899", None),
         ("   ", "http://localhost:8899", "Client ID is required"),  # Whitespace only
         (
             "client with spaces",
@@ -168,8 +169,11 @@ def test_get_authorization_url_scenarios(  # pylint: disable=redefined-outer-nam
         auth_url = oauth.get_authorization_url()
 
         assert auth_url.startswith("https://id.twitch.tv/oauth2/authorize?")
-        # Use trimmed client_id for URL validation since validation normalizes it
-        expected_client_id = client_id.strip() if client_id else client_id
+        # Blank/None → bundled client ID is used as fallback
+        if client_id and client_id.strip():
+            expected_client_id = client_id.strip()
+        else:
+            expected_client_id = TWITCH_BUNDLED_CLIENT_ID
         assert f"client_id={expected_client_id}" in auth_url
         assert "response_type=code" in auth_url
         encoded_uri = redirect_uri.replace(":", "%3A").replace("/", "%2F")
@@ -574,13 +578,11 @@ def test_missing_config_handling(bootstrap, invalid_config_key):  # pylint: disa
     # Set redirect URI directly (no longer from config)
     oauth.redirect_uri = "http://localhost"
 
-    # Should handle missing config gracefully
+    # Missing clientid → bundled ID used as fallback; missing secret is always fine
+    auth_url = oauth.get_authorization_url()
     if invalid_config_key == "twitchbot/clientid":
-        with pytest.raises(ValueError, match="Client ID is required"):
-            oauth.get_authorization_url()
+        assert f"client_id={TWITCH_BUNDLED_CLIENT_ID}" in auth_url
     else:
-        # Missing secret shouldn't prevent URL generation
-        auth_url = oauth.get_authorization_url()
         assert "client_id=test_client" in auth_url
 
 


### PR DESCRIPTION
Users on port 8899 no longer need their own Twitch developer app. The bundled WNP client ID uses OAuth2 implicit grant flow -- no client_secret, no PKCE, token arrives in the URL fragment and is extracted by a JS relay page served by the webserver.

Users with their own client_id + client_secret continue using the auth code + PKCE flow unchanged.

Key changes:
- oauth2.py: add get_implicit_auth_url() with fail-closed CSRF state validation (secrets.compare_digest, distinct state keys for broadcaster vs chat)
- webserver.py: implicit redirect handlers; JS extraction page served when redirect arrives with no ?code= parameter
- twitch/constants.py: remove user:bot from BROADCASTER_AUTH_SCOPES
- twitch/utils.py: set auto_refresh_auth=False when no refresh token so TwitchAPI library accepts implicit grant tokens
- twitch/redemptions.py: reload config each retry cycle so tokens saved by the webserver process are visible; short retry (10s) when no token present vs 60s for connection failures
- twitch/settings.py + twitch.ui: split OAuth status into two rows (Broadcaster + Chat Bot); Auth Wizard covers both steps
- authwizard.py: new standalone auth wizard module

## Summary by Sourcery

Add a guided OAuth wizard and Twitch implicit grant support using a bundled client ID, updating webserver callbacks, OAuth client behavior, and UI flows so users can authenticate Twitch and Kick accounts without manually managing redirect URLs or secrets.

New Features:
- Introduce a reusable AuthWizard dialog to guide users through Twitch broadcaster/chat and Kick OAuth setup.
- Support Twitch OAuth2 implicit grant flow using a bundled public client ID when no client credentials are configured.
- Automatically prompt users to complete OAuth after first-run setup once the local webserver is ready.

Bug Fixes:
- Ensure Twitch EventSub redemptions reload configuration and retry more quickly when no token is available.
- Prevent Twitch API auto-refresh from failing when using implicit grant tokens without a refresh token.

Enhancements:
- Simplify Twitch and Kick settings UIs by replacing ad‑hoc OAuth button logic with an authentication wizard entry point and clearer status messages per account.
- Relax Twitch configuration requirements so a client secret is optional and client ID falls back to a bundled value, while adjusting token exchange to handle provider‑specific parameter placement.
- Refine OAuth scope definitions so broadcaster tokens no longer request the USER_BOT permission intended only for dedicated bot accounts.

Tests:
- Update Twitch OAuth tests to cover bundled client ID fallback and the relaxed client ID/secret requirements.