### PR TITLE
fix: WebSocket heartbeat + wizard Finish button

### DIFF
--- a/nowplaying/installwizard/_finish.py
+++ b/nowplaying/installwizard/_finish.py
@@ -26,6 +26,10 @@ class _FinishPage(QWizardPage):
         layout.addStretch()
         self.setLayout(layout)
 
+    def nextId(self) -> int:  # pylint: disable=invalid-name,no-self-use
+        """Terminal page — returning -1 makes Qt show the Finish button."""
+        return -1
+
     def set_summary(
         self,
         input_display: str,

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -311,7 +311,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
 
     async def websocket_artistfanart_streamer(self, request: web.Request):  # pylint: disable=too-many-branches
         """handle continually streamed updates"""
-        websocket = web.WebSocketResponse()
+        websocket = web.WebSocketResponse(heartbeat=30.0)
         await websocket.prepare(request)
         request.app[WS_KEY].add(websocket)
         endloop = False
@@ -433,7 +433,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
     async def websocket_streamer(self, request: web.Request):
         """handle continually streamed updates"""
 
-        websocket = web.WebSocketResponse()
+        websocket = web.WebSocketResponse(heartbeat=30.0)
         await websocket.prepare(request)
         request.app[WS_KEY].add(websocket)
 
@@ -493,7 +493,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
 
     async def websocket_handler(self, request: web.Request):
         """handle inbound websockets"""
-        websocket = web.WebSocketResponse()
+        websocket = web.WebSocketResponse(heartbeat=30.0)
         await websocket.prepare(request)
         request.app[WS_KEY].add(websocket)
         try:

--- a/nowplaying/webserver/gifwords_websocket.py
+++ b/nowplaying/webserver/gifwords_websocket.py
@@ -29,7 +29,7 @@ class GifwordsWebSocketHandler:
 
     async def websocket_gifwords_streamer(self, request: web.Request):
         """Handle gifwords WebSocket connection - just waits for broadcasts"""
-        websocket = web.WebSocketResponse()
+        websocket = web.WebSocketResponse(heartbeat=30.0)
         await websocket.prepare(request)
 
         # Get session ID from query parameters

--- a/nowplaying/webserver/guessgame_websocket.py
+++ b/nowplaying/webserver/guessgame_websocket.py
@@ -28,7 +28,7 @@ class GuessgameWebSocketHandler:
 
     async def websocket_guessgame_streamer(self, request: web.Request):
         """Handle guess game WebSocket connection - just waits for broadcasts"""
-        websocket = web.WebSocketResponse()
+        websocket = web.WebSocketResponse(heartbeat=30.0)
         await websocket.prepare(request)
 
         # Get session ID from query parameters

--- a/nowplaying/webserver/images_websocket.py
+++ b/nowplaying/webserver/images_websocket.py
@@ -44,7 +44,7 @@ class ImagesWebSocketHandler:  # pylint: disable=too-few-public-methods
 
     async def websocket_images_handler(self, request: web.Request):  # pylint: disable=too-many-branches
         """handle Images WebSocket API"""
-        websocket = web.WebSocketResponse()
+        websocket = web.WebSocketResponse(heartbeat=30.0)
         await websocket.prepare(request)
         request.app[self.ws_key].add(websocket)
 


### PR DESCRIPTION
Add heartbeat=30.0 to all six WebSocketResponse instances
(webserver.py, gifwords/guessgame/images websocket handlers)
to prevent idle connection drops on proxied or firewalled setups.

Add nextId()->-1 to _FinishPage so Qt renders the Finish button
instead of Next on the final wizard page.

## Summary by Sourcery

Stabilize WebSocket connections and ensure the install wizard correctly shows a Finish button on the final page.

Bug Fixes:
- Prevent idle WebSocket connections from being dropped on proxied or firewalled setups by enabling periodic heartbeats.
- Make the final install wizard page display a Finish button instead of Next by marking it as the terminal page.