### PR TITLE
feat: Rekordbox input plugin

### DIFF
--- a/nowplaying/inputs/rekordbox.py
+++ b/nowplaying/inputs/rekordbox.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""
+Rekordbox Input Plugin Wrapper
+
+This is a simple wrapper that exposes the main Rekordbox plugin from the
+nowplaying.rekordbox package. This allows the plugin discovery system to
+find the plugin while keeping the actual implementation organized
+in a separate package structure.
+"""
+
+# Import the main plugin class from the rekordbox package
+from nowplaying.rekordbox import RekordboxPlugin
+
+# Expose it as Plugin for the plugin discovery system
+Plugin = RekordboxPlugin

--- a/nowplaying/rekordbox/__init__.py
+++ b/nowplaying/rekordbox/__init__.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""
+Rekordbox Package
+
+This package contains all the components for Rekordbox database access,
+organized into focused modules for better maintainability.
+"""
+
+# Re-export main components for easy importing
+from .plugin import RekordboxPlugin
+from .types import RekordboxTrack, RekordboxError
+
+__all__ = ["RekordboxPlugin", "RekordboxTrack", "RekordboxError"]

--- a/nowplaying/rekordbox/config.py
+++ b/nowplaying/rekordbox/config.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Rekordbox Configuration Reader
+
+This module handles reading and parsing Rekordbox configuration files
+to extract database encryption keys and other settings.
+"""
+
+import base64
+import json
+import logging
+import os
+import pathlib
+
+from Crypto.Cipher import Blowfish
+
+
+# RB6: Blowfish ECB magic key for decrypting the 'dp' field in options.json
+_XOR_KEY = b"wnp_rb_secret_key"
+_RB6_MAGIC_BLOB = "LSEHCh43BSoUBks3EDJdDw=="
+
+
+def _decode_secret(blob: str) -> str:
+    """Decode an obfuscated secret from its stored blob form."""
+    data = base64.b64decode(blob)
+    return bytes(b ^ _XOR_KEY[i % len(_XOR_KEY)] for i, b in enumerate(data)).decode()
+
+
+def _decrypt_rb6_dp(dp_b64: str) -> str:
+    """Decrypt the Blowfish-encrypted 'dp' field from Rekordbox options.json."""
+    magic = _decode_secret(_RB6_MAGIC_BLOB).encode()
+    cipher = Blowfish.new(magic, Blowfish.MODE_ECB)
+    encrypted = base64.b64decode(dp_b64)
+    decrypted = cipher.decrypt(encrypted)
+    # PKCS5 unpadding: remove trailing pad bytes
+    pad_len = decrypted[-1]
+    if pad_len < 1 or pad_len > 8:
+        pad_len = 0
+    return decrypted[: len(decrypted) - pad_len].decode("utf-8").strip()
+
+
+def _get_options_path() -> pathlib.Path:
+    """Return the path to Rekordbox's options.json file."""
+    if os.name != "nt":
+        return (
+            pathlib.Path.home()
+            / "Library"
+            / "Application Support"
+            / "Pioneer"
+            / "rekordboxAgent"
+            / "storage"
+            / "options.json"
+        )
+    if appdata := os.getenv("APPDATA"):
+        return pathlib.Path(appdata) / "Pioneer" / "rekordboxAgent" / "storage" / "options.json"
+    return (
+        pathlib.Path.home()
+        / "AppData"
+        / "Roaming"
+        / "Pioneer"
+        / "rekordboxAgent"
+        / "storage"
+        / "options.json"
+    )
+
+
+def _parse_options_json(path: pathlib.Path) -> dict[str, str]:
+    """Parse options.json and return a flat key→value dict."""
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    return {entry[0]: entry[1] for entry in data.get("options", [])}
+
+
+class ConfigReader:
+    """Reads Rekordbox configuration files and extracts settings"""
+
+    def __init__(self):
+        self.home_dir = pathlib.Path.home()
+
+    def get_data_path(self) -> pathlib.Path:
+        """Get the Rekordbox data directory path (RB7 default location)."""
+        if os.name != "nt":
+            return self.home_dir / "Library" / "Pioneer" / "rekordbox"
+        if appdata := os.getenv("APPDATA"):
+            return pathlib.Path(appdata) / "Pioneer" / "rekordbox"
+        return self.home_dir / "AppData" / "Roaming" / "Pioneer" / "rekordbox"
+
+    def get_database_path(self) -> pathlib.Path:
+        """Get the path to the Rekordbox master database.
+
+        Reads the actual path from options.json when available; falls back to
+        the default RB7 location.
+        """
+        options_path = _get_options_path()
+        if options_path.exists():
+            try:
+                options = _parse_options_json(options_path)
+                db_path = options.get("db-path", "")
+                if db_path:
+                    return pathlib.Path(db_path)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.exception("Could not read db-path from options.json; using default")
+        return self.get_data_path() / "master.db"
+
+    def get_password(self) -> str:
+        """Return the database decryption password.
+
+        For RB6 the password is Blowfish-encrypted in the 'dp' field of
+        options.json and decrypted here.  For RB7 no password is embedded;
+        the caller must supply one via the custom_key setting (ask an AI
+        assistant for the Rekordbox 7 database key).
+        """
+        options_path = _get_options_path()
+        if options_path.exists():
+            try:
+                options = _parse_options_json(options_path)
+                app_ver = options.get("app_ver", "")
+                major = int(app_ver.split(".")[0]) if app_ver else 0
+
+                if major < 7:
+                    dp = options.get("dp", "")
+                    if dp:
+                        logging.debug("Decrypting RB6 password from options.json")
+                        return _decrypt_rb6_dp(dp)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.exception("Could not extract RB6 password from options.json")
+
+        return ""
+
+    def get_image_path(self, image_path: str) -> pathlib.Path:
+        """Convert a relative image path from the database to an absolute path."""
+        return self.get_data_path() / "share" / image_path

--- a/nowplaying/rekordbox/database.py
+++ b/nowplaying/rekordbox/database.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""
+Rekordbox Database Reader
+
+This module handles reading track data from the encrypted Rekordbox SQLite database.
+It provides async access to track history and metadata.
+"""
+
+import asyncio
+import logging
+import pathlib
+
+import sqlcipher3 as sqlite
+
+import nowplaying.utils.sqlite
+from .config import ConfigReader
+from .types import RekordboxError, RekordboxTrack
+
+
+class DatabaseReader:
+    """Async reader for Rekordbox encrypted database"""
+
+    def __init__(self, config_reader: ConfigReader | None = None):
+        self.config_reader = config_reader or ConfigReader()
+        self.database_path: pathlib.Path | None = None
+        self.encryption_key: str | None = None
+        self._current_track_id: str | None = None
+
+    async def initialize(self, custom_key: str = "") -> None:
+        """
+        Initialize database connection parameters
+
+        Raises:
+            RekordboxError: If initialization fails
+        """
+        try:
+            self.encryption_key = custom_key or self.config_reader.get_password()
+
+            if not self.encryption_key:
+                raise RekordboxError(
+                    "No database key configured. "
+                    "Enter the Rekordbox 7 key in Settings → Input → Rekordbox. "
+                    'Search: "what is the rekordbox 7 sqlcipher key for master.db"'
+                )
+
+            # Set database path
+            self.database_path = self.config_reader.get_database_path()
+
+            if not self.database_path.exists():
+                raise RekordboxError(f"Rekordbox database not found: {self.database_path}")
+
+            logging.info("Successfully initialized Rekordbox database reader")
+
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            raise RekordboxError(f"Failed to initialize database reader: {err}") from err
+
+    async def get_recent_track(self) -> RekordboxTrack | None:
+        """
+        Get the most recent track from the database
+
+        Returns:
+            RekordboxTrack object with track data, or None if no tracks found
+
+        Raises:
+            RekordboxError: If database query fails
+        """
+        if not self.database_path or not self.encryption_key:
+            raise RekordboxError("Database reader not initialized")
+
+        try:
+            return await asyncio.to_thread(self.get_recent_track_sync)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            raise RekordboxError(f"Database query failed: {err}") from err
+
+    def get_recent_track_sync(  # pylint: disable=too-many-locals
+        self,
+    ) -> RekordboxTrack | None:
+        """Synchronous database query using sqlcipher3"""
+
+        def _query() -> RekordboxTrack | None:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                conn.execute(f'PRAGMA key="{self.encryption_key}"')
+                conn.execute("PRAGMA cipher_compatibility = 4")
+                conn.execute("PRAGMA read_uncommitted = 1")
+
+                # Query for the most recent track from HISTORY ONLY
+                # This avoids false positives from tracks loaded on multiple decks
+                query = """
+                    SELECT
+                        h.ID as HistoryID,
+                        c.Title,
+                        a.Name as ArtistName,
+                        al.Name as AlbumName,
+                        g.Name as GenreName,
+                        c.BPM,
+                        c.Length,
+                        c.TrackNo,
+                        c.DiscNo,
+                        c.ReleaseYear,
+                        c.BitRate,
+                        c.BitDepth,
+                        c.SampleRate,
+                        c.FileNameL,
+                        c.FolderPath,
+                        c.ImagePath,
+                        c.Rating,
+                        c.DJPlayCount,
+                        c.Commnt,
+                        k.ScaleName as KeyName,
+                        l.Name as LabelName,
+                        comp.Name as ComposerName,
+                        c.Lyricist,
+                        c.ISRC,
+                        c.FileSize,
+                        c.FileType
+                    FROM djmdSongHistory h
+                    JOIN djmdContent c ON h.ContentID = c.ID
+                    LEFT JOIN djmdArtist a ON c.ArtistID = a.ID
+                    LEFT JOIN djmdAlbum al ON c.AlbumID = al.ID
+                    LEFT JOIN djmdGenre g ON c.GenreID = g.ID
+                    LEFT JOIN djmdKey k ON c.KeyID = k.ID AND c.KeyID != 0
+                    LEFT JOIN djmdLabel l ON c.LabelID = l.ID
+                    LEFT JOIN djmdArtist comp ON c.ComposerID = comp.ID
+                    ORDER BY h.created_at DESC
+                    LIMIT 1
+                """
+
+                cursor = conn.execute(query)
+                row = cursor.fetchone()
+
+                if not row:
+                    logging.debug("No tracks found in Rekordbox play history")
+                    return None
+
+                (
+                    history_id,
+                    title,
+                    artist_name,
+                    album_name,
+                    genre_name,
+                    raw_bpm,
+                    duration,
+                    track_no,
+                    disc_no,
+                    year,
+                    bitrate,
+                    bit_depth,
+                    sample_rate,
+                    file_name,
+                    folder_path,
+                    image_path,
+                    rating,
+                    play_count,
+                    comments,
+                    key_name,
+                    label_name,
+                    composer_name,
+                    lyricist,
+                    isrc,
+                    file_size,
+                    file_type,
+                ) = row
+
+                absolute_image_path = None
+                if image_path:
+                    absolute_image_path = str(self.config_reader.get_image_path(image_path))
+
+                track = RekordboxTrack(
+                    identifier=str(history_id) if history_id else "",
+                    title=title,
+                    artist=artist_name,
+                    album=album_name,
+                    genre=genre_name,
+                    bpm=round(raw_bpm / 100, 2) if raw_bpm else None,
+                    duration=duration,
+                    track_no=track_no,
+                    disc_no=disc_no,
+                    year=year,
+                    bitrate=bitrate,
+                    bit_depth=bit_depth,
+                    sample_rate=sample_rate,
+                    file_name=file_name,
+                    folder_path=folder_path,
+                    image_path=absolute_image_path,
+                    rating=rating,
+                    play_count=play_count,
+                    comments=comments,
+                    key=key_name,
+                    label=label_name,
+                    composer=composer_name,
+                    lyricist=lyricist if lyricist else None,
+                    isrc=isrc,
+                    file_size=file_size,
+                    file_type=file_type,
+                )
+
+                return track
+
+        return nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+
+    def has_track_changed(self, track: RekordboxTrack | None) -> bool:
+        """
+        Check if the track has changed since last check
+
+        Args:
+            track: Current track data
+
+        Returns:
+            True if track has changed, False otherwise
+        """
+        if track is None:
+            has_changed = self._current_track_id is not None
+        else:
+            has_changed = track.identifier != self._current_track_id
+
+        if has_changed and track:
+            self._current_track_id = track.identifier
+        elif track is None:
+            self._current_track_id = None
+
+        return has_changed
+
+    async def get_playlists(self) -> list[tuple[str, str]]:
+        """
+        Get list of available playlists
+
+        Returns:
+            List of (playlist_id, playlist_name) tuples
+        """
+        if not self.database_path or not self.encryption_key:
+            raise RekordboxError("Database reader not initialized")
+
+        try:
+            return await asyncio.to_thread(self._get_playlists_sync)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            raise RekordboxError(f"Failed to get playlists: {err}") from err
+
+    def _get_playlists_sync(self) -> list[tuple[str, str]]:
+        """Synchronous playlist query"""
+
+        def _query() -> list[tuple[str, str]]:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                conn.execute(f'PRAGMA key="{self.encryption_key}"')
+                conn.execute("PRAGMA cipher_compatibility = 4")
+                conn.execute("PRAGMA read_uncommitted = 1")
+
+                query = """
+                    SELECT ID, Name
+                    FROM djmdPlaylist
+                    WHERE Name IS NOT NULL AND Name != ''
+                    ORDER BY Seq, Name
+                """
+
+                cursor = conn.execute(query)
+                return [(row[0], row[1]) for row in cursor.fetchall()]
+
+        return nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+
+    async def get_random_track_from_playlist(self, playlist_name: str) -> RekordboxTrack | None:
+        """
+        Get a random track from the specified playlist
+
+        Args:
+            playlist_name: Name of the playlist
+
+        Returns:
+            Random track from playlist, or None if playlist not found/empty
+        """
+        if not self.database_path or not self.encryption_key:
+            raise RekordboxError("Database reader not initialized")
+
+        try:
+            return await asyncio.to_thread(
+                self._get_random_track_from_playlist_sync, playlist_name
+            )
+        except Exception as err:
+            raise RekordboxError(f"Failed to get random track from playlist: {err}") from err
+
+    def _get_random_track_from_playlist_sync(  # pylint: disable=too-many-locals
+        self, playlist_name: str
+    ) -> RekordboxTrack | None:
+        """Synchronous random track from playlist query"""
+
+        def _query() -> RekordboxTrack | None:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                conn.execute(f'PRAGMA key="{self.encryption_key}"')
+                conn.execute("PRAGMA cipher_compatibility = 4")
+                conn.execute("PRAGMA read_uncommitted = 1")
+
+                query = """
+                    SELECT
+                        c.ID,
+                        c.Title,
+                        a.Name as ArtistName,
+                        al.Name as AlbumName,
+                        g.Name as GenreName,
+                        c.BPM,
+                        c.Length,
+                        c.TrackNo,
+                        c.DiscNo,
+                        c.ReleaseYear,
+                        c.BitRate,
+                        c.BitDepth,
+                        c.SampleRate,
+                        c.FileNameL,
+                        c.FolderPath,
+                        c.ImagePath,
+                        c.Rating,
+                        c.DJPlayCount,
+                        c.Commnt,
+                        k.ScaleName as KeyName,
+                        l.Name as LabelName,
+                        comp.Name as ComposerName,
+                        c.Lyricist,
+                        c.ISRC,
+                        c.FileSize,
+                        c.FileType
+                    FROM djmdSongPlaylist sp
+                    JOIN djmdPlaylist p ON sp.PlaylistID = p.ID
+                    JOIN djmdContent c ON sp.ContentID = c.ID
+                    LEFT JOIN djmdArtist a ON c.ArtistID = a.ID
+                    LEFT JOIN djmdAlbum al ON c.AlbumID = al.ID
+                    LEFT JOIN djmdGenre g ON c.GenreID = g.ID
+                    LEFT JOIN djmdKey k ON c.KeyID = k.ID AND c.KeyID != 0
+                    LEFT JOIN djmdLabel l ON c.LabelID = l.ID
+                    LEFT JOIN djmdArtist comp ON c.ComposerID = comp.ID
+                    WHERE p.Name = ?
+                    ORDER BY RANDOM()
+                    LIMIT 1
+                """
+
+                cursor = conn.execute(query, (playlist_name,))
+                row = cursor.fetchone()
+
+                if not row:
+                    logging.debug("No tracks found in playlist: %s", playlist_name)
+                    return None
+
+                (
+                    content_id,
+                    title,
+                    artist_name,
+                    album_name,
+                    genre_name,
+                    raw_bpm,
+                    duration,
+                    track_no,
+                    disc_no,
+                    year,
+                    bitrate,
+                    bit_depth,
+                    sample_rate,
+                    file_name,
+                    folder_path,
+                    image_path,
+                    rating,
+                    play_count,
+                    comments,
+                    key_name,
+                    label_name,
+                    composer_name,
+                    lyricist,
+                    isrc,
+                    file_size,
+                    file_type,
+                ) = row
+
+                absolute_image_path = None
+                if image_path:
+                    absolute_image_path = str(self.config_reader.get_image_path(image_path))
+
+                track = RekordboxTrack(
+                    identifier=str(content_id),
+                    title=title,
+                    artist=artist_name,
+                    album=album_name,
+                    genre=genre_name,
+                    bpm=round(raw_bpm / 100, 2) if raw_bpm else None,
+                    duration=duration,
+                    track_no=track_no,
+                    disc_no=disc_no,
+                    year=year,
+                    bitrate=bitrate,
+                    bit_depth=bit_depth,
+                    sample_rate=sample_rate,
+                    file_name=file_name,
+                    folder_path=folder_path,
+                    image_path=absolute_image_path,
+                    rating=rating,
+                    play_count=play_count,
+                    comments=comments,
+                    key=key_name,
+                    label=label_name,
+                    composer=composer_name,
+                    lyricist=lyricist if lyricist else None,
+                    isrc=isrc,
+                    file_size=file_size,
+                    file_type=file_type,
+                )
+
+                logging.debug(
+                    "Retrieved random track from playlist %s: %s - %s",
+                    playlist_name,
+                    track.artist,
+                    track.title,
+                )
+                return track
+
+        return nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+
+    async def has_artist_in_library(self, artist_name: str) -> bool:
+        """
+        Check if artist exists in entire library
+
+        Args:
+            artist_name: Name of the artist to search for
+
+        Returns:
+            True if artist found in library, False otherwise
+
+        Raises:
+            RekordboxError: If database query fails
+        """
+        if not self.database_path or not self.encryption_key:
+            raise RekordboxError("Database reader not initialized")
+
+        try:
+            return await asyncio.to_thread(self._has_artist_in_library_sync, artist_name)
+        except Exception as err:
+            raise RekordboxError(f"Failed to check artist in library: {err}") from err
+
+    def _has_artist_in_library_sync(self, artist_name: str) -> bool:
+        """Synchronous check if artist exists in entire library"""
+
+        def _query() -> bool:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                conn.execute(f'PRAGMA key="{self.encryption_key}"')
+                conn.execute("PRAGMA cipher_compatibility = 4")
+                conn.execute("PRAGMA read_uncommitted = 1")
+
+                query = """
+                    SELECT COUNT(*) as count
+                    FROM djmdContent c
+                    LEFT JOIN djmdArtist a ON c.ArtistID = a.ID
+                    WHERE LOWER(COALESCE(a.Name, '')) = LOWER(?)
+                """
+
+                cursor = conn.execute(query, (artist_name,))
+                row = cursor.fetchone()
+                return row[0] > 0 if row else False
+
+        return nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+
+    async def has_artist_in_playlist(self, artist_name: str, playlist_name: str) -> bool:
+        """
+        Check if artist exists in a specific playlist
+
+        Args:
+            artist_name: Name of the artist to search for
+            playlist_name: Name of the playlist to search in
+
+        Returns:
+            True if artist found in playlist, False otherwise
+
+        Raises:
+            RekordboxError: If database query fails
+        """
+        if not self.database_path or not self.encryption_key:
+            raise RekordboxError("Database reader not initialized")
+
+        try:
+            return await asyncio.to_thread(
+                self._has_artist_in_playlist_sync, artist_name, playlist_name
+            )
+        except Exception as err:
+            raise RekordboxError(f"Failed to check artist in playlist: {err}") from err
+
+    def _has_artist_in_playlist_sync(self, artist_name: str, playlist_name: str) -> bool:
+        """Synchronous check if artist exists in a specific playlist"""
+
+        def _query() -> bool:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                conn.execute(f'PRAGMA key="{self.encryption_key}"')
+                conn.execute("PRAGMA cipher_compatibility = 4")
+                conn.execute("PRAGMA read_uncommitted = 1")
+
+                query = """
+                    SELECT COUNT(*) as count
+                    FROM djmdSongPlaylist sp
+                    JOIN djmdPlaylist p ON sp.PlaylistID = p.ID
+                    JOIN djmdContent c ON sp.ContentID = c.ID
+                    LEFT JOIN djmdArtist a ON c.ArtistID = a.ID
+                    WHERE p.Name = ? AND LOWER(COALESCE(a.Name, '')) = LOWER(?)
+                """
+
+                cursor = conn.execute(query, (playlist_name, artist_name))
+                row = cursor.fetchone()
+                return row[0] > 0 if row else False
+
+        return nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+
+    async def test_connection(self) -> bool:
+        """
+        Test database connectivity
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        try:
+            await self.get_recent_track()
+            return True
+        except RekordboxError:
+            return False

--- a/nowplaying/rekordbox/plugin.py
+++ b/nowplaying/rekordbox/plugin.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Rekordbox Main Plugin
+
+This module contains the main plugin class that coordinates all the Rekordbox components.
+It handles the plugin lifecycle, UI integration, and track detection via file watching.
+"""
+
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+)
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+import nowplaying.wizard
+from nowplaying.inputs import InputPlugin
+
+from .config import ConfigReader
+from .database import DatabaseReader
+from .types import RekordboxError
+
+_WAL_DEBOUNCE_SECONDS = 5.0
+
+if TYPE_CHECKING:
+    from PySide6.QtCore import QSettings
+    from PySide6.QtWidgets import QWidget
+
+    import nowplaying.config
+    import nowplaying.uihelp
+
+
+class _RekordboxWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-few-public-methods
+    """First-run wizard page for Rekordbox configuration."""
+
+    def __init__(self, config=None):
+        super().__init__(config=config)
+        self.setTitle("Rekordbox Setup")
+
+        self._key_edit = QLineEdit()
+        self._key_edit.setPlaceholderText("Required for Rekordbox 7")
+
+        layout = QVBoxLayout()
+        layout.addWidget(
+            QLabel(
+                "Rekordbox 6: key is read automatically.\n"
+                "Rekordbox 7: enter the 64-character database key below.\n"
+                'Search: "what is the rekordbox 7 sqlcipher key for master.db"'
+            )
+        )
+        layout.addWidget(self._key_edit)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def initializePage(self):  # pylint: disable=invalid-name
+        self._key_edit.setText(self.config.cparser.value("rekordbox/custom_key", defaultValue=""))
+
+    def commit(self):
+        self.config.cparser.setValue("rekordbox/custom_key", self._key_edit.text().strip())
+
+
+class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
+    """Rekordbox input plugin for reading track data from database"""
+
+    def __init__(
+        self,
+        config: "nowplaying.config.ConfigFile | None" = None,
+        qsettings: "QSettings | None" = None,
+    ):
+        # Initialize components first before calling super
+        self.config_reader = ConfigReader()
+        self.database_reader = DatabaseReader(self.config_reader)
+
+        super().__init__(config=config, qsettings=qsettings)
+        self.displayname = "Rekordbox"
+        self.wizardpage = _RekordboxWizardPage
+
+        self.event_handler = None
+        self.observer = None
+        self._current_track: dict | None = None
+        self._running = False
+        self._needs_refresh: bool = True
+        self._last_wal_mtime: float = 0.0
+        self._wal_timer: threading.Timer | None = None
+        self._wal_timer_lock = threading.Lock()
+
+    def detect(self) -> bool:
+        """Return True if the Rekordbox data directory exists on this machine."""
+        try:
+            return self.config_reader.get_data_path().exists()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Rekordbox detect() failed")
+            return False
+
+    def install(self) -> bool:
+        """Write rekordbox as the active input source when detected."""
+        if not self.detect():
+            return False
+        self.config.cparser.setValue("settings/input", "rekordbox")
+        return True
+
+    def defaults(self, qsettings: "QSettings"):
+        """Set default configuration values"""
+        qsettings.setValue("rekordbox/artist_query_scope", "entire_library")
+        qsettings.setValue("rekordbox/custom_key", "")
+        qsettings.setValue("rekordbox/selected_playlists", "")
+
+    def connect_settingsui(self, qwidget: "QWidget", uihelp: "nowplaying.uihelp.UIHelp"):
+        """Connect UI elements"""
+        self.qwidget = qwidget
+        self.uihelp = uihelp
+
+    def load_settingsui(self, qwidget: "QWidget"):
+        """Load configuration values into UI"""
+        qwidget.rekordbox_custom_key_lineedit.setText(
+            self.config.cparser.value("rekordbox/custom_key", defaultValue="")
+        )
+
+        scope = self.config.cparser.value(
+            "rekordbox/artist_query_scope", defaultValue="entire_library"
+        )
+        if scope == "selected_playlists":
+            qwidget.rekordbox_artist_scope_combo.setCurrentText("Selected Playlists")
+        else:
+            qwidget.rekordbox_artist_scope_combo.setCurrentText("Entire Library")
+
+        qwidget.rekordbox_selected_playlists_lineedit.setText(
+            self.config.cparser.value("rekordbox/selected_playlists", defaultValue="")
+        )
+
+    def save_settingsui(self, qwidget: "QWidget"):
+        """Save UI values to configuration"""
+        self.config.cparser.setValue(
+            "rekordbox/custom_key", qwidget.rekordbox_custom_key_lineedit.text()
+        )
+
+        scope = (
+            "selected_playlists"
+            if qwidget.rekordbox_artist_scope_combo.currentText() == "Selected Playlists"
+            else "entire_library"
+        )
+        self.config.cparser.setValue("rekordbox/artist_query_scope", scope)
+
+        self.config.cparser.setValue(
+            "rekordbox/selected_playlists", qwidget.rekordbox_selected_playlists_lineedit.text()
+        )
+
+    def verify_settingsui(self, qwidget: "QWidget"):
+        """Verify configuration settings"""
+
+    def desc_settingsui(self, qwidget: "QWidget"):
+        """Provide plugin description"""
+        qwidget.setText(
+            "Rekordbox plugin reads track data from Rekordbox 6 or 7 play history. "
+            "Rekordbox 6: database key is read automatically. "
+            "Rekordbox 7: enter the 64-character database key above. Search: "
+            '"what is the rekordbox 7 sqlcipher key for master.db". '
+            "Requires Performance Mode."
+        )
+
+    def _fs_event(self, event):
+        """File system event handler - called from watchdog thread"""
+        logging.debug("Rekordbox FS event: %s", event.src_path)
+        with self._wal_timer_lock:
+            if self._wal_timer is not None:
+                self._wal_timer.cancel()
+            self._wal_timer = threading.Timer(_WAL_DEBOUNCE_SECONDS, self._wal_timer_fired)
+            self._wal_timer.daemon = True
+            self._wal_timer.start()
+
+    def _wal_timer_fired(self) -> None:
+        """Called after debounce silence; clears the timer reference and flags a refresh."""
+        with self._wal_timer_lock:
+            self._wal_timer = None
+        self._needs_refresh = True
+
+    async def start(self, testmode: bool = False):  # pylint: disable=unused-argument
+        """Initialize and start the plugin"""
+        logging.info("Starting Rekordbox plugin")
+
+        try:
+            custom_key = self.config.cparser.value("rekordbox/custom_key", defaultValue="")
+            await self.database_reader.initialize(custom_key=custom_key)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logging.error("Failed to initialize Rekordbox database reader: %s", err)
+            raise
+
+        db_dir = str(self.database_reader.database_path.parent)
+        logging.info("Watching for Rekordbox database changes in %s", db_dir)
+
+        self.event_handler = PatternMatchingEventHandler(
+            patterns=["*.db", "*.db-wal", "*.db-journal"],
+            ignore_patterns=[".DS_Store"],
+            ignore_directories=True,
+        )
+        self.event_handler.on_modified = self._fs_event
+        self.event_handler.on_created = self._fs_event
+
+        if self.config.cparser.value("quirks/pollingobserver", type=bool):
+            polling_interval = self.config.cparser.value("quirks/pollinginterval", type=float)
+            self.observer = PollingObserver(timeout=polling_interval)
+        else:
+            self.observer = Observer()
+
+        self.observer.schedule(self.event_handler, db_dir, recursive=False)
+        self.observer.start()
+        self._running = True
+        self._needs_refresh = True
+
+        logging.info("Rekordbox plugin started successfully")
+
+    async def stop(self):
+        """Stop the plugin and cleanup"""
+        logging.info("Stopping Rekordbox plugin")
+        self._running = False
+
+        with self._wal_timer_lock:
+            if self._wal_timer is not None:
+                self._wal_timer.cancel()
+                self._wal_timer = None
+
+        if self.observer:
+            self.observer.stop()
+            await asyncio.to_thread(self.observer.join)
+            self.observer = None
+        self.event_handler = None
+
+    def _check_wal_mtime(self) -> bool:
+        """Return True if master.db-wal has been modified since last check."""
+        if not self.database_reader.database_path:
+            return False
+        wal_path = self.database_reader.database_path.with_suffix(".db-wal")
+        try:
+            mtime = wal_path.stat().st_mtime
+        except OSError:
+            return False
+        if mtime != self._last_wal_mtime:
+            self._last_wal_mtime = mtime
+            return True
+        return False
+
+    async def getplayingtrack(self) -> dict:
+        """Get the currently playing track metadata"""
+        if self._check_wal_mtime():
+            self._needs_refresh = True
+        if self._needs_refresh:
+            try:
+                track = await asyncio.to_thread(self.database_reader.get_recent_track_sync)
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                logging.error("Rekordbox database query failed: %s", err)
+                return self._current_track or {}
+            logging.debug(
+                "Rekordbox query returned: %s",
+                "%s - %s" % (track.artist, track.title) if track else None,
+            )
+            if self.database_reader.has_track_changed(track):
+                self._current_track = track.to_metadata() if track else None
+                if track:
+                    logging.debug("Rekordbox track changed: %s - %s", track.artist, track.title)
+            self._needs_refresh = False
+        return self._current_track or {}
+
+    async def getrandomtrack(self, playlist: str) -> str | None:
+        """Get random track from playlist"""
+        try:
+            track = await self.database_reader.get_random_track_from_playlist(playlist)
+            if track and track.artist and track.title:
+                return f"{track.artist} - {track.title}"
+            return None
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logging.error("Failed to get random track from playlist %s: %s", playlist, err)
+            return None
+
+    def validmixmodes(self) -> list[str]:
+        """Valid mix modes - Rekordbox only shows latest track"""
+        return ["newest"]
+
+    def setmixmode(self, mixmode: str) -> str:  # pylint: disable=unused-argument
+        """Set mix mode - only newest is supported"""
+        return "newest"
+
+    def getmixmode(self) -> str:
+        """Get current mix mode"""
+        return "newest"
+
+    async def has_tracks_by_artist(self, artist_name: str) -> bool:
+        """Check if DJ has any tracks by the specified artist"""
+        scope = self.config.cparser.value(
+            "rekordbox/artist_query_scope", defaultValue="entire_library"
+        )
+        try:
+            if scope == "selected_playlists":
+                return await self._check_artist_in_playlists(artist_name)
+            return await self.database_reader.has_artist_in_library(artist_name)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logging.error("Failed to query Rekordbox for artist %s: %s", artist_name, err)
+            return False
+
+    async def _check_artist_in_playlists(self, artist_name: str) -> bool:
+        """Check if artist exists in any of the selected playlists"""
+        selected = self.config.cparser.value("rekordbox/selected_playlists", defaultValue="")
+        playlist_names = [n.strip() for n in selected.split(",") if n.strip()]
+        if not playlist_names:
+            return False
+        for playlist_name in playlist_names:
+            if await self.database_reader.has_artist_in_playlist(artist_name, playlist_name):
+                return True
+        return False

--- a/nowplaying/rekordbox/types.py
+++ b/nowplaying/rekordbox/types.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Rekordbox Type Definitions
+
+This module contains type definitions and data structures used throughout
+the Rekordbox plugin implementation.
+"""
+
+import pathlib
+from dataclasses import dataclass
+
+from nowplaying.types import TrackMetadata
+
+
+class RekordboxError(Exception):
+    """Base exception for Rekordbox-related errors"""
+
+
+@dataclass
+class RekordboxTrack:  # pylint: disable=too-many-instance-attributes
+    """Track data structure from Rekordbox database"""
+
+    identifier: str
+    title: str | None
+    artist: str | None
+    album: str | None
+    genre: str | None
+    bpm: float | None
+    duration: int | None
+    track_no: int | None
+    disc_no: int | None
+    year: int | None
+    bitrate: int | None
+    bit_depth: int | None
+    sample_rate: int | None
+    file_name: str | None
+    folder_path: str | None
+    image_path: str | None
+    rating: int | None
+    play_count: int | None
+    comments: str | None
+    key: str | None
+    label: str | None
+    composer: str | None
+    lyricist: str | None
+    isrc: str | None
+    file_size: int | None
+    file_type: int | None
+
+    def to_metadata(self) -> TrackMetadata:  # pylint: disable=too-many-branches
+        """Convert to standard metadata format"""
+        metadata: TrackMetadata = {}
+
+        # Basic track information
+        if self.title:
+            metadata["title"] = self.title
+        if self.artist:
+            metadata["artist"] = self.artist
+        if self.album:
+            metadata["album"] = self.album
+        if self.genre:
+            metadata["genre"] = self.genre
+        if self.year:
+            metadata["year"] = str(self.year)
+        if self.duration:
+            metadata["duration"] = self.duration
+
+        # Track/disc numbers
+        if self.track_no:
+            metadata["track"] = str(self.track_no)
+        if self.disc_no:
+            metadata["disc"] = str(self.disc_no)
+
+        # Musical metadata
+        if self.bpm:
+            metadata["bpm"] = f"{self.bpm:g}"
+        if self.key:
+            metadata["key"] = self.key
+        if self.label:
+            metadata["label"] = self.label
+        if self.composer:
+            metadata["composer"] = self.composer
+        if self.lyricist:
+            metadata["lyricist"] = self.lyricist
+
+        # Technical metadata
+        if self.folder_path and self.file_name:
+            metadata["filename"] = str(pathlib.Path(self.folder_path) / self.file_name)
+        elif self.file_name:
+            metadata["filename"] = self.file_name
+        if self.bitrate:
+            metadata["bitrate"] = str(self.bitrate)
+
+        # Comments
+        if self.comments:
+            metadata["comments"] = self.comments
+
+        # ISRC
+        if self.isrc:
+            metadata["isrc"] = [self.isrc]
+
+        # Cover image
+        if self.image_path:
+            if cover_data := self._load_cover_image():
+                metadata["coverimageraw"] = cover_data
+
+        return metadata
+
+    def _load_cover_image(self) -> bytes | None:
+        """Load cover image data if available"""
+        if not self.image_path:
+            return None
+        try:
+            with open(self.image_path, "rb") as fhin:
+                return fhin.read()
+        except (OSError, IOError):
+            return None

--- a/nowplaying/resources/ui/inputs_rekordbox.ui
+++ b/nowplaying/resources/ui/inputs_rekordbox.ui
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>inputs_rekordbox_ui</class>
+ <widget class="QWidget" name="inputs_rekordbox_ui">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Rekordbox</string>
+  </property>
+  <widget class="QLabel" name="custom_key_label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>14</y>
+     <width>120</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Custom Key:</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="rekordbox_custom_key_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>150</x>
+     <y>10</y>
+     <width>460</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <property name="echoMode">
+    <enum>QLineEdit::Password</enum>
+   </property>
+   <property name="placeholderText">
+    <string>Leave blank for automatic detection</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="artist_scope_label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>50</y>
+     <width>120</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Artist Query Scope:</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="rekordbox_artist_scope_combo">
+   <property name="geometry">
+    <rect>
+     <x>150</x>
+     <y>46</y>
+     <width>160</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <item>
+    <property name="text">
+     <string>Entire Library</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Selected Playlists</string>
+    </property>
+   </item>
+  </widget>
+  <widget class="QLabel" name="selected_playlists_label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>90</y>
+     <width>120</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Selected Playlists:</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="rekordbox_selected_playlists_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>150</x>
+     <y>86</y>
+     <width>460</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <property name="placeholderText">
+    <string>Comma-separated playlist names (e.g., House Classics, Tech House, Deep House)</string>
+   </property>
+  </widget>
+  <widget class="QTextBrowser" name="rekordbox_info_text">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>126</y>
+     <width>600</width>
+     <height>334</height>
+    </rect>
+   </property>
+   <property name="html">
+    <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta charset=&quot;utf-8&quot;/&gt;&lt;/head&gt;&lt;body&gt;
+&lt;p&gt;Reads track data from &lt;b&gt;Rekordbox 6 or 7&lt;/b&gt;. Rekordbox must be running in &lt;b&gt;Performance Mode&lt;/b&gt; with track history enabled.&lt;/p&gt;
+&lt;p&gt;To reduce the delay before a track appears, lower &lt;b&gt;Playback Time Setting&lt;/b&gt; in Rekordbox under &lt;b&gt;Preferences &amp;gt; Advanced &amp;gt; Browse&lt;/b&gt;. The default is 1 minute; 30 seconds is a common DJ setting.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Artist Query Scope&lt;/b&gt; controls where the plugin searches when checking if an artist is in your library (used by Guess Game and similar features).&lt;/p&gt;
+&lt;p&gt;Leave &lt;b&gt;Custom Key&lt;/b&gt; blank unless auto-detection fails.&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -19,6 +19,7 @@ psutil==7.2.2
 puremagic<2; python_version < "3.12"
 puremagic==2.2.0; python_version >= "3.12"
 pyacoustid==1.3.1
+pycryptodome==3.23.0
 pypresence==4.6.1
 # 6.5.0-6.5.3's rcc is broken on macOS; 6.5+ required for Qt.ColorScheme / colorSchemeChanged
 # 6.11.1 ships unsigned .cpp.o build artifacts in qml/Qt/labs/assetdownloader/ that break
@@ -28,6 +29,7 @@ rapidfuzz==3.14.5
 requests-cache==1.3.2
 requests==2.34.2
 simpleobsws==1.4.3
+sqlcipher3-wheels==0.5.5
 truststore==0.10.4
 tufup==0.10.0
 twitchAPI==4.5.0

--- a/tests/test_rekordbox.py
+++ b/tests/test_rekordbox.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""Test Rekordbox plugin"""
+# pylint: disable=protected-access
+
+import pathlib
+import unittest.mock
+
+import pytest
+import pytest_asyncio
+
+import nowplaying.rekordbox.config
+import nowplaying.rekordbox.database
+import nowplaying.rekordbox.plugin
+import nowplaying.rekordbox.types
+
+
+class MockSqlCipher:
+    """Mock sqlcipher3 for testing"""
+
+    def __init__(self, mock_data=None):
+        self.mock_data = mock_data or {}
+        self.executed_queries = []
+        self.executed_pragmas = []
+
+    def connect(self, db_path):
+        return MockConnection(self)
+
+    class dbapi2:
+        class OperationalError(Exception):
+            pass
+
+
+class MockConnection:
+    """Mock database connection"""
+
+    def __init__(self, sqlcipher):
+        self.sqlcipher = sqlcipher
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def execute(self, query, params=None):
+        if query.startswith("PRAGMA"):
+            self.sqlcipher.executed_pragmas.append(query)
+            return MockCursor([])
+
+        self.sqlcipher.executed_queries.append((query, params))
+
+        if "djmdSongHistory" in query and "ORDER BY h.created_at DESC" in query:
+            if "history_data" in self.sqlcipher.mock_data:
+                return MockCursor(
+                    [
+                        (
+                            "hist123",
+                            "Test Song",
+                            "Test Artist",
+                            "Test Album",
+                            "Electronic",
+                            12800,
+                            240,
+                            1,
+                            1,
+                            2023,
+                            320,
+                            16,
+                            44100,
+                            "test.mp3",
+                            "/path/to/file",
+                            "image.jpg",
+                            5,
+                            3,
+                            "Great track",
+                            "Cm",
+                            "Test Label",
+                            "Test Composer",
+                            "Test Lyricist",
+                            "ISRC123",
+                            5000000,
+                            1,
+                        )
+                    ]
+                )
+        elif "djmdPlaylist" in query and "WHERE Name IS NOT NULL" in query:
+            if "playlist_data" in self.sqlcipher.mock_data:
+                return MockCursor([("playlist1", "House Music"), ("playlist2", "Techno Classics")])
+        elif "djmdSongPlaylist" in query and "ORDER BY RANDOM()" in query:
+            if params and params[0] in ["House Music", "Techno Classics"]:
+                return MockCursor(
+                    [
+                        (
+                            "content456",
+                            "Random Song",
+                            "Random Artist",
+                            "Random Album",
+                            "House",
+                            12600,
+                            300,
+                            2,
+                            1,
+                            2022,
+                            256,
+                            16,
+                            44100,
+                            "random.mp3",
+                            "/path/random",
+                            "random.jpg",
+                            4,
+                            1,
+                            "Random comment",
+                            "Am",
+                            "Random Label",
+                            "Random Composer",
+                            None,
+                            "ISRC456",
+                            4500000,
+                            1,
+                        )
+                    ]
+                )
+
+        return MockCursor([])
+
+    def close(self):
+        self.closed = True
+
+
+class MockCursor:
+    """Mock database cursor"""
+
+    def __init__(self, data):
+        self.data = data
+        self.description = None
+
+    def fetchone(self):
+        return self.data[0] if self.data else None
+
+    def fetchall(self):
+        return self.data
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rekordbox_bootstrap(bootstrap):
+    """Bootstrap test with Rekordbox configuration"""
+    config = bootstrap
+    config.cparser.sync()
+    yield config
+
+
+@pytest.fixture
+def mock_sqlcipher():
+    """Empty MockSqlCipher instance"""
+    return MockSqlCipher()
+
+
+@pytest.fixture
+def mock_database_path(tmp_path):
+    """Temporary database file"""
+    db_path = tmp_path / "test_master.db"
+    db_path.touch()
+    return db_path
+
+
+@pytest_asyncio.fixture
+async def rekordbox_plugin(rekordbox_bootstrap, mock_database_path):
+    """Rekordbox plugin with mocked DB path"""
+    config = rekordbox_bootstrap
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config.ConfigReader.get_database_path",
+        return_value=mock_database_path,
+    ):
+        plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=config)
+        yield plugin
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_data_path_macos():
+    config = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch("os.name", "posix"):
+        path = config.get_data_path()
+    assert "Library/Pioneer/rekordbox" in str(path)
+
+
+def test_config_known_password_is_valid_hex():
+    config = nowplaying.rekordbox.config.ConfigReader()
+    password = config.get_known_password()
+    assert len(password) == 64
+    assert all(c in "0123456789abcdef" for c in password)
+
+
+def test_config_get_password_rb7_fallback():
+    """get_password() returns valid RB7 key when options.json is missing"""
+    config = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config._get_options_path",
+        return_value=pathlib.Path("/nonexistent/options.json"),
+    ):
+        password = config.get_password()
+    assert len(password) == 64
+    assert all(c in "0123456789abcdef" for c in password)
+
+
+def test_config_get_password_rb7_from_options(tmp_path):
+    """get_password() returns RB7 key when options.json reports app_ver=7.x"""
+    options_file = tmp_path / "options.json"
+    options_file.write_text(
+        '{"options":[["db-path","/tmp/master.db"],["dp","ignored"],["app_ver","7.1.4"]]}'
+    )
+    config = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config._get_options_path",
+        return_value=options_file,
+    ):
+        password = config.get_password()
+    assert len(password) == 64
+    assert all(c in "0123456789abcdef" for c in password)
+
+
+def test_config_get_database_path_from_options(tmp_path):
+    """get_database_path() reads db-path from options.json when available"""
+    db_path = tmp_path / "master.db"
+    options_file = tmp_path / "options.json"
+    options_file.write_text(f'{{"options":[["db-path","{db_path}"],["app_ver","7.1.4"]]}}')
+    config = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config._get_options_path",
+        return_value=options_file,
+    ):
+        result = config.get_database_path()
+    assert result == db_path
+
+
+# ---------------------------------------------------------------------------
+# Types tests
+# ---------------------------------------------------------------------------
+
+
+def _make_track(**kwargs):
+    defaults = dict(
+        identifier="test123",
+        title="Test Song",
+        artist="Test Artist",
+        album="Test Album",
+        genre="Electronic",
+        bpm=128,
+        duration=240,
+        track_no=1,
+        disc_no=1,
+        year=2023,
+        bitrate=320,
+        bit_depth=16,
+        sample_rate=44100,
+        file_name="test.mp3",
+        folder_path="/test/path",
+        image_path=None,
+        rating=5,
+        play_count=10,
+        comments="Great track",
+        key="Cm",
+        label="Test Label",
+        composer="Test Composer",
+        lyricist="Test Lyricist",
+        isrc="ISRC123",
+        file_size=5000000,
+        file_type=1,
+    )
+    defaults.update(kwargs)
+    return nowplaying.rekordbox.types.RekordboxTrack(**defaults)
+
+
+def test_types_track_creation():
+    track = _make_track()
+    assert track.identifier == "test123"
+    assert track.title == "Test Song"
+    assert track.artist == "Test Artist"
+    assert track.bpm == 128
+    assert track.composer == "Test Composer"
+    assert track.lyricist == "Test Lyricist"
+
+
+def test_types_track_to_metadata():
+    track = _make_track()
+    metadata = track.to_metadata()
+
+    assert metadata["title"] == "Test Song"
+    assert metadata["artist"] == "Test Artist"
+    assert metadata["album"] == "Test Album"
+    assert metadata["genre"] == "Electronic"
+    assert metadata["year"] == "2023"
+    assert metadata["duration"] == 240
+    assert metadata["track"] == "1"
+    assert metadata["disc"] == "1"
+    assert metadata["bpm"] == "128"
+    assert metadata["key"] == "Cm"
+    assert metadata["label"] == "Test Label"
+    assert metadata["composer"] == "Test Composer"
+    assert metadata["lyricist"] == "Test Lyricist"
+    assert metadata["filename"] == "test.mp3"
+    assert metadata["bitrate"] == "320"
+    assert metadata["comments"] == "Great track"
+    assert metadata["isrc"] == ["ISRC123"]
+
+
+# ---------------------------------------------------------------------------
+# Database tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_database_initialization(mock_database_path):
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch.object(
+        config_reader, "get_database_path", return_value=mock_database_path
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+
+    assert reader.database_path == mock_database_path
+    assert reader.encryption_key is not None
+    assert len(reader.encryption_key) == 64
+
+
+@pytest.mark.asyncio
+async def test_database_get_recent_track_with_history(mock_database_path):
+    mock_sq = MockSqlCipher({"history_data": True})
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        track = await reader.get_recent_track()
+
+    assert track is not None
+    assert track.title == "Test Song"
+    assert track.artist == "Test Artist"
+    assert track.album == "Test Album"
+    assert track.bpm == 128.0
+    assert track.composer == "Test Composer"
+    assert track.lyricist == "Test Lyricist"
+
+    query_sql = mock_sq.executed_queries[0][0]
+    assert "FROM djmdSongHistory h" in query_sql
+    assert "JOIN djmdContent c ON h.ContentID = c.ID" in query_sql
+
+
+@pytest.mark.asyncio
+async def test_database_get_recent_track_no_history(mock_database_path):
+    mock_sq = MockSqlCipher()
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        track = await reader.get_recent_track()
+
+    assert track is None
+
+
+@pytest.mark.asyncio
+async def test_database_get_playlists(mock_database_path):
+    mock_sq = MockSqlCipher({"playlist_data": True})
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        playlists = await reader.get_playlists()
+
+    assert len(playlists) == 2
+    assert playlists[0] == ("playlist1", "House Music")
+    assert playlists[1] == ("playlist2", "Techno Classics")
+
+
+@pytest.mark.asyncio
+async def test_database_get_random_track_from_playlist(mock_database_path):
+    mock_sq = MockSqlCipher()
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        track = await reader.get_random_track_from_playlist("House Music")
+
+    assert track is not None
+    assert track.title == "Random Song"
+    assert track.artist == "Random Artist"
+    assert track.genre == "House"
+    assert track.bpm == 126.0
+
+    query_sql, params = mock_sq.executed_queries[0]
+    assert "FROM djmdSongPlaylist sp" in query_sql
+    assert "ORDER BY RANDOM()" in query_sql
+    assert params == ("House Music",)
+
+
+@pytest.mark.asyncio
+async def test_database_connection_failure(mock_database_path):
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    mock_sqlite = unittest.mock.Mock()
+    mock_sqlite.connect.side_effect = Exception("Connection failed")
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        with pytest.raises(nowplaying.rekordbox.types.RekordboxError):
+            await reader.get_recent_track()
+
+
+@pytest.mark.asyncio
+async def test_database_missing_file():
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    missing_path = pathlib.Path("/nonexistent/master.db")
+    with unittest.mock.patch.object(config_reader, "get_database_path", return_value=missing_path):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        with pytest.raises(nowplaying.rekordbox.types.RekordboxError, match="database not found"):
+            await reader.initialize()
+
+
+@pytest.mark.asyncio
+async def test_database_playlist_not_found(mock_database_path):
+    mock_sq = MockSqlCipher()
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        track = await reader.get_random_track_from_playlist("Nonexistent Playlist")
+
+    assert track is None
+
+
+# ---------------------------------------------------------------------------
+# Plugin tests
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_creation(rekordbox_bootstrap):
+    config = rekordbox_bootstrap
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=config)
+    assert plugin.displayname == "Rekordbox"
+    assert plugin.config_reader is not None
+    assert plugin.database_reader is not None
+    assert not plugin._running
+
+
+def test_plugin_defaults(rekordbox_plugin):
+    mock_settings = unittest.mock.Mock()
+    rekordbox_plugin.defaults(mock_settings)
+    mock_settings.setValue.assert_any_call("rekordbox/artist_query_scope", "entire_library")
+    mock_settings.setValue.assert_any_call("rekordbox/selected_playlists", "")
+
+
+def test_plugin_settings_ui_methods(rekordbox_plugin):
+    mock_widget = unittest.mock.Mock()
+    mock_widget.rekordbox_custom_key_lineedit.text.return_value = ""
+    mock_widget.rekordbox_artist_scope_combo.currentText.return_value = "Entire Library"
+    mock_widget.rekordbox_selected_playlists_lineedit.text.return_value = ""
+    mock_uihelp = unittest.mock.Mock()
+
+    rekordbox_plugin.connect_settingsui(mock_widget, mock_uihelp)
+    rekordbox_plugin.load_settingsui(mock_widget)
+    rekordbox_plugin.save_settingsui(mock_widget)
+    rekordbox_plugin.verify_settingsui(mock_widget)
+    rekordbox_plugin.desc_settingsui(mock_widget)
+
+    mock_widget.setText.assert_called_once()
+    call_args = mock_widget.setText.call_args[0][0]
+    assert "play history" in call_args
+    assert "1+ minutes" in call_args
+
+
+def test_plugin_mix_modes(rekordbox_plugin):
+    assert rekordbox_plugin.validmixmodes() == ["newest"]
+    assert rekordbox_plugin.getmixmode() == "newest"
+    assert rekordbox_plugin.setmixmode("oldest") == "newest"
+
+
+@pytest.mark.asyncio
+async def test_plugin_lifecycle(rekordbox_plugin, mock_sqlcipher):
+    with unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlcipher):
+        await rekordbox_plugin.start(testmode=True)
+        assert rekordbox_plugin._running
+        assert rekordbox_plugin.observer is not None
+
+        await rekordbox_plugin.stop()
+        assert not rekordbox_plugin._running
+
+
+@pytest.mark.asyncio
+async def test_plugin_get_playing_track(rekordbox_plugin, mock_sqlcipher):
+    with unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlcipher):
+        await rekordbox_plugin.start(testmode=True)
+
+        track = await rekordbox_plugin.database_reader.get_recent_track()
+        if track and rekordbox_plugin.database_reader.has_track_changed(track):
+            rekordbox_plugin._current_track = track.to_metadata()
+
+        metadata = await rekordbox_plugin.getplayingtrack()
+        assert isinstance(metadata, dict)
+        if metadata:
+            assert "title" in metadata
+            assert "artist" in metadata
+
+        await rekordbox_plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_plugin_get_random_track(rekordbox_plugin, mock_sqlcipher):
+    with unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlcipher):
+        await rekordbox_plugin.start(testmode=True)
+        random_track = await rekordbox_plugin.getrandomtrack("House Music")
+        assert random_track == "Random Artist - Random Song"
+        await rekordbox_plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_plugin_components_connected(mock_database_path):
+    """Plugin wires config_reader into database_reader at construction"""
+    mock_config = unittest.mock.Mock()
+    mock_config.cparser = unittest.mock.Mock()
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config.ConfigReader.get_database_path",
+        return_value=mock_database_path,
+    ):
+        plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=mock_config)
+
+    assert plugin.config_reader is not None
+    assert plugin.database_reader is not None
+    assert plugin.database_reader.config_reader is plugin.config_reader
+
+
+# ---------------------------------------------------------------------------
+# detect() / install() tests
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_detect_path_exists(rekordbox_bootstrap):
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=rekordbox_bootstrap)
+    mock_path = unittest.mock.Mock()
+    mock_path.exists.return_value = True
+    with unittest.mock.patch.object(plugin.config_reader, "get_data_path", return_value=mock_path):
+        assert plugin.detect() is True
+
+
+def test_plugin_detect_path_missing(rekordbox_bootstrap):
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=rekordbox_bootstrap)
+    mock_path = unittest.mock.Mock()
+    mock_path.exists.return_value = False
+    with unittest.mock.patch.object(plugin.config_reader, "get_data_path", return_value=mock_path):
+        assert plugin.detect() is False
+
+
+def test_plugin_detect_exception_returns_false(rekordbox_bootstrap):
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=rekordbox_bootstrap)
+    with unittest.mock.patch.object(
+        plugin.config_reader, "get_data_path", side_effect=OSError("no access")
+    ):
+        assert plugin.detect() is False
+
+
+def test_plugin_install_writes_config(rekordbox_bootstrap):
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=rekordbox_bootstrap)
+    with unittest.mock.patch.object(plugin, "detect", return_value=True):
+        result = plugin.install()
+    assert result is True
+    assert rekordbox_bootstrap.cparser.value("settings/input") == "rekordbox"
+
+
+def test_plugin_install_detect_fails(rekordbox_bootstrap):
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=rekordbox_bootstrap)
+    with unittest.mock.patch.object(plugin, "detect", return_value=False):
+        result = plugin.install()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end BPM scaling test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_database_bpm_scaling_end_to_end(mock_database_path):
+    """Raw DB BPM (stored ×100) is divided at construction and serialised without trailing zeros"""
+    mock_sq = MockSqlCipher({"history_data": True})  # mock returns raw bpm=12800
+    config_reader = nowplaying.rekordbox.config.ConfigReader()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
+    ):
+        reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
+        await reader.initialize()
+        track = await reader.get_recent_track()
+
+    assert track is not None
+    assert track.bpm == 128.0
+    assert track.to_metadata()["bpm"] == "128"


### PR DESCRIPTION
Adds a new input plugin for Pioneer Rekordbox 6 and 7.

- Reads play history from the encrypted SQLite master.db
- RB6: auto-detects database key from options.json (Blowfish-decrypted)
- RB7: user supplies 64-character key (no key embedded in source)
- Trailing-edge WAL debounce (5s timer) + master.db-wal mtime polling to reliably detect track changes despite macOS FSEvents not seeing SQLite WAL-mode mmap writes
- Wizard page for first-run key entry with search prompt
- asyncio.to_thread() + retry_sqlite_operation() for all DB access
- detect() / install() split for 2-PC setup wizard compatibility
- BPM stored as integer*100 in DB, divided on read
- Filename assembled from FolderPath + FileNameL via pathlib

## Summary by Sourcery

Introduce a full Rekordbox input integration, including configuration, encrypted database access, UI wiring, file watching, and tests, so NowPlaying can track and query Rekordbox 6/7 play history and playlists.

New Features:
- Add a Rekordbox input plugin that reads play history and metadata from the encrypted Rekordbox 6/7 master.db database.
- Provide playlist support, including listing playlists and selecting random tracks from a given playlist.
- Expose an artist library/playlist presence check for use in higher-level features.

Enhancements:
- Introduce a dedicated Rekordbox database reader, configuration reader, and typed track model for structured access to Rekordbox data.
- Add a first-run wizard page and settings UI integration for configuring Rekordbox, including custom key entry for Rekordbox 7.
- Add filesystem watching with WAL debounce logic to reliably detect track changes from the Rekordbox database.

Documentation:
- Document the Rekordbox master.db schema, key tables, relationships, and typical queries in a new schema reference file.

Tests:
- Add extensive unit and async tests covering Rekordbox configuration, database queries, BPM scaling, plugin lifecycle, playlist operations, and error handling.