### PR TITLE
fix: djuced install() config writes were no-ops

### DIFF
--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -83,13 +83,13 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         return frozenset({"djuced/directory"})
 
     def install(self) -> bool:
-        """locate Virtual DJ"""
+        """Auto-install for DJUCED: detect and write default library path."""
         djuceddir = self.config.userdocs.joinpath("DJUCED")
-        if djuceddir.exists():
-            self.config.cparser.value("settings/input", "djuced")
-            self.config.cparser.value("djuced/directory", str(djuceddir))
-            return True
-        return False
+        if not djuceddir.exists():
+            return False
+        self.config.cparser.setValue("settings/input", "djuced")
+        self.config.cparser.setValue("djuced/directory", str(djuceddir))
+        return True
 
     def _reset_meta(self):
         """reset the metadata"""

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -541,7 +541,6 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def connect_settingsui(self, qwidget: "QWidget", uihelp: "nowplaying.uihelp.UIHelp"):
         """connect m3u button to filename picker"""
         self.qwidget = qwidget
-        self.uihelp = uihelp
         qwidget.dir_button.clicked.connect(self.on_djuced_dir_button)
 
     def load_settingsui(self, qwidget: "QWidget"):

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -130,7 +130,7 @@ class TraktorSAXHandler(xml.sax.ContentHandler):
                 self.current_playlist = None
 
 
-class Plugin(IcecastPlugin):
+class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes
     """base class of input plugins"""
 
     def __init__(self, config: "nowplaying.config.ConfigFile | None" = None, qsettings=None):

--- a/tests-qt/test_settingsui.py
+++ b/tests-qt/test_settingsui.py
@@ -80,9 +80,7 @@ def test_settingsui_default_save_values(bootstrap, qtbot):
     qtbot.mouseClick(settingsui.qtui.save_button, Qt.MouseButton.LeftButton)
 
     none_keys = [
-        k
-        for k in config.cparser.allKeys()
-        if "/" in k and config.cparser.value(k) is None
+        k for k in config.cparser.allKeys() if "/" in k and config.cparser.value(k) is None
     ]
     assert not none_keys, (
         f"Keys are None after default save (missing from defaults()): {none_keys}"


### PR DESCRIPTION
cparser.value() is a getter; the auto-install code was calling it with the intended config values as arguments and discarding the return, so DJUCED was never actually written to config.

(backport of fix from #1777)

## Summary by Sourcery

Fix DJUCED input auto-install so it correctly persists the detected library path in configuration.

Bug Fixes:
- Ensure DJUCED auto-install writes the selected input and detected library directory to the configuration instead of performing a no-op.

Enhancements:
- Clarify the DJUCED input install() docstring to describe its auto-install behavior.