### PR TITLE
fix: retry failed input plugin start instead of spinning forever

### DIFF
--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -182,6 +182,8 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
                 await self.input.start()
             except Exception as error:  # pylint: disable=broad-except
                 logging.error("cannot start %s: %s", self.previousinput, error)
+                self.input = None
+                self.previousinput = None  # force input plugin restart on next iteration
                 return False
 
         await self._manage_earshot_plugin()

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -183,6 +183,8 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
                 await self.input.start()
             except Exception as error:  # pylint: disable=broad-except
                 logging.error("cannot start %s: %s", self.previousinput, error)
+                self.input = None
+                self.previousinput = None  # force input plugin restart on next iteration
                 return False
 
         await self._manage_earshot_plugin()

--- a/nowplaying/rekordbox/config.py
+++ b/nowplaying/rekordbox/config.py
@@ -104,27 +104,26 @@ class ConfigReader:
 
     @staticmethod
     def get_password() -> str:
-        """Return the database decryption password.
+        """Return the database decryption password, if one can be auto-detected.
 
-        For RB6 the password is Blowfish-encrypted in the 'dp' field of
-        options.json and decrypted here.  For RB7 no password is embedded;
-        the caller must supply one via the custom_key setting (ask an AI
-        assistant for the Rekordbox 7 database key).
+        The password is Blowfish-encrypted in the 'dp' field of
+        options.json.  This field is present on RB6 installs and also on
+        RB7 installs that were upgraded from RB6, but is not guaranteed
+        on a fresh RB7 install (Pioneer's own docs suggest RB7 has no
+        embedded key). Callers must independently validate any key this
+        returns actually opens the database before trusting it, and fall
+        back to the custom_key setting if it doesn't.
         """
         options_path = _get_options_path()
         if options_path.exists():
             try:
                 options = _parse_options_json(options_path)
-                app_ver = options.get("app_ver", "")
-                major = int(app_ver.split(".")[0]) if app_ver else 0
-
-                if major < 7:
-                    dp = options.get("dp", "")
-                    if dp:
-                        logging.debug("Decrypting RB6 password from options.json")
-                        return _decrypt_rb6_dp(dp)
+                dp = options.get("dp", "")
+                if dp:
+                    logging.debug("Decrypting database password from options.json")
+                    return _decrypt_rb6_dp(dp)
             except Exception:  # pylint: disable=broad-exception-caught
-                logging.exception("Could not extract RB6 password from options.json")
+                logging.exception("Could not extract database password from options.json")
 
         return ""
 

--- a/nowplaying/rekordbox/database.py
+++ b/nowplaying/rekordbox/database.py
@@ -73,15 +73,17 @@ class DatabaseReader:
         Raises:
             RekordboxError: If initialization fails
         """
+        no_key_error = RekordboxError(
+            "No database key configured. "
+            "Enter the Rekordbox 7 key in Settings → Input → Rekordbox. "
+            'Search: "what is the rekordbox 7 sqlcipher key for master.db"'
+        )
         try:
+            auto_detected = not custom_key
             self.encryption_key = custom_key or self.config_reader.get_password()
 
             if not self.encryption_key:
-                raise RekordboxError(
-                    "No database key configured. "
-                    "Enter the Rekordbox 7 key in Settings → Input → Rekordbox. "
-                    'Search: "what is the rekordbox 7 sqlcipher key for master.db"'
-                )
+                raise no_key_error
 
             # PRAGMA key cannot use parameterized queries (SQLCipher limitation).
             # Validate the key is a 64-character hex string before it reaches any SQL.
@@ -94,12 +96,44 @@ class DatabaseReader:
             if not self.database_path.exists():
                 raise RekordboxError(f"Rekordbox database not found: {self.database_path}")
 
+            try:
+                await asyncio.to_thread(self._validate_key_sync)
+            except RekordboxError as err:
+                self.encryption_key = None
+                if auto_detected:
+                    # Auto-detected key (e.g. a leftover RB6 'dp' field on an
+                    # upgraded install) didn't actually open the database -
+                    # this install needs a manually supplied key instead.
+                    raise no_key_error from err
+                raise
+
             logging.info("Successfully initialized Rekordbox database reader")
 
         except RekordboxError:
             raise
         except Exception as err:  # pylint: disable=broad-exception-caught
             raise RekordboxError(f"Failed to initialize database reader: {err}") from err
+
+    def _validate_key_sync(self) -> None:
+        """Confirm the configured key can actually decrypt the database.
+
+        PRAGMA key never fails on its own; SQLCipher only errors on the
+        first real query, so without this check a wrong key would surface
+        later as a confusing generic query failure instead of a clear,
+        actionable initialization error.
+        """
+
+        def _query() -> None:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                self._open_conn(conn)
+                conn.execute("SELECT count(*) FROM djmdContent").fetchone()
+
+        try:
+            nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            raise RekordboxError(
+                f"Database key is incorrect or database is unreadable: {err}"
+            ) from err
 
     def _open_conn(self, conn):
         """Apply standard SQLCipher pragmas to an open connection."""

--- a/tests/test_rekordbox.py
+++ b/tests/test_rekordbox.py
@@ -2,6 +2,7 @@
 """Test Rekordbox plugin"""
 # pylint: disable=protected-access,missing-function-docstring,redefined-outer-name
 
+import base64
 import json
 import pathlib
 import sys
@@ -10,6 +11,7 @@ from contextlib import asynccontextmanager
 
 import pytest
 import pytest_asyncio
+from Crypto.Cipher import Blowfish
 
 import nowplaying.rekordbox.config
 import nowplaying.rekordbox.database
@@ -17,6 +19,19 @@ import nowplaying.rekordbox.plugin
 import nowplaying.rekordbox.types
 
 _TEST_KEY = "0123456789abcdef" * 4  # valid 64-char hex key for tests
+
+
+def _make_dp_blob(plaintext: str) -> str:
+    """Encrypt plaintext the same way Rekordbox's options.json 'dp' field is
+    encrypted, so tests can exercise a real decrypt round-trip."""
+    magic = nowplaying.rekordbox.config._decode_secret(
+        nowplaying.rekordbox.config._RB6_MAGIC_BLOB
+    ).encode()
+    cipher = Blowfish.new(magic, Blowfish.MODE_ECB)
+    data = plaintext.encode("utf-8")
+    pad_len = 8 - (len(data) % 8)
+    padded = data + bytes([pad_len]) * pad_len
+    return base64.b64encode(cipher.encrypt(padded)).decode()
 
 
 class MockSqlCipher:  # pylint: disable=too-few-public-methods
@@ -238,8 +253,8 @@ def test_config_data_path_windows_fallback(monkeypatch):
     assert path.parts[-4:] == ("AppData", "Roaming", "Pioneer", "rekordbox")
 
 
-def test_config_get_password_rb7_fallback():
-    """get_password() returns empty string for RB7 (no embedded key)"""
+def test_config_get_password_missing_options_file():
+    """get_password() returns empty string when options.json doesn't exist"""
     config = nowplaying.rekordbox.config.ConfigReader()
     with unittest.mock.patch(
         "nowplaying.rekordbox.config._get_options_path",
@@ -249,8 +264,28 @@ def test_config_get_password_rb7_fallback():
     assert password == ""
 
 
-def test_config_get_password_rb7_from_options(tmp_path):
-    """get_password() returns empty string when options.json reports app_ver=7.x"""
+@pytest.mark.parametrize("app_ver", ["6.8.5", "7.1.4"])
+def test_config_get_password_decrypts_dp_regardless_of_version(tmp_path, app_ver):
+    """get_password() decrypts a valid 'dp' field regardless of app_ver.
+
+    RB6 and RB7 installs upgraded from RB6 both carry this field; only a
+    fresh RB7 install may lack it, which callers must handle separately
+    by validating the returned key actually opens the database.
+    """
+    options_file = tmp_path / "options.json"
+    options_file.write_text(
+        json.dumps({"options": [["dp", _make_dp_blob(_TEST_KEY)], ["app_ver", app_ver]]})
+    )
+    config = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config._get_options_path",
+        return_value=options_file,
+    ):
+        assert config.get_password() == _TEST_KEY
+
+
+def test_config_get_password_undecryptable_dp_returns_empty(tmp_path):
+    """get_password() gracefully returns empty string when 'dp' can't be decrypted"""
     options_file = tmp_path / "options.json"
     options_file.write_text(
         '{"options":[["db-path","/tmp/master.db"],["dp","ignored"],["app_ver","7.1.4"]]}'
@@ -359,8 +394,12 @@ def test_types_track_to_metadata():
 @pytest.mark.asyncio
 async def test_database_initialization(mock_database_path):
     config_reader = nowplaying.rekordbox.config.ConfigReader()
-    with unittest.mock.patch.object(
-        config_reader, "get_database_path", return_value=mock_database_path
+    mock_sq = MockSqlCipher()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
     ):
         reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
         await reader.initialize(custom_key=_TEST_KEY)
@@ -424,6 +463,8 @@ async def test_database_get_random_track_from_playlist(mock_database_path):
 
 @pytest.mark.asyncio
 async def test_database_connection_failure(mock_database_path):
+    """A connection failure during the key-validation query now surfaces from
+    initialize() itself rather than later from get_recent_track()."""
     config_reader = nowplaying.rekordbox.config.ConfigReader()
     mock_sqlite = unittest.mock.Mock()
     mock_sqlite.connect.side_effect = Exception("Connection failed")
@@ -434,9 +475,8 @@ async def test_database_connection_failure(mock_database_path):
         unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite),
     ):
         reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
-        await reader.initialize(custom_key=_TEST_KEY)
         with pytest.raises(nowplaying.rekordbox.types.RekordboxError):
-            await reader.get_recent_track()
+            await reader.initialize(custom_key=_TEST_KEY)
 
 
 @pytest.mark.asyncio
@@ -567,6 +607,20 @@ async def test_plugin_get_random_track(rekordbox_plugin, mock_sqlcipher):
         random_track = await rekordbox_plugin.getrandomtrack("House Music")
         assert random_track == "Random Artist - Random Song"
         await rekordbox_plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_plugin_start_fails_when_key_does_not_validate(rekordbox_plugin):
+    """start() propagates a RekordboxError when the configured key can't
+    actually open the database, instead of silently reporting success."""
+    mock_sqlite = unittest.mock.Mock()
+    mock_sqlite.connect.side_effect = Exception("file is not a database")
+    with (
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite),
+        pytest.raises(nowplaying.rekordbox.types.RekordboxError),
+    ):
+        await rekordbox_plugin.start(testmode=True)
+    assert not rekordbox_plugin._running
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
switch_input_plugin() set self.previousinput before attempting start(), so when start() raised (caught locally, never reaching the outer recovery handler in run()), the next poll cycle saw previousinput == configured and skipped straight past the create-and-start block, believing the plugin was already running. Every subsequent poll then called getplayingtrack() on a plugin that never actually started, repeating the same error forever instead of retrying.

## Summary by Sourcery

Ensure failed input plugins can recover and detect invalid Rekordbox database credentials during startup.

Bug Fixes:
- Retry failed input plugin starts on subsequent polling cycles instead of repeatedly using an unstarted plugin.
- Validate Rekordbox database keys during initialization and provide actionable fallback errors when auto-detected keys are invalid.

Enhancements:
- Support decrypting Rekordbox database passwords from options.json for both RB6 and upgraded RB7 installations, regardless of reported application version.

Tests:
- Expand Rekordbox coverage for version-independent password detection, invalid keys, and initialization-time database validation.