### PR TITLE
denon: fix StagelinQ service parsing, leaks, discovery filter

### DIFF
--- a/nowplaying/denon/connection.py
+++ b/nowplaying/denon/connection.py
@@ -12,17 +12,26 @@ import logging
 import socket
 from collections.abc import Callable
 
+import netifaces
+
 import nowplaying.version  # pylint: disable=no-member,import-error,no-name-in-module
 
 from .protocol import StagelinqProtocol
 from .types import (
     DISCOVERY_PORT,
+    IGNORED_SOFTWARE_NAMES,
     MSG_REFERENCE,
     MSG_SERVICE_ANNOUNCEMENT,
+    MSG_SERVICES_REQUEST,
     DenonDevice,
     DenonService,
     DenonState,
 )
+
+
+def _is_ignored_device(device: DenonDevice) -> bool:
+    """True for non-player StagelinQ processes that never offer StateMap"""
+    return device.software_name in IGNORED_SOFTWARE_NAMES
 
 
 class ConnectionManager:
@@ -34,6 +43,8 @@ class ConnectionManager:
         self.state_service: DenonService | None = None
         self.connections: list[asyncio.StreamWriter] = []
         self.tasks: list[asyncio.Task] = []
+        self._main_writer: asyncio.StreamWriter | None = None
+        self._main_ref_task: asyncio.Task | None = None
 
     async def discover_devices(self, timeout: float) -> list[DenonDevice]:
         """Discover StagelinQ devices on the network"""
@@ -59,8 +70,16 @@ class ConnectionManager:
                         and device.token not in found_tokens
                         and device.token != self.manager.token
                     ):
-                        devices.append(device)
                         found_tokens.add(device.token)
+                        if _is_ignored_device(device):
+                            logging.debug(
+                                "Ignoring non-player StagelinQ service: %s (%s) at %s",
+                                device.name,
+                                device.software_name,
+                                addr[0],
+                            )
+                        else:
+                            devices.append(device)
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     logging.debug("Failed to parse discovery message from %s: %s", addr, err)
 
@@ -96,13 +115,10 @@ class ConnectionManager:
         """Connect to device and get available services"""
         reader, writer = await asyncio.open_connection(device.ipaddr, device.port)
 
+        # Start reference message task to keep the connection alive
+        ref_task = asyncio.create_task(self._send_reference_messages(writer, device.token))
+
         try:
-            self.connections.append(writer)
-
-            # Start reference message task
-            ref_task = asyncio.create_task(self._send_reference_messages(writer, device.token))
-            self.tasks.append(ref_task)
-
             # Send services request
             services_msg = StagelinqProtocol.create_services_request(self.token)
             writer.write(services_msg)
@@ -136,25 +152,68 @@ class ConnectionManager:
                         if service:
                             services.append(service)
 
+                    elif msg_id == MSG_SERVICES_REQUEST:
+                        # Devices are peers: they ask what services we offer.
+                        # Consume the device's token and keep reading; we
+                        # offer no services of our own.
+                        await reader.readexactly(16)
+
                     elif msg_id == MSG_REFERENCE:
                         # End of service list
                         await reader.readexactly(40)  # Skip reference message data
                         break
 
+                    else:
+                        # Unknown message: length is unknowable, so the rest
+                        # of the stream cannot be parsed safely
+                        logging.warning(
+                            "Unknown StagelinQ message id 0x%08x from %s; "
+                            "stopping service read with %d service(s)",
+                            msg_id,
+                            device.ipaddr,
+                            len(services),
+                        )
+                        break
+
                 except asyncio.IncompleteReadError:
                     break
 
+            # Hand the live connection and its keepalive to the manager;
+            # callers that decide not to use this device must call
+            # disconnect_main() to release them
+            self._main_writer = writer
+            self._main_ref_task = ref_task
+            self.connections.append(writer)
+            self.tasks.append(ref_task)
             return services
 
         except Exception:
-            # Ensure writer is closed on any failure
+            # Ensure keepalive is stopped and writer is closed on any failure
+            ref_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ref_task
             with contextlib.suppress(Exception):
                 writer.close()
                 await writer.wait_closed()
-            # Remove from connections list if it was added
-            if writer in self.connections:
-                self.connections.remove(writer)
             raise
+
+    async def disconnect_main(self) -> None:
+        """Close the main device connection and stop its keepalive task"""
+        if self._main_ref_task:
+            self._main_ref_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._main_ref_task
+            if self._main_ref_task in self.tasks:
+                self.tasks.remove(self._main_ref_task)
+            self._main_ref_task = None
+
+        if self._main_writer:
+            with contextlib.suppress(Exception):
+                self._main_writer.close()
+                await self._main_writer.wait_closed()
+            if self._main_writer in self.connections:
+                self.connections.remove(self._main_writer)
+            self._main_writer = None
 
     async def monitor_state_changes(  # pylint: disable=too-many-locals
         self,
@@ -189,11 +248,27 @@ class ConnectionManager:
                         f"/Engine/Deck{deck}/Track/Genre",
                         f"/Engine/Deck{deck}/Track/SongLoaded",
                         f"/Mixer/CH{deck}faderPosition",
+                        # Effective per-deck audibility: Denon mixers and
+                        # all-in-one controllers push fader x crossfader into
+                        # the deck's own StateMap; standalone players never
+                        # emit /Mixer/ states at all
+                        f"/Engine/Deck{deck}/ExternalMixerVolume",
+                        f"/Engine/Deck{deck}/DeckIsMaster",
                     ]
                 )
 
             # Also subscribe to crossfader position
             state_paths.append("/Mixer/CrossfaderPosition")
+
+            # Device-level states: DJ-assigned player number (deck identity
+            # across multiple players), deck count, and sync-master status
+            state_paths.extend(
+                [
+                    "/Client/Preferences/Player",
+                    "/Engine/DeckCount",
+                    "/Engine/Sync/Network/MasterStatus",
+                ]
+            )
 
             for state_path in state_paths:
                 sub_msg = StagelinqProtocol.create_state_subscription(state_path)
@@ -230,6 +305,21 @@ class ConnectionManager:
         except Exception as err:  # pylint: disable=broad-exception-caught
             logging.debug("Announcement error: %s", err)
 
+    @staticmethod
+    def _get_broadcast_addresses() -> list[str]:
+        """Get broadcast addresses for all IPv4 interfaces plus the global broadcast"""
+        addresses = {"255.255.255.255"}
+        try:
+            # pylint: disable=no-member
+            for interface in netifaces.interfaces():
+                for addr_info in netifaces.ifaddresses(interface).get(netifaces.AF_INET, []):
+                    broadcast = addr_info.get("broadcast")
+                    if broadcast and not addr_info.get("addr", "").startswith("127."):
+                        addresses.add(broadcast)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Failed to enumerate interface broadcast addresses")
+        return sorted(addresses)
+
     async def _announce_self(self) -> None:
         """Send UDP announcement to let devices know about us"""
         try:
@@ -240,10 +330,14 @@ class ConnectionManager:
                 nowplaying.version.__VERSION__,  # pylint:disable=no-member
             )
 
-            # Send to broadcast address
+            # The global broadcast address only goes out the default-route
+            # interface, so also send to each interface's subnet broadcast
+            # to reach devices on non-default networks
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            sock.sendto(message, ("255.255.255.255", DISCOVERY_PORT))
+            for address in self._get_broadcast_addresses():
+                with contextlib.suppress(OSError):
+                    sock.sendto(message, (address, DISCOVERY_PORT))
             sock.close()
 
         except Exception as err:  # pylint: disable=broad-exception-caught
@@ -286,3 +380,5 @@ class ConnectionManager:
         self.connections.clear()
         self.device = None
         self.state_service = None
+        self._main_writer = None
+        self._main_ref_task = None

--- a/nowplaying/denon/plugin.py
+++ b/nowplaying/denon/plugin.py
@@ -198,7 +198,7 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                                 return
 
                     # No devices found or connection failed, wait before trying again
-                    logging.debug("No devices found, retrying in 10 seconds...")
+                    logging.debug("No usable devices found, retrying in 10 seconds...")
                     await asyncio.sleep(10.0)
 
                 except Exception as err:  # pylint: disable=broad-exception-caught
@@ -229,7 +229,9 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     "StateMap service not available on device (found %d other services)",
                     len(services),
                 )
-                # Connection manager will handle cleanup
+                # Release the connection and its keepalive task; otherwise
+                # every failed attempt leaks a socket and a 250ms timer
+                await self.connection_manager.disconnect_main()
                 return False
 
             # Successfully connected

--- a/nowplaying/denon/types.py
+++ b/nowplaying/denon/types.py
@@ -19,6 +19,11 @@ MSG_SERVICE_ANNOUNCEMENT = 0x00000000
 MSG_REFERENCE = 0x00000001
 MSG_SERVICES_REQUEST = 0x00000002
 
+# Non-player StagelinQ processes that announce themselves on the network
+# but never offer the StateMap service (Engine OS runs several of these
+# alongside the actual player software)
+IGNORED_SOFTWARE_NAMES = {"OfflineAnalyzer", "SoundSwitchEmbedded"}
+
 # State message magic bytes
 STATE_SUBSCRIBE_MAGIC = b"\x00\x00\x07\xd2"
 STATE_EMIT_MAGIC = b"\x00\x00\x00\x00"

--- a/tests/test_denon.py
+++ b/tests/test_denon.py
@@ -2,11 +2,16 @@
 """Tests for Denon DJ StagelinQ input plugin"""
 # pylint: disable=protected-access,redefined-outer-name
 
+import asyncio
+import struct
+
 import pytest
 
 import nowplaying.inputs.denon
 from nowplaying.denon import StagelinqError
+from nowplaying.denon.connection import ConnectionManager, _is_ignored_device
 from nowplaying.denon.protocol import StagelinqProtocol
+from nowplaying.denon.types import MSG_SERVICES_REQUEST, DenonDevice, DenonService
 
 
 @pytest.fixture
@@ -432,3 +437,201 @@ async def test_load_save_deckskip_settings(denon_plugin):
     assert not widget2.denon_deck2_skip_checkbox.isChecked()
     assert widget2.denon_deck3_skip_checkbox.isChecked()
     assert not widget2.denon_deck4_skip_checkbox.isChecked()
+
+
+class FakeStreamWriter:
+    """Minimal StreamWriter stand-in for connection tests"""
+
+    def __init__(self):
+        self.written = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        """collect written bytes"""
+        self.written += data
+
+    async def drain(self) -> None:
+        """no-op"""
+
+    def close(self) -> None:
+        """mark closed"""
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        """no-op"""
+
+    @staticmethod
+    def get_extra_info(_name: str) -> tuple[str, int]:
+        """fake socket address info"""
+        return ("127.0.0.1", 12345)
+
+
+def _make_test_device(token: bytes, software_name: str = "JP14") -> DenonDevice:
+    """Build a DenonDevice for connection tests"""
+    return DenonDevice(
+        ipaddr="127.0.0.1",
+        port=50010,
+        name="sc6000m",
+        software_name=software_name,
+        software_version="3.4.0",
+        token=token,
+    )
+
+
+def _patch_open_connection(monkeypatch, reader, writer):
+    """Patch asyncio.open_connection to return the given fake streams"""
+
+    async def fake_open_connection(_host, _port):
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_connection", fake_open_connection)
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_handles_device_services_request(monkeypatch):
+    """Test service reading survives the device sending its own ServicesRequest first"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    reader = asyncio.StreamReader()
+    # Device asks what services we offer before announcing its own
+    reader.feed_data(struct.pack(">I", MSG_SERVICES_REQUEST) + device_token)
+    reader.feed_data(StagelinqProtocol.create_service_announcement(device_token, "StateMap", 42))
+    reader.feed_data(StagelinqProtocol.create_reference_message(device_token, our_token))
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    services = await manager.connect_to_device(device)
+
+    assert [(service.name, service.port) for service in services] == [("StateMap", 42)]
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_unknown_message_stops_cleanly(monkeypatch):
+    """Test an unknown message id stops parsing without discarding found services"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(StagelinqProtocol.create_service_announcement(device_token, "StateMap", 42))
+    # Unknown message id: cannot be skipped safely, must stop parsing
+    reader.feed_data(struct.pack(">I", 0xDEADBEEF))
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    services = await manager.connect_to_device(device)
+
+    assert [(service.name, service.port) for service in services] == [("StateMap", 42)]
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_main_releases_connection(monkeypatch):
+    """Test disconnect_main cancels the keepalive task and closes the writer"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(StagelinqProtocol.create_reference_message(device_token, our_token))
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    await manager.connect_to_device(device)
+    assert manager.connections == [writer]
+    assert len(manager.tasks) == 1
+
+    await manager.disconnect_main()
+
+    assert writer.closed
+    assert not manager.connections
+    assert not manager.tasks
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_failure_stops_keepalive(monkeypatch):
+    """Test handshake failure cancels the keepalive task and closes the writer"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    class FailingWriter(FakeStreamWriter):
+        """Writer whose drain fails, aborting the handshake"""
+
+        async def drain(self) -> None:
+            raise OSError("handshake failure")
+
+    reader = asyncio.StreamReader()
+    writer = FailingWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    with pytest.raises(OSError):
+        await manager.connect_to_device(device)
+
+    assert writer.closed
+    assert not manager.connections
+    assert not manager.tasks
+    # The keepalive task must be fully finished before the exception
+    # propagates, not left pending in the event loop
+    leftover = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
+    assert not leftover
+
+
+@pytest.mark.asyncio
+async def test_monitor_subscribes_expected_states(monkeypatch):
+    """Test StateMap subscriptions include audibility and device-identity states"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+    service = DenonService(name="StateMap", port=50011)
+
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    await manager.monitor_state_changes(device, service, lambda state: None)
+
+    for state_path in [
+        "/Engine/Deck1/Track/ArtistName",
+        "/Engine/Deck4/ExternalMixerVolume",
+        "/Engine/Deck1/DeckIsMaster",
+        "/Client/Preferences/Player",
+        "/Engine/DeckCount",
+        "/Engine/Sync/Network/MasterStatus",
+        "/Mixer/CrossfaderPosition",
+    ]:
+        assert state_path.encode("utf-16be") in writer.written
+
+    await manager.cleanup()
+
+
+@pytest.mark.parametrize(
+    "software_name,expected",
+    [
+        ("JP14", False),
+        ("OfflineAnalyzer", True),
+        ("SoundSwitchEmbedded", True),
+    ],
+)
+def test_is_ignored_device(software_name, expected):
+    """Test non-player StagelinQ processes are filtered from discovery"""
+    token = StagelinqProtocol.generate_token()
+    device = _make_test_device(token, software_name=software_name)
+    assert _is_ignored_device(device) is expected
+
+
+def test_get_broadcast_addresses():
+    """Test broadcast address enumeration always includes the global broadcast"""
+    addresses = ConnectionManager._get_broadcast_addresses()
+    assert "255.255.255.255" in addresses
+    for address in addresses:
+        assert not address.startswith("127.")

--- a/tests/test_denon.py
+++ b/tests/test_denon.py
@@ -572,6 +572,8 @@ async def test_connect_to_device_failure_stops_keepalive(monkeypatch):
     writer = FailingWriter()
     _patch_open_connection(monkeypatch, reader, writer)
 
+    pre_tasks = set(asyncio.all_tasks())
+
     with pytest.raises(OSError):
         await manager.connect_to_device(device)
 
@@ -579,8 +581,9 @@ async def test_connect_to_device_failure_stops_keepalive(monkeypatch):
     assert not manager.connections
     assert not manager.tasks
     # The keepalive task must be fully finished before the exception
-    # propagates, not left pending in the event loop
-    leftover = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
+    # propagates, not left pending in the event loop; compare against a
+    # pre-call snapshot so unrelated runner tasks cannot flake this
+    leftover = [task for task in asyncio.all_tasks() - pre_tasks if not task.done()]
     assert not leftover
 
 


### PR DESCRIPTION
Fixes for SC6000M standalone setups that always saw "0 services":

* Handle the device sending its own ServicesRequest on the main connection (StagelinQ peers ask what services we offer); the old read loop treated it as unknown and misparsed the rest of the stream, discarding all service announcements. Unknown message ids now log loudly and stop parsing instead of silently misaligning.
* Release the main connection and its 250ms keepalive task when a device offers no StateMap; previously every failed attempt leaked a socket and a timer ("Reference message error" spam). On handshake failure the keepalive cancellation is awaited so no pending task is left behind in the event loop.
* Filter non-player StagelinQ processes (OfflineAnalyzer, SoundSwitchEmbedded) out of discovery; they never offer StateMap.
* Broadcast our announcements to every interface's subnet broadcast address in addition to 255.255.255.255, which only leaves via the default-route interface; devices drop TCP connections from peers whose announcements they have never seen.

Also subscribe to additional StateMap states (log-only, values land unused in the state store), informed by protocol research across the reference implementations:

* /Engine/Deck{n}/ExternalMixerVolume - effective per-deck audibility; Denon mixers (X1800/X1850) and all-in-one controllers push fader x crossfader into the deck's own StateMap. Standalone players never emit /Mixer/ states, so this is the correct audibility source for separates setups.
* /Engine/Deck{n}/DeckIsMaster and /Engine/Sync/Network/MasterStatus - sync-master signals, candidate audibility heuristics for rigs with analog mixers.
* /Client/Preferences/Player - the DJ-assigned 1-4 player number, needed to identify decks across multiple players.
* /Engine/DeckCount - decks per device.

No behavior change from the new subscriptions: they appear in the existing 'State update' debug logging, so a field-test build can answer what mixerless players actually emit (notably the initial ExternalMixerVolume value, undocumented in any reference source).

## Summary by Sourcery

Improve Denon StagelinQ connection robustness, service discovery, and state monitoring for standalone players and mixed setups.

Bug Fixes:
- Ensure service parsing tolerates incoming ServicesRequest messages and stops cleanly on unknown message IDs without losing discovered services.
- Prevent leaks of the main TCP connection and its keepalive task when handshakes fail or devices lack a StateMap service.
- Exclude non-player StagelinQ processes from discovery to avoid unusable devices blocking connection attempts.

Enhancements:
- Broadcast discovery announcements to all interface-specific IPv4 broadcast addresses in addition to the global broadcast, improving reachability on multi-network setups.
- Extend StateMap subscriptions to include deck audibility, player identity, deck count, and sync-master states for richer diagnostics and future features.

Tests:
- Add async tests covering connection handshake behavior, unknown message handling, keepalive cancellation, state subscription paths, discovery filtering, and broadcast address enumeration.