### PR TITLE
feat: release notes dialog in update window

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -21,9 +21,19 @@
 > WNP EarShot, an optional companion app using Shazam-based audio identification.
 > Includes built-in Twitch, Kick, and Discord bots for track announcements and
 > chat commands. Outputs to OBS and custom HTML overlays via a built-in web server
-> with Jinja2 templating. Ships with 42 OBS browser overlay templates (including
-> 7 WebGL/canvas animated effects) and 36 text templates for Twitch, Kick, and
-> plain text output, all ready to use out of the box.
+> with WebSocket streaming and Jinja2 templating; browser source overlays update
+> the instant a track changes — no polling, no page refresh needed.
+> Ships with 42 OBS browser overlay templates spanning multiple effect categories:
+> WebGL 3D GPU-rendered effects (spinning vinyl record textured with cover art,
+> animated EQ spectrum bars, cyberpunk scanline hologram with glitch text reveal,
+> floating particle field, rotating 3D cube textured with artist fanart, animated
+> wave boundary); anime.js motion effects (elastic scale, bounce, character stagger,
+> explode, spin, slide); Typed.js realistic typewriter with mistakes (terminal,
+> amber, classic paper styles); Matrix digital rain with falling katakana; CSS
+> frosted-glass lower-thirds; artist fanart slideshows cycling through multiple
+> images; and cover art slideshows using multiple simultaneous WebSocket streams.
+> Also includes 36 text templates for Twitch, Kick, and plain text output, all
+> ready to use out of the box.
 > OBS Scene Export generates a complete, ready-to-import OBS 28+ scene collection
 > with pre-configured browser sources in one click.
 > Supports two-computer DJ/streaming setups via automatic network discovery
@@ -53,6 +63,10 @@
 > - **EarShot always-accept**: When WNP EarShot (Shazam-based identification)
 >   is active alongside DJ software, it automatically overrides the active source
 >   when it identifies a different track, with no manual switching required.
+> - **Live-updating OBS overlays**: Browser source templates receive track data
+>   via WebSocket the moment a track changes — no polling or page refresh. Each
+>   template includes per-template timing metadata (`wnp-timing`) controlling
+>   reveal, hold, and hide phase durations independently.
 > - **Two-computer setup**: Remote Output sends live track data from the DJ
 >   machine to the streaming/OBS PC automatically over the local network via
 >   Bonjour/Zeroconf with no IP addresses or port forwarding needed.

--- a/nowplaying/upgrade.py
+++ b/nowplaying/upgrade.py
@@ -8,11 +8,16 @@ import pathlib
 import sys
 import webbrowser
 
-from PySide6.QtCore import QSettings  # pylint: disable=no-name-in-module
+import requests
+
+from PySide6.QtCore import Qt, QSettings  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QDialog,
     QDialogButtonBox,
+    QFrame,
     QLabel,
+    QScrollArea,
+    QTextBrowser,
     QVBoxLayout,
     QWidget,
 )
@@ -24,6 +29,102 @@ import nowplaying.version  # pylint: disable=import-error, no-name-in-module
 from nowplaying.upgrades.config import UpgradeConfig
 from nowplaying.upgrades.platform import PlatformDetector
 from nowplaying.upgrades.templates import UpgradeTemplates
+
+
+class ReleaseNotesDialog(QDialog):
+    """Modal child dialog showing aggregated release notes since from_version."""
+
+    def __init__(self, newversion: str, from_version: str, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle(f"What's New in v{newversion}")
+        self.resize(660, 540)
+
+        entries = self._fetch_entries(from_version) or []
+
+        content = QWidget()
+        clayout = QVBoxLayout(content)
+        clayout.setSpacing(12)
+        clayout.setContentsMargins(16, 16, 16, 16)
+
+        for i, entry in enumerate(entries):
+            if i > 0:
+                sep = QFrame()
+                sep.setFrameShape(QFrame.Shape.HLine)
+                sep.setFrameShadow(QFrame.Shadow.Sunken)
+                clayout.addWidget(sep)
+
+            ver = entry.get("version", "")
+            date = entry.get("date", "")
+            is_pre = entry.get("is_prerelease", False)
+            notes_text = (entry.get("notes") or "").replace("\r\n", "\n").strip()
+
+            pre_badge = (
+                " <span style='color:#b45309; font-size:small;'>(pre-release)</span>"
+                if is_pre
+                else ""
+            )
+            hdr = QLabel(
+                f"<span style='font-size:14pt; font-weight:bold;'>v{ver}</span>{pre_badge}"
+            )
+            hdr.setTextFormat(Qt.TextFormat.RichText)
+            clayout.addWidget(hdr)
+
+            if date:
+                date_lbl = QLabel(date)
+                date_lbl.setStyleSheet("color: gray;")
+                clayout.addWidget(date_lbl)
+
+            if notes_text:
+                browser = QTextBrowser()
+                browser.setOpenExternalLinks(True)
+                browser.setFrameShape(QFrame.Shape.NoFrame)
+                browser.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+                browser.setStyleSheet("QTextBrowser { background: transparent; border: none; }")
+                browser.setMarkdown(notes_text)
+                browser.document().documentLayout().documentSizeChanged.connect(
+                    lambda sz, b=browser: b.setFixedHeight(int(sz.height()) + 4)
+                )
+                clayout.addWidget(browser)
+
+        if not entries:
+            fallback = QLabel(
+                f"Release notes for v{newversion} could not be loaded.\n"
+                "Check the project's GitHub releases page for details."
+            )
+            fallback.setWordWrap(True)
+            clayout.addWidget(fallback)
+
+        clayout.addStretch()
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setWidget(content)
+
+        close_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        close_box.rejected.connect(self.reject)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.addWidget(scroll)
+        main_layout.addWidget(close_box)
+
+    @staticmethod
+    def _fetch_entries(from_version: str) -> list[dict] | None:
+        try:
+            response = requests.get(
+                nowplaying.upgrades.RELEASE_NOTES_URL,
+                params={"from_version": from_version},
+                timeout=5,
+            )
+            response.raise_for_status()
+            entries = response.json()
+            if not isinstance(entries, list):
+                logging.debug("Release notes API returned non-list for v%s", from_version)
+                return None
+            return entries
+        except Exception:  # pylint: disable=broad-except
+            logging.debug("Failed to fetch release notes since v%s", from_version, exc_info=True)
+            return None
 
 
 class _UpgradeAction(enum.Enum):
@@ -96,6 +197,8 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         super().__init__(parent)
         self.setWindowTitle("New Version Available!")
         self.action: _UpgradeAction = _UpgradeAction.LATER
+        self.newversion: str | None = None
+        self.oldversion: str | None = None
 
         self.buttonbox = QDialogButtonBox()
         # Caller is responsible for setting offer_auto_install only when
@@ -105,6 +208,8 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         if offer_auto_install:
             install_btn = self.buttonbox.addButton("Install Now", QDialogButtonBox.AcceptRole)
             install_btn.clicked.connect(self._install_now)
+        release_notes_btn = self.buttonbox.addButton("Release Notes", QDialogButtonBox.ActionRole)
+        release_notes_btn.clicked.connect(self._show_release_notes)
         downloads_btn = self.buttonbox.addButton("View Downloads", QDialogButtonBox.ActionRole)
         downloads_btn.clicked.connect(self._view_downloads)
         later_btn = self.buttonbox.addButton("Remind Me Later", QDialogButtonBox.RejectRole)
@@ -115,6 +220,10 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
     def _install_now(self) -> None:
         self.action = _UpgradeAction.INSTALL_NOW
         self.accept()
+
+    def _show_release_notes(self) -> None:
+        if self.newversion and self.oldversion:
+            ReleaseNotesDialog(self.newversion, self.oldversion, parent=self).exec_()
 
     def _view_downloads(self) -> None:
         self.action = _UpgradeAction.VIEW_DOWNLOADS
@@ -130,6 +239,8 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
         cached: bool = False,
     ) -> None:
         """fill in the upgrade versions and message"""
+        self.newversion = newversion
+        self.oldversion = oldversion
         messages = [
             f"Your version: {oldversion}",
             f"New version: {newversion}",

--- a/nowplaying/upgrade.py
+++ b/nowplaying/upgrade.py
@@ -8,8 +8,6 @@ import pathlib
 import sys
 import webbrowser
 
-import requests
-
 from PySide6.QtCore import Qt, QSettings  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QDialog,
@@ -31,7 +29,7 @@ from nowplaying.upgrades.platform import PlatformDetector
 from nowplaying.upgrades.templates import UpgradeTemplates
 
 
-class ReleaseNotesDialog(QDialog):
+class ReleaseNotesDialog(QDialog):  # pylint: disable=too-few-public-methods
     """Modal child dialog showing aggregated release notes since from_version."""
 
     def __init__(self, newversion: str, from_version: str, parent: QWidget | None = None):
@@ -39,7 +37,7 @@ class ReleaseNotesDialog(QDialog):
         self.setWindowTitle(f"What's New in v{newversion}")
         self.resize(660, 540)
 
-        entries = self._fetch_entries(from_version) or []
+        entries = nowplaying.upgrades.fetch_release_notes(from_version) or []
 
         content = QWidget()
         clayout = QVBoxLayout(content)
@@ -47,44 +45,7 @@ class ReleaseNotesDialog(QDialog):
         clayout.setContentsMargins(16, 16, 16, 16)
 
         for i, entry in enumerate(entries):
-            if i > 0:
-                sep = QFrame()
-                sep.setFrameShape(QFrame.Shape.HLine)
-                sep.setFrameShadow(QFrame.Shadow.Sunken)
-                clayout.addWidget(sep)
-
-            ver = entry.get("version", "")
-            date = entry.get("date", "")
-            is_pre = entry.get("is_prerelease", False)
-            notes_text = (entry.get("notes") or "").replace("\r\n", "\n").strip()
-
-            pre_badge = (
-                " <span style='color:#b45309; font-size:small;'>(pre-release)</span>"
-                if is_pre
-                else ""
-            )
-            hdr = QLabel(
-                f"<span style='font-size:14pt; font-weight:bold;'>v{ver}</span>{pre_badge}"
-            )
-            hdr.setTextFormat(Qt.TextFormat.RichText)
-            clayout.addWidget(hdr)
-
-            if date:
-                date_lbl = QLabel(date)
-                date_lbl.setStyleSheet("color: gray;")
-                clayout.addWidget(date_lbl)
-
-            if notes_text:
-                browser = QTextBrowser()
-                browser.setOpenExternalLinks(True)
-                browser.setFrameShape(QFrame.Shape.NoFrame)
-                browser.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-                browser.setStyleSheet("QTextBrowser { background: transparent; border: none; }")
-                browser.setMarkdown(notes_text)
-                browser.document().documentLayout().documentSizeChanged.connect(
-                    lambda sz, b=browser: b.setFixedHeight(int(sz.height()) + 4)
-                )
-                clayout.addWidget(browser)
+            self._build_entry(clayout, entry, add_separator=i > 0)
 
         if not entries:
             fallback = QLabel(
@@ -109,22 +70,42 @@ class ReleaseNotesDialog(QDialog):
         main_layout.addWidget(close_box)
 
     @staticmethod
-    def _fetch_entries(from_version: str) -> list[dict] | None:
-        try:
-            response = requests.get(
-                nowplaying.upgrades.RELEASE_NOTES_URL,
-                params={"from_version": from_version},
-                timeout=5,
+    def _build_entry(clayout: QVBoxLayout, entry: dict, *, add_separator: bool) -> None:
+        if add_separator:
+            sep = QFrame()
+            sep.setFrameShape(QFrame.Shape.HLine)
+            sep.setFrameShadow(QFrame.Shadow.Sunken)
+            clayout.addWidget(sep)
+
+        ver = entry.get("version", "")
+        date = entry.get("date", "")
+        is_pre = entry.get("is_prerelease", False)
+        notes_text = (entry.get("notes") or "").replace("\r\n", "\n").strip()
+
+        pre_badge = (
+            " <span style='color:#b45309; font-size:small;'>(pre-release)</span>" if is_pre else ""
+        )
+        hdr = QLabel(f"<span style='font-size:14pt; font-weight:bold;'>v{ver}</span>{pre_badge}")
+        hdr.setTextFormat(Qt.TextFormat.RichText)
+        clayout.addWidget(hdr)
+
+        if date:
+            date_lbl = QLabel(date)
+            date_lbl.setStyleSheet("color: gray;")
+            clayout.addWidget(date_lbl)
+
+        if notes_text:
+            browser = QTextBrowser()
+            browser.setOpenExternalLinks(True)
+            browser.setFrameShape(QFrame.Shape.NoFrame)
+            browser.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            browser.setStyleSheet("QTextBrowser { background: transparent; border: none; }")
+            browser.setMarkdown(notes_text)
+            browser.document().documentLayout().documentSizeChanged.connect(
+                lambda sz, b=browser: b.setFixedHeight(int(sz.height()) + 4)
             )
-            response.raise_for_status()
-            entries = response.json()
-            if not isinstance(entries, list):
-                logging.debug("Release notes API returned non-list for v%s", from_version)
-                return None
-            return entries
-        except Exception:  # pylint: disable=broad-except
-            logging.debug("Failed to fetch release notes since v%s", from_version, exc_info=True)
-            return None
+            clayout.addWidget(browser)
+
 
 
 class _UpgradeAction(enum.Enum):

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -16,6 +16,7 @@ if t.TYPE_CHECKING:
     import nowplaying.config
 
 UPDATE_CHECK_URL = "https://whatsnowplaying.com/api/v1/check-version"
+RELEASE_NOTES_URL = "https://whatsnowplaying.com/api/v1/release-notes"
 
 _PRERELEASE_MARKERS = ("-rc", "-preview", "+")
 

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -18,6 +18,29 @@ if t.TYPE_CHECKING:
 UPDATE_CHECK_URL = "https://whatsnowplaying.com/api/v1/check-version"
 RELEASE_NOTES_URL = "https://whatsnowplaying.com/api/v1/release-notes"
 
+
+def fetch_release_notes(from_version: str) -> list[dict] | None:
+    """Fetch aggregated release notes since from_version from the WNP API.
+
+    Returns a list of release entry dicts (version, date, is_prerelease, notes)
+    ordered newest-first, or None on any error.
+    """
+    try:
+        response = requests.get(
+            RELEASE_NOTES_URL,
+            params={"from_version": from_version},
+            timeout=5,
+        )
+        response.raise_for_status()
+        entries = response.json()
+        if not isinstance(entries, list):
+            logging.debug("Release notes API returned non-list for v%s", from_version)
+            return None
+        return entries
+    except Exception:  # pylint: disable=broad-except
+        logging.debug("Failed to fetch release notes since v%s", from_version, exc_info=True)
+        return None
+
 _PRERELEASE_MARKERS = ("-rc", "-preview", "+")
 
 # regex that support's git describe --tags as well as many semver-type strings

--- a/tests/test_upgradeutils.py
+++ b/tests/test_upgradeutils.py
@@ -148,7 +148,7 @@ def up_to_date_response():
     }
 
 
-def _mock_response(data: dict, status_code: int = 200) -> MagicMock:
+def _mock_response(data: dict | list, status_code: int = 200) -> MagicMock:
     """Build a mock requests.Response"""
     mock = MagicMock()
     mock.status_code = status_code
@@ -353,3 +353,66 @@ def test_check_for_update_prerelease_running_ignores_setting(monkeypatch, up_to_
         sent_params = kwargs.get("params", {})
 
     assert sent_params.get("track") == "prerelease"
+
+
+# ---------------------------------------------------------------------------
+# fetch_release_notes
+# ---------------------------------------------------------------------------
+
+_SAMPLE_ENTRIES = [
+    {
+        "version": "5.2.2",
+        "date": "2026-06-20",
+        "is_prerelease": False,
+        "notes": "Security and polish release.",
+    },
+    {
+        "version": "5.2.1",
+        "date": "2026-05-21",
+        "is_prerelease": False,
+        "notes": "Reliability release.",
+    },
+]
+
+
+def test_fetch_release_notes_returns_entries():
+    """returns the list from a successful API response"""
+    with patch("requests.get", return_value=_mock_response(_SAMPLE_ENTRIES)):
+        result = nowplaying.upgrades.fetch_release_notes("5.2.0")
+    assert result == _SAMPLE_ENTRIES
+
+
+def test_fetch_release_notes_sends_from_version():
+    """passes from_version as a query parameter"""
+    with patch("requests.get", return_value=_mock_response(_SAMPLE_ENTRIES)) as mock_get:
+        nowplaying.upgrades.fetch_release_notes("5.1.0")
+        _, kwargs = mock_get.call_args
+    assert kwargs.get("params", {}).get("from_version") == "5.1.0"
+
+
+def test_fetch_release_notes_empty_list():
+    """returns an empty list when no releases are newer"""
+    with patch("requests.get", return_value=_mock_response([])):
+        result = nowplaying.upgrades.fetch_release_notes("5.2.2")
+    assert result == []
+
+
+def test_fetch_release_notes_non_list_returns_none():
+    """returns None when the API returns non-list JSON"""
+    with patch("requests.get", return_value=_mock_response({"error": "bad"})):
+        result = nowplaying.upgrades.fetch_release_notes("5.2.0")
+    assert result is None
+
+
+def test_fetch_release_notes_http_error():
+    """returns None on HTTP error"""
+    with patch("requests.get", return_value=_mock_response({}, status_code=500)):
+        result = nowplaying.upgrades.fetch_release_notes("5.2.0")
+    assert result is None
+
+
+def test_fetch_release_notes_network_failure():
+    """returns None on network failure"""
+    with patch("requests.get", side_effect=ConnectionError("network down")):
+        result = nowplaying.upgrades.fetch_release_notes("5.2.0")
+    assert result is None


### PR DESCRIPTION
Adds a Release Notes button to the update-available dialog that opens a scrollable in-app window fetching aggregated notes from POST /api/v1/release-notes?from_version=<current> on whatsnowplaying.com.

Each release entry renders with a styled version header, gray date label, amber pre-release badge, and a frameless transparent QTextBrowser for the markdown body. Entries are separated by QFrame dividers; documentSizeChanged drives fixed-height sizing so each browser shrinks to its content with no internal scrollbar.

Also expands llms.txt template description to surface WebSocket live-update, WebGL, anime.js, Typed.js, Matrix rain, and frosted-glass capabilities.

## Summary by Sourcery

Add an in-app release notes viewer accessible from the update dialog, backed by a remote release-notes API.

New Features:
- Add a Release Notes button to the update-available dialog that opens a modal window showing recent version changes fetched from the server.

Enhancements:
- Introduce a dedicated release notes API endpoint constant for reuse in upgrade-related code.

Documentation:
- Expand llms.txt to describe additional frontend capabilities such as live WebSocket updates, WebGL effects, animation libraries, and visual treatments.