### PR TITLE
fix: replace unreliable QSS palette() with translucent overlay

### DIFF
--- a/nowplaying/resources/ui/artistextras.ui
+++ b/nowplaying/resources/ui/artistextras.ui
@@ -72,7 +72,7 @@
       <bool>true</bool>
      </property>
      <property name="styleSheet">
-      <string notr="true">background-color: palette(alternate-base); border: 1px solid palette(mid); border-radius: 4px; padding: 6px;</string>
+      <string notr="true">background-color: rgba(128, 128, 128, 40); border: 1px solid rgba(128, 128, 128, 110); border-radius: 4px; padding: 6px;</string>
      </property>
     </widget>
    </item>

--- a/nowplaying/resources/ui/guessgame_1_about.ui
+++ b/nowplaying/resources/ui/guessgame_1_about.ui
@@ -47,7 +47,7 @@
       <bool>true</bool>
      </property>
      <property name="styleSheet">
-      <string notr="true">background-color: palette(alternate-base); border: 1px solid palette(mid); border-radius: 4px; padding: 6px;</string>
+      <string notr="true">background-color: rgba(128, 128, 128, 40); border: 1px solid rgba(128, 128, 128, 110); border-radius: 4px; padding: 6px;</string>
      </property>
     </widget>
    </item>

--- a/nowplaying/resources/ui/inputs_serato3_connection.ui
+++ b/nowplaying/resources/ui/inputs_serato3_connection.ui
@@ -75,7 +75,7 @@
          <bool>true</bool>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: palette(alternate-base); border: 1px solid palette(mid); border-radius: 4px; padding: 6px;</string>
+         <string notr="true">background-color: rgba(128, 128, 128, 40); border: 1px solid rgba(128, 128, 128, 110); border-radius: 4px; padding: 6px;</string>
         </property>
        </widget>
       </item>

--- a/nowplaying/resources/ui/inputs_serato3_library.ui
+++ b/nowplaying/resources/ui/inputs_serato3_library.ui
@@ -90,7 +90,7 @@
          <bool>true</bool>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: palette(alternate-base); border: 1px solid palette(mid); border-radius: 4px; padding: 6px;</string>
+         <string notr="true">background-color: rgba(128, 128, 128, 40); border: 1px solid rgba(128, 128, 128, 110); border-radius: 4px; padding: 6px;</string>
         </property>
        </widget>
       </item>
@@ -164,7 +164,7 @@
          <bool>true</bool>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: palette(alternate-base); border: 1px solid palette(mid); border-radius: 4px; padding: 6px;</string>
+         <string notr="true">background-color: rgba(128, 128, 128, 40); border: 1px solid rgba(128, 128, 128, 110); border-radius: 4px; padding: 6px;</string>
         </property>
        </widget>
       </item>

--- a/nowplaying/resources/ui/updates.ui
+++ b/nowplaying/resources/ui/updates.ui
@@ -204,7 +204,7 @@
 &lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="styleSheet">
-      <string notr="true">background-color: palette(alternate-base); border: 1px solid palette(mid); border-radius: 4px; padding: 6px;</string>
+      <string notr="true">background-color: rgba(128, 128, 128, 40); border: 1px solid rgba(128, 128, 128, 110); border-radius: 4px; padding: 6px;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
QSS 'palette(alternate-base)'/'palette(mid)' don't reliably track a live macOS dark-mode switch, leaving the callout boxes added in text correctly followed the palette to light/white), making the text unreadable in Dark mode. Use a theme-agnostic translucent gray overlay instead, which blends with whatever's actually behind it regardless of palette resolution.

## Summary by Sourcery

Ensure overlay styling in various UI forms is theme-agnostic and compatible with macOS dark-mode changes.

Bug Fixes:
- Fix callout box backgrounds that failed to update with macOS dark-mode switches, preventing unreadable light-on-light text.
- Replace QSS palette-based background colors with a translucent gray overlay so overlays blend correctly with underlying themes.