### PR TITLE
refactor: split input plugin install() into detect() + install()

### DIFF
--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -150,23 +150,29 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def get_path_keys(cls) -> frozenset[str]:
         return frozenset({"djaypro/directory"})
 
-    def install(self) -> bool:
-        """locate djay Pro database directory"""
+    def _find_djaypro_dir(self) -> pathlib.Path | None:
+        """Return the djay Pro media library directory if it exists with a valid DB, else None."""
         music_dir = self.config.userdocs.parent.joinpath("Music")
-        # Try macOS path first
-        djaypro_dir = music_dir.joinpath("djay", "djay Media Library.djayMediaLibrary")
+        for candidate in [
+            music_dir.joinpath("djay", "djay Media Library.djayMediaLibrary"),
+            music_dir.joinpath("djay", "djay Media Library"),
+        ]:
+            if candidate.exists() and candidate.joinpath("MediaLibrary.db").exists():
+                return candidate
+        return None
 
-        if not djaypro_dir.exists():
-            # Try Windows path
-            djaypro_dir = music_dir.joinpath("djay", "djay Media Library")
+    def detect(self) -> bool:
+        """Return True if djay Pro is installed with a valid media library."""
+        return self._find_djaypro_dir() is not None
 
-        if djaypro_dir.exists():
-            dbfile = djaypro_dir.joinpath("MediaLibrary.db")
-            if dbfile.exists():
-                self.config.cparser.setValue("settings/input", "djaypro")
-                self.config.cparser.setValue("djaypro/directory", str(djaypro_dir))
-                return True
-        return False
+    def install(self) -> bool:
+        """Auto-install for djay Pro: detect and write default library path."""
+        djaypro_dir = self._find_djaypro_dir()
+        if djaypro_dir is None:
+            return False
+        self.config.cparser.setValue("settings/input", "djaypro")
+        self.config.cparser.setValue("djaypro/directory", str(djaypro_dir))
+        return True
 
     def _reset_meta(self):
         """reset the metadata"""

--- a/nowplaying/inputs/__init__.py
+++ b/nowplaying/inputs/__init__.py
@@ -33,6 +33,10 @@ class InputPlugin(WNPBasePlugin):
 
     #### Autoinstallation methods ####
 
+    def detect(self) -> bool:  # pylint: disable=no-self-use
+        """return True if this DJ software is installed on the machine; no side-effects"""
+        return False
+
     def install(self) -> bool:  # pylint: disable=no-self-use
         """if a fresh install, run this"""
         return False

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -117,14 +117,18 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def get_path_keys(cls) -> frozenset[str]:
         return frozenset({"djuced/directory"})
 
+    def detect(self) -> bool:
+        """Return True if the DJUCED library directory exists."""
+        return self.config.userdocs.joinpath("DJUCED").exists()
+
     def install(self) -> bool:
-        """locate Virtual DJ"""
+        """Auto-install for DJUCED: detect and write default library path."""
         djuceddir = self.config.userdocs.joinpath("DJUCED")
-        if djuceddir.exists():
-            self.config.cparser.value("settings/input", "djuced")
-            self.config.cparser.value("djuced/directory", str(djuceddir))
-            return True
-        return False
+        if not djuceddir.exists():
+            return False
+        self.config.cparser.setValue("settings/input", "djuced")
+        self.config.cparser.setValue("djuced/directory", str(djuceddir))
+        return True
 
     def _reset_meta(self):
         """reset the metadata"""

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -117,14 +117,19 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def get_path_keys(cls) -> frozenset[str]:
         return frozenset({"djuced/directory"})
 
+    def _find_djuced_dir(self) -> pathlib.Path | None:
+        """Return the DJUCED library directory if it exists, else None."""
+        djuceddir = self.config.userdocs.joinpath("DJUCED")
+        return djuceddir if djuceddir.exists() else None
+
     def detect(self) -> bool:
         """Return True if the DJUCED library directory exists."""
-        return self.config.userdocs.joinpath("DJUCED").exists()
+        return self._find_djuced_dir() is not None
 
     def install(self) -> bool:
         """Auto-install for DJUCED: detect and write default library path."""
-        djuceddir = self.config.userdocs.joinpath("DJUCED")
-        if not djuceddir.exists():
+        djuceddir = self._find_djuced_dir()
+        if djuceddir is None:
             return False
         self.config.cparser.setValue("settings/input", "djuced")
         self.config.cparser.setValue("djuced/directory", str(djuceddir))

--- a/nowplaying/inputs/earshot.py
+++ b/nowplaying/inputs/earshot.py
@@ -26,11 +26,15 @@ class Plugin(nowplaying.inputs.remote.Plugin):
         super().__init__(config=config, qsettings=qsettings)
         self.displayname = "EarShot"
 
-    def install(self) -> bool:
+    def detect(self) -> bool:
         """Detect WNP EarShot.app in /Applications on macOS."""
         if sys.platform != "darwin":
             return False
         return pathlib.Path("/Applications/WNP EarShot.app").exists()
+
+    def install(self) -> bool:
+        """Auto-install for EarShot — detection only, nothing to configure."""
+        return self.detect()
 
     def get_source_agent_data(self) -> dict:
         """EarShot preserves source_agent data set by the sender."""

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -204,6 +204,10 @@ class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
         all_collections.sort(key=lambda p: p.stat().st_mtime)
         return all_collections[-1]
 
+    def detect(self) -> bool:
+        """Return True if a Traktor collection.nml can be found."""
+        return self._find_best_collection() is not None
+
     def install(self):
         """auto-install for Traktor; picks most-recently-used version when multiple installed"""
         best = self._find_best_collection()

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -531,28 +531,31 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
     def get_path_keys(cls) -> frozenset[str]:
         return frozenset({"virtualdj/history", "virtualdj/playlists"})
 
-    def install(self) -> bool:
-        """locate Virtual DJ"""
-        # Check multiple possible VirtualDJ locations
-        possible_locations = [
-            # Traditional Documents/VirtualDJ location
+    def _find_vdj_dir(self) -> pathlib.Path | None:
+        """Return the first VirtualDJ directory found, or None."""
+        for vdjdir in [
             self.config.userdocs.joinpath("VirtualDJ"),
-            # Windows 11 AppData\Local\VirtualDJ location
             pathlib.Path(
                 QStandardPaths.standardLocations(QStandardPaths.AppLocalDataLocation)[0]
             ).parent.joinpath("VirtualDJ"),
-        ]
-
-        for vdjdir in possible_locations:
+        ]:
             if vdjdir.exists():
-                self.config.cparser.setValue("settings/input", "virtualdj")
-                self.config.cparser.setValue("virtualdj/history", str(vdjdir.joinpath("History")))
-                self.config.cparser.setValue(
-                    "virtualdj/playlists", str(vdjdir.joinpath("Playlists"))
-                )
-                return True
+                return vdjdir
+        return None
 
-        return False
+    def detect(self) -> bool:
+        """Return True if a VirtualDJ directory can be found."""
+        return self._find_vdj_dir() is not None
+
+    def install(self) -> bool:
+        """Auto-install for VirtualDJ: detect and write default history/playlists paths."""
+        vdjdir = self._find_vdj_dir()
+        if vdjdir is None:
+            return False
+        self.config.cparser.setValue("settings/input", "virtualdj")
+        self.config.cparser.setValue("virtualdj/history", str(vdjdir.joinpath("History")))
+        self.config.cparser.setValue("virtualdj/playlists", str(vdjdir.joinpath("Playlists")))
+        return True
 
     async def start(self) -> None:
         """setup the watcher to run in a separate thread"""

--- a/nowplaying/installwizard/_input_source.py
+++ b/nowplaying/installwizard/_input_source.py
@@ -63,9 +63,9 @@ class _InputSourcePage(QWizardPage):
             display = plugin_obj.displayname
             detected = False
             try:
-                detected = bool(plugin_obj.install())
+                detected = bool(plugin_obj.detect())
             except Exception:  # pylint: disable=broad-exception-caught
-                logging.exception("wizard: install() failed for %s", key)
+                logging.exception("wizard: detect() failed for %s", key)
 
             label = f"✓  {display}" if detected else f"    {display}"
             btn = QRadioButton(label)

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -262,6 +262,10 @@ class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instanc
             await self._http_session.close()
             self._http_session = None
 
+    def detect(self) -> bool:
+        """Return True if a Serato 4+ library can be found on this machine."""
+        return bool(self.detected_serato_library_path)
+
     def install(self) -> bool:
         """Auto-install for Serato 4"""
         serato_lib_path = self.detected_serato_library_path

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -113,7 +113,7 @@ class _SeratoLegacyWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=
         self.config.cparser.setValue("serato/url", self._url_edit.text().strip())
 
 
-class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
+class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """handler for NowPlaying"""
 
     def __init__(

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -161,7 +161,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes,too-m
             if serato_plugin.detect():
                 return None
         except Exception:  # pylint: disable=broad-exception-caught
-            pass
+            logging.exception("serato3: serato4 detect() raised; treating as absent")
         return seratodir
 
     def detect(self) -> bool:

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -149,29 +149,33 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def get_path_keys(cls) -> frozenset[str]:
         return frozenset({"serato/libpath"})
 
-    def install(self):
-        """auto-install for Serato"""
+    def _find_serato3_dir(self) -> pathlib.Path | None:
+        """Return the _Serato_ directory if it exists and serato4 would not claim it."""
         seratodir = pathlib.Path(
             QStandardPaths.standardLocations(QStandardPaths.MusicLocation)[0]
         ).joinpath("_Serato_")
+        if not seratodir.exists():
+            return None
+        try:
+            serato_plugin = nowplaying.serato.plugin.Plugin(config=self.config)
+            if serato_plugin.detect():
+                return None
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        return seratodir
 
-        if seratodir.exists():
-            # Check if this is actually Serato 4+ by trying the main serato plugin first
-            try:
-                serato_plugin = nowplaying.serato.plugin.Plugin(config=self.config)
-                if serato_plugin.install():
-                    # Modern Serato can handle this installation, defer to it
-                    return False
-            except (ImportError, Exception):  # pylint: disable=broad-exception-caught
-                # Modern Serato plugin not available or failed, continue with legacy
-                pass
+    def detect(self) -> bool:
+        """Return True if a legacy Serato 3 library exists and serato4 would not claim it."""
+        return self._find_serato3_dir() is not None
 
-            # This is legacy Serato (no master.sqlite or modern serato plugin unavailable)
-            self.config.cparser.setValue("settings/input", "serato3")
-            self.config.cparser.setValue("serato/libpath", str(seratodir))
-            return True
-
-        return False
+    def install(self):
+        """auto-install for Serato"""
+        seratodir = self._find_serato3_dir()
+        if seratodir is None:
+            return False
+        self.config.cparser.setValue("settings/input", "serato3")
+        self.config.cparser.setValue("serato/libpath", str(seratodir))
+        return True
 
     async def gethandler(self):
         """setup the SeratoHandler for this session"""


### PR DESCRIPTION
Add a pure detect() -> bool to InputPlugin base (no side-effects) for each plugin that can auto-detect its DJ software. The install wizard now calls detect() for checkmark display without triggering config writes; systemtray auto-setup continues to call install().

Also fix a pre-existing bug in djuced.install() where .value() (getter) was called instead of .setValue(), making the config writes no-ops.

## Summary by Sourcery

Introduce a side-effect-free detect() method for input plugins and update auto-detection to use it while keeping install() responsible for writing configuration.

New Features:
- Add a default detect() hook to the InputPlugin base class and implement plugin-specific detection for Serato 3, Serato 4, VirtualDJ, djay Pro, DJUCED, EarShot, and Traktor.

Bug Fixes:
- Fix DJUCED auto-install to actually write configuration values by using setValue() instead of the no-op value() getter.
- Ensure legacy Serato 3 auto-installation does not run when a Serato 4+ library is present.

Enhancements:
- Refactor multiple input plugins to share internal directory-finding helpers between detect() and install(), reducing side effects during detection.
- Update the install wizard to rely on detect() for showing which DJ software is present without performing configuration writes.