### PR TITLE
feat: 2-PC setup wizard fork (DJ/source + display paths)

### DIFF
--- a/nowplaying/installwizard/__init__.py
+++ b/nowplaying/installwizard/__init__.py
@@ -17,11 +17,19 @@ from nowplaying.installwizard._constants import (
     PAGE_FINISH,
     PAGE_INPUT,
     PAGE_INPUT_CONFIG,
+    PAGE_MULTIPC,
+    PAGE_MULTIPC_ROLE,
     PAGE_OUTPUTS,
+    PAGE_REMOTE_OUTPUT,
     PAGE_WELCOME,
 )
 from nowplaying.installwizard._finish import _FinishPage
 from nowplaying.installwizard._input_source import _InputSourcePage
+from nowplaying.installwizard._multipc import (
+    _MultiPcQuestionPage,
+    _MultiPcRolePage,
+    _RemoteOutputPage,
+)
 from nowplaying.installwizard._outputs import _OutputsPage
 from nowplaying.installwizard._welcome import _WelcomePage
 
@@ -29,16 +37,19 @@ __all__ = [
     "InstallWizard",
     "maybe_show_wizard",
     "PAGE_WELCOME",
+    "PAGE_MULTIPC",
+    "PAGE_MULTIPC_ROLE",
     "PAGE_INPUT",
     "PAGE_INPUT_CONFIG",
     "PAGE_ARTISTEXTRAS",
     "PAGE_OUTPUTS",
     "PAGE_CONFIGURE_OUTPUTS",
+    "PAGE_REMOTE_OUTPUT",
     "PAGE_FINISH",
 ]
 
 
-class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
+class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """First-run setup wizard; shown when config.initialized is False."""
 
     def __init__(
@@ -50,19 +61,31 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
         self.setWizardStyle(QWizard.WizardStyle.ModernStyle)
         self.setMinimumSize(620, 520)
 
+        # Multi-PC state set by _MultiPcRolePage.validatePage()
+        self.multipc: bool = False
+        self.multipc_role: str | None = None  # 'dj', 'display', or None
+        self.after_input_config_page: int | None = None  # PAGE_REMOTE_OUTPUT for DJ
+
         self._welcome_page = _WelcomePage()
+        self._multipc_page = _MultiPcQuestionPage()
+        self._multipc_role_page = _MultiPcRolePage(config)
         self._input_page = _InputSourcePage(config)
         self._extras_page = _ArtistExtrasPage(config)
         self._outputs_page = _OutputsPage(config)
         self._configure_page = _ConfigureOutputsPage(self._outputs_page, config)
+        self._remote_output_page = _RemoteOutputPage(config)
         self._finish_page = _FinishPage()
 
         self.setPage(PAGE_WELCOME, self._welcome_page)
+        self.setPage(PAGE_MULTIPC, self._multipc_page)
+        self.setPage(PAGE_MULTIPC_ROLE, self._multipc_role_page)
         self.setPage(PAGE_INPUT, self._input_page)
         # PAGE_INPUT_CONFIG is reserved; populated dynamically by _InputSourcePage
+        # or _MultiPcRolePage (for the display machine path)
         self.setPage(PAGE_ARTISTEXTRAS, self._extras_page)
         self.setPage(PAGE_OUTPUTS, self._outputs_page)
         self.setPage(PAGE_CONFIGURE_OUTPUTS, self._configure_page)
+        self.setPage(PAGE_REMOTE_OUTPUT, self._remote_output_page)
         self.setPage(PAGE_FINISH, self._finish_page)
 
         self.setStartId(PAGE_WELCOME)
@@ -71,11 +94,24 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
 
     def _on_page_changed(self, page_id: int) -> None:
         if page_id == PAGE_FINISH:
-            self._finish_page.set_summary(
-                self._input_page.selected_display_name(),
-                self._extras_page.enabled_display_names(),
-                self._outputs_page.enabled_display_names(),
-            )
+            if self.multipc_role == "dj":
+                self._finish_page.set_summary(
+                    self._input_page.selected_display_name(),
+                    [],
+                    ["Remote Output (autodiscovery)"],
+                )
+            elif self.multipc_role == "display":
+                self._finish_page.set_summary(
+                    "Remote (receiving from DJ machine)",
+                    self._extras_page.enabled_display_names(),
+                    self._outputs_page.enabled_display_names(),
+                )
+            else:
+                self._finish_page.set_summary(
+                    self._input_page.selected_display_name(),
+                    self._extras_page.enabled_display_names(),
+                    self._outputs_page.enabled_display_names(),
+                )
 
     def _commit(self) -> None:  # pylint: disable=too-many-branches,too-many-statements
         """Persist all wizard choices to QSettings and mark initialized."""
@@ -85,11 +121,58 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
         if PAGE_INPUT_CONFIG in self.pageIds():
             self.page(PAGE_INPUT_CONFIG).commit()
 
+        if self.multipc_role == "dj":
+            self._commit_dj_machine(cparser)
+        elif self.multipc_role == "display":
+            self._commit_display_machine(cparser)
+        else:
+            self._commit_single_machine(cparser)
+
+        self.config.initialized = True
+        self.config.save()
+        logging.info("wizard: first-run setup complete (role=%s)", self.multipc_role or "single")
+
+    def _commit_dj_machine(self, cparser) -> None:  # pylint: disable=too-many-branches
+        """Commit settings for the DJ/source machine in a multi-PC setup."""
         short_name = self._input_page.selected_short_name()
         if short_name:
             cparser.setValue("settings/input", short_name)
             logging.info("wizard: set input source to %s", short_name)
 
+        # Artist extras off — the display machine handles metadata enrichment
+        for key in self.config.plugins.get("artistextras", {}):
+            sname = key.replace("nowplaying.artistextras.", "")
+            cparser.setValue(f"{sname}/enabled", False)
+
+        # Remote Output — the only output on a DJ machine
+        self._remote_output_page.commit()
+
+        # System notifications on so the DJ can see track changes going across
+        cparser.setValue("settings/notif", True)
+
+    def _commit_display_machine(self, cparser) -> None:  # pylint: disable=too-many-branches
+        """Commit settings for the display/streaming machine in a multi-PC setup."""
+        cparser.setValue("settings/input", "remote")
+        logging.info("wizard: set input source to remote")
+
+        self._commit_artist_extras(cparser)
+        self._commit_outputs(cparser)
+
+        # System notifications on so the operator can see incoming track changes
+        cparser.setValue("settings/notif", True)
+
+    def _commit_single_machine(self, cparser) -> None:  # pylint: disable=too-many-branches
+        """Commit settings for a standalone single-machine setup."""
+        short_name = self._input_page.selected_short_name()
+        if short_name:
+            cparser.setValue("settings/input", short_name)
+            logging.info("wizard: set input source to %s", short_name)
+
+        self._commit_artist_extras(cparser)
+        self._commit_outputs(cparser)
+
+    def _commit_artist_extras(self, cparser) -> None:
+        """Write artist extras selections to config."""
         for key in self.config.plugins.get("artistextras", {}):
             sname = key.replace("nowplaying.artistextras.", "")
             check = self._extras_page.enable_checks.get(sname)
@@ -98,7 +181,6 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
             edit = self._extras_page.apikey_edits.get(sname)
             if edit is not None:
                 cparser.setValue(f"{sname}/apikey", edit.text().strip())
-
         cparser.setValue(
             "artistextras/prioritizenetworkart",
             self._extras_page.prioritize_network.isChecked(),
@@ -109,6 +191,8 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
             self._extras_page.coverfornofanart.isChecked(),
         )
 
+    def _commit_outputs(self, cparser) -> None:
+        """Write outputs selections and credentials to config."""
         op = self._outputs_page
         cparser.setValue("weboutput/httpenabled", op.weboverlay_check.isChecked())
         cparser.setValue("obsws/enabled", op.obsws_check.isChecked())
@@ -144,10 +228,6 @@ class InstallWizard(QWizard):  # pylint: disable=too-few-public-methods
             pending_oauth.append("kick")
         if pending_oauth:
             cparser.setValue("settings/pending_oauth", ",".join(pending_oauth))
-
-        self.config.initialized = True
-        self.config.save()
-        logging.info("wizard: first-run setup complete")
 
 
 def maybe_show_wizard(config: nowplaying.config.ConfigFile) -> None:

--- a/nowplaying/installwizard/_constants.py
+++ b/nowplaying/installwizard/_constants.py
@@ -8,3 +8,6 @@ PAGE_ARTISTEXTRAS = 3
 PAGE_OUTPUTS = 4
 PAGE_CONFIGURE_OUTPUTS = 5
 PAGE_FINISH = 6
+PAGE_MULTIPC = 7  # "Are you using multiple computers?"
+PAGE_MULTIPC_ROLE = 8  # "Which machine is this?" (DJ source / display)
+PAGE_REMOTE_OUTPUT = 9  # Remote Output config for DJ/source path

--- a/nowplaying/installwizard/_input_source.py
+++ b/nowplaying/installwizard/_input_source.py
@@ -15,7 +15,11 @@ from PySide6.QtWidgets import (
 )
 
 import nowplaying.config
-from nowplaying.installwizard._constants import PAGE_ARTISTEXTRAS, PAGE_INPUT_CONFIG
+from nowplaying.installwizard._constants import (
+    PAGE_ARTISTEXTRAS,
+    PAGE_INPUT_CONFIG,
+    PAGE_REMOTE_OUTPUT,
+)
 
 
 class _InputSourcePage(QWizardPage):
@@ -133,8 +137,10 @@ class _InputSourcePage(QWizardPage):
         return self.selected_short_name() is not None
 
     def nextId(self) -> int:  # pylint: disable=invalid-name
-        """Route to the plugin config page if one was registered, else artist extras."""
+        """Route to the plugin config page if registered; skip artist extras for DJ path."""
         wizard = self.wizard()
         if wizard and PAGE_INPUT_CONFIG in wizard.pageIds():
             return PAGE_INPUT_CONFIG
+        if wizard and getattr(wizard, "multipc_role", None) == "dj":
+            return PAGE_REMOTE_OUTPUT
         return PAGE_ARTISTEXTRAS

--- a/nowplaying/installwizard/_multipc.py
+++ b/nowplaying/installwizard/_multipc.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Multi-PC setup pages for the installation wizard."""
+
+# pylint: disable=no-name-in-module
+
+import logging
+
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QRadioButton,
+    QVBoxLayout,
+    QWidget,
+    QWizard,
+    QWizardPage,
+)
+
+import nowplaying.config
+from nowplaying.installwizard._constants import (
+    PAGE_FINISH,
+    PAGE_INPUT,
+    PAGE_INPUT_CONFIG,
+    PAGE_MULTIPC_ROLE,
+    PAGE_REMOTE_OUTPUT,
+)
+
+
+class _MultiPcQuestionPage(QWizardPage):
+    """Ask whether this is a single-machine or multi-PC setup."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setTitle("Single or Multi-PC Setup")
+        self.setSubTitle("Tell us how you have What's Now Playing deployed.")
+
+        self._single = QRadioButton("Single PC")
+        single_detail = QLabel("My DJ software and streaming outputs run on the same machine.")
+        single_detail.setWordWrap(True)
+        single_detail.setIndent(20)
+
+        self._multi = QRadioButton("Multiple computers")
+        multi_detail = QLabel(
+            "My DJ software runs on one machine; I stream or display track info from another."
+        )
+        multi_detail.setWordWrap(True)
+        multi_detail.setIndent(20)
+
+        self._single.setChecked(True)
+
+        self._group = QButtonGroup(self)
+        self._group.addButton(self._single)
+        self._group.addButton(self._multi)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._single)
+        layout.addWidget(single_detail)
+        layout.addSpacing(8)
+        layout.addWidget(self._multi)
+        layout.addWidget(multi_detail)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def _is_multipc(self) -> bool:
+        return self._multi.isChecked()
+
+    def validatePage(self) -> bool:  # pylint: disable=invalid-name
+        """Store the single/multi choice on the wizard for later pages to read."""
+        wizard = self.wizard()
+        if wizard is not None:
+            wizard.multipc = self._is_multipc()  # type: ignore[union-attr]
+            if not wizard.multipc:  # type: ignore[union-attr]
+                # Reset role in case user went back and changed answer
+                wizard.multipc_role = None  # type: ignore[union-attr]
+                wizard.after_input_config_page = None  # type: ignore[union-attr]
+        return True
+
+    def nextId(self) -> int:  # pylint: disable=invalid-name
+        """Single-PC goes straight to input selection; multi-PC asks role next."""
+        if self._is_multipc():
+            return PAGE_MULTIPC_ROLE
+        return PAGE_INPUT
+
+
+class _MultiPcRolePage(QWizardPage):
+    """Ask which role this machine plays in a multi-PC setup."""
+
+    def __init__(
+        self, config: nowplaying.config.ConfigFile, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self._remote_page_registered: bool = False
+        self.setTitle("Which Machine Is This?")
+        self.setSubTitle(
+            "We'll configure each machine for its role in your setup. "
+            "You can always adjust settings later."
+        )
+
+        self._dj = QRadioButton("DJ / Source machine")
+        dj_detail = QLabel(
+            "This computer runs your DJ software. It will detect the playing track "
+            "and send the information to your display machine."
+        )
+        dj_detail.setWordWrap(True)
+        dj_detail.setIndent(20)
+
+        self._display = QRadioButton("Display / Streaming machine")
+        display_detail = QLabel(
+            "This computer connects to OBS, Twitch, Kick, and other outputs. "
+            "It will receive track information from the DJ machine."
+        )
+        display_detail.setWordWrap(True)
+        display_detail.setIndent(20)
+
+        self._dj.setChecked(True)
+
+        self._group = QButtonGroup(self)
+        self._group.addButton(self._dj)
+        self._group.addButton(self._display)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._dj)
+        layout.addWidget(dj_detail)
+        layout.addSpacing(12)
+        layout.addWidget(self._display)
+        layout.addWidget(display_detail)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def _is_display(self) -> bool:
+        return self._display.isChecked()
+
+    def validatePage(self) -> bool:  # pylint: disable=invalid-name
+        """Store the role on the wizard and prepare dynamic pages."""
+        wizard = self.wizard()
+        if wizard is None:
+            return True
+
+        if self._is_display():
+            wizard.multipc_role = "display"  # type: ignore[union-attr]
+            wizard.after_input_config_page = None  # type: ignore[union-attr]
+            self._remote_page_registered = self._register_remote_input_page(wizard)
+        else:
+            wizard.multipc_role = "dj"  # type: ignore[union-attr]
+            wizard.after_input_config_page = PAGE_REMOTE_OUTPUT  # type: ignore[union-attr]
+            # Clear any remote input page left from a previous display selection
+            if PAGE_INPUT_CONFIG in wizard.pageIds():
+                wizard.removePage(PAGE_INPUT_CONFIG)
+        return True
+
+    def _register_remote_input_page(self, wizard: QWizard) -> bool:
+        """Auto-register the Remote input's wizard page for the display machine path.
+
+        Returns True if the page was successfully registered, False otherwise.
+        """
+        module = self._config.plugins.get("inputs", {}).get("nowplaying.inputs.remote")
+        if not module:
+            logging.warning("wizard: remote input plugin not found")
+            return False
+        try:
+            plugin_obj = module.Plugin(config=self._config)
+            if plugin_obj.wizardpage is not None:
+                if PAGE_INPUT_CONFIG in wizard.pageIds():
+                    wizard.removePage(PAGE_INPUT_CONFIG)
+                page = plugin_obj.wizardpage(config=self._config)
+                wizard.setPage(PAGE_INPUT_CONFIG, page)
+                return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("wizard: failed to register remote input page")
+        return False
+
+    def nextId(self) -> int:  # pylint: disable=invalid-name
+        """Display machine goes to Remote input config if registered, else input picker."""
+        if self._is_display():
+            return PAGE_INPUT_CONFIG if self._remote_page_registered else PAGE_INPUT
+        return PAGE_INPUT
+
+
+class _RemoteOutputPage(QWizardPage):
+    """Configure Remote Output so this DJ machine can push tracks to the display machine."""
+
+    def __init__(
+        self, config: nowplaying.config.ConfigFile, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self.setTitle("Remote Output")
+        self.setSubTitle(
+            "What's Now Playing will automatically find your display machine "
+            "on the local network using Bonjour/mDNS. "
+            "Make sure What's Now Playing is running on the display machine."
+        )
+
+        explain = QLabel(
+            "No manual address entry is needed — autodiscovery handles it. "
+            "If both machines share a secret key, enter it below so they can authenticate."
+        )
+        explain.setWordWrap(True)
+
+        self._secret = QLineEdit()
+        self._secret.setPlaceholderText("optional — must match the display machine's secret")
+        self._secret.setText(str(self._config.cparser.value("remote/remote_key", defaultValue="")))
+
+        form = QFormLayout()
+        form.addRow("Shared secret:", self._secret)
+
+        layout = QVBoxLayout()
+        layout.addWidget(explain)
+        layout.addSpacing(12)
+        layout.addLayout(form)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def nextId(self) -> int:  # pylint: disable=invalid-name,no-self-use
+        """DJ path ends at Finish after this page."""
+        return PAGE_FINISH
+
+    def commit(self) -> None:
+        """Write Remote Output config to QSettings."""
+        self._config.cparser.setValue("remote/enabled", True)
+        self._config.cparser.setValue("remote/autodiscover", True)
+        self._config.cparser.setValue("remote/remote_key", self._secret.text().strip())

--- a/nowplaying/installwizard/_welcome.py
+++ b/nowplaying/installwizard/_welcome.py
@@ -5,6 +5,8 @@
 
 from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget, QWizardPage
 
+from nowplaying.installwizard._constants import PAGE_MULTIPC
+
 
 class _WelcomePage(QWizardPage):
     """Introductory page shown at wizard start."""
@@ -24,3 +26,7 @@ class _WelcomePage(QWizardPage):
         layout.addWidget(intro)
         layout.addStretch()
         self.setLayout(layout)
+
+    def nextId(self) -> int:  # pylint: disable=invalid-name,no-self-use
+        """Go to the multi-PC question before anything else."""
+        return PAGE_MULTIPC

--- a/nowplaying/wizard.py
+++ b/nowplaying/wizard.py
@@ -89,5 +89,13 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
         edit.setValidator(QIntValidator(1, 65535))
         return edit
 
+    def nextId(self) -> int:  # pylint: disable=invalid-name
+        """Route to the page the wizard set up for after input config, or the default."""
+        wizard = self.wizard()
+        override = getattr(wizard, "after_input_config_page", None)
+        if override is not None:
+            return override
+        return super().nextId()
+
     def commit(self) -> None:
         """Write this page's settings to QSettings. Called when wizard is accepted."""


### PR DESCRIPTION
Adds a "single or multi-PC?" question early in the install wizard that forks into three paths:
- Single PC: existing flow unchanged
- DJ/source machine: pick software → optional plugin config → Remote Output page → Finish (artist extras auto-disabled, remote/autodiscover=True, notifications on)
- Display/streaming machine: auto-selects Remote input → artist extras → outputs → Finish (notifications on)

New files:
- nowplaying/installwizard/_multipc.py: _MultiPcQuestionPage, _MultiPcRolePage, _RemoteOutputPage Constants PAGE_MULTIPC, PAGE_MULTIPC_ROLE, PAGE_REMOTE_OUTPUT added. WizardPage.nextId() checks wizard.after_input_config_page for DJ path routing without circular imports.
Display machine is found via Bonjour/mDNS autodiscovery at runtime; wizard only asks for the optional shared secret.

## Summary by Sourcery

Introduce a forked multi-PC setup flow in the first-run install wizard with dedicated DJ/source and display/streaming machine paths, including role-specific summaries and config commits.

New Features:
- Add a multi-PC setup option to the install wizard with a single-PC vs multi-PC question and role selection pages.
- Introduce a Remote Output configuration page for DJ/source machines that uses Bonjour/mDNS autodiscovery and optional shared secret.
- Automatically register and use the Remote input plugin configuration for display/streaming machines when available.

Enhancements:
- Refactor wizard commit logic into role-specific helpers for DJ, display, and single-machine setups, including shared helpers for artist extras and outputs.
- Update wizard navigation so welcome routes into the multi-PC flow and pages can override the next step after input configuration.
- Adjust finish-page summaries to reflect single, DJ, or display machine roles appropriately.