### PR TITLE
backport many changes to 5.2.x

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,6 +22,7 @@ env:
 jobs:
   testing-macos:
     runs-on: macos-latest
+    timeout-minutes: 50
     permissions:
       contents: read
     steps:
@@ -86,6 +87,7 @@ jobs:
 
   testing-win:
     runs-on: windows-2025
+    timeout-minutes: 50
     permissions:
       contents: read
     env:
@@ -147,6 +149,7 @@ jobs:
 
   testing-linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     permissions:
       contents: read
     strategy:

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """pytest fixtures"""
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -13,6 +14,7 @@ import unittest.mock
 
 import pytest
 import pytest_asyncio
+from aiointercept import aiointercept
 from PySide6.QtCore import (  # pylint: disable=import-error, no-name-in-module
     QCoreApplication,
     QSettings,
@@ -207,6 +209,37 @@ async def shared_api_cache():
         await _SHARED_CACHE_INSTANCE._initialize_db()  # pylint: disable=protected-access
 
     yield _SHARED_CACHE_INSTANCE
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def _shared_aiointercept():
+    """One aiointercept(mock_external_urls=True) instance for the whole session.
+
+    aiointercept starts a background thread with its own event loop per
+    instantiation. On Windows (ProactorEventLoop) repeated start/stop cycles
+    across many tests have been observed to hang the test run after a
+    handful of uses, regardless of what a given test mocks. Tests share this
+    one instance instead of creating a fresh one each time; use the
+    aiointercept_mock fixture for a per-test-cleared view of it.
+
+    passthrough_unmatched=True is required here: this instance's DNS patch
+    stays installed for the entire session (not just the tests that use it),
+    so without it, any host a given test didn't explicitly register — e.g.
+    the real webserver tests spin up and connect to — gets silently
+    redirected into this mock's own dummy server instead of the real network.
+    """
+    async with aiointercept(mock_external_urls=True, passthrough_unmatched=True) as mock:
+        yield mock
+
+
+@pytest_asyncio.fixture
+async def aiointercept_mock(_shared_aiointercept):  # pylint: disable=redefined-outer-name
+    """Function-scoped, auto-cleared view onto the shared aiointercept mock."""
+    _shared_aiointercept._caller_loop = asyncio.get_running_loop()  # pylint: disable=protected-access
+    try:
+        yield _shared_aiointercept
+    finally:
+        _shared_aiointercept.clear()
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -10,7 +10,7 @@ diskcache==5.6.3
 jinja2==3.1.6
 lxml==6.1.1
 netifaces-plus==0.12.5
-nltk==3.9.4
+nltk==3.10.0
 pillow==12.3.0
 pillow_avif_plugin==1.5.5
 psutil==7.2.2

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -1,6 +1,6 @@
 aiocache==0.12.3
 aiofiles==25.1.0
-aiohttp==3.14.1
+aiohttp==3.14.2
 aiosqlite==0.22.1
 chardet<8 # required by requests
 charset-normalizer==3.4.7

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -1,6 +1,6 @@
 aiocache==0.12.3
 aiofiles==25.1.0
-aiohttp==3.13.5
+aiohttp==3.14.1
 aiosqlite==0.22.1
 chardet<8 # required by requests
 charset-normalizer==3.4.7

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 #
 # tests
 #
-aioresponses==0.7.9
+aiointercept==0.1.9
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0

--- a/tests/kick/test_kick_chat.py
+++ b/tests/kick/test_kick_chat.py
@@ -7,7 +7,6 @@ import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aiointercept import aiointercept
 
 import nowplaying.kick.chat  # pylint: disable=no-name-in-module
 import nowplaying.kick.constants
@@ -67,7 +66,7 @@ async def test_kickchat_authenticate(bootstrap, refresh_succeeds, expected_resul
 
 
 @pytest.mark.asyncio
-async def test_kickchat_send_message_success(bootstrap):
+async def test_kickchat_send_message_success(bootstrap, aiointercept_mock):
     """Test successful message sending."""
     config = bootstrap
     stopevent = asyncio.Event()
@@ -81,16 +80,15 @@ async def test_kickchat_send_message_success(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock successful API response
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post(
-            "https://api.kick.com/public/v1/chat",
-            status=200,
-            payload={"data": {"is_sent": True}, "message": "OK"},
-        )
+    aiointercept_mock.post(
+        "https://api.kick.com/public/v1/chat",
+        status=200,
+        payload={"data": {"is_sent": True}, "message": "OK"},
+    )
 
-        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+    result = await chat._send_message("Test message")  # pylint: disable=protected-access
 
-        assert result is True
+    assert result is True
 
 
 @pytest.mark.asyncio
@@ -108,7 +106,7 @@ async def test_kickchat_send_message_not_authenticated(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_kickchat_send_message_api_error(bootstrap):
+async def test_kickchat_send_message_api_error(bootstrap, aiointercept_mock):
     """Test message sending with API error."""
     config = bootstrap
     stopevent = asyncio.Event()
@@ -122,20 +120,19 @@ async def test_kickchat_send_message_api_error(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock failed API response
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post(
-            "https://api.kick.com/public/v1/chat",
-            status=400,
-            payload={"message": "Invalid request"},
-        )
+    aiointercept_mock.post(
+        "https://api.kick.com/public/v1/chat",
+        status=400,
+        payload={"message": "Invalid request"},
+    )
 
-        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+    result = await chat._send_message("Test message")  # pylint: disable=protected-access
 
-        assert result is False
+    assert result is False
 
 
 @pytest.mark.asyncio
-async def test_kickchat_send_message_token_expired(bootstrap):
+async def test_kickchat_send_message_token_expired(bootstrap, aiointercept_mock):
     """Test message sending with expired token."""
     config = bootstrap
     stopevent = asyncio.Event()
@@ -149,15 +146,14 @@ async def test_kickchat_send_message_token_expired(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock 401 response (token expired)
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post(
-            "https://api.kick.com/public/v1/chat", status=401, payload={"message": "Unauthorized"}
-        )
+    aiointercept_mock.post(
+        "https://api.kick.com/public/v1/chat", status=401, payload={"message": "Unauthorized"}
+    )
 
-        result = await chat._send_message("Test message")  # pylint: disable=protected-access
+    result = await chat._send_message("Test message")  # pylint: disable=protected-access
 
-        assert result is False
-        assert not chat.authenticated
+    assert result is False
+    assert not chat.authenticated
 
 
 @pytest.mark.asyncio

--- a/tests/kick/test_kick_chat.py
+++ b/tests/kick/test_kick_chat.py
@@ -7,7 +7,7 @@ import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.kick.chat  # pylint: disable=no-name-in-module
 import nowplaying.kick.constants
@@ -81,7 +81,7 @@ async def test_kickchat_send_message_success(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock successful API response
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "https://api.kick.com/public/v1/chat",
             status=200,
@@ -122,7 +122,7 @@ async def test_kickchat_send_message_api_error(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock failed API response
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "https://api.kick.com/public/v1/chat",
             status=400,
@@ -149,7 +149,7 @@ async def test_kickchat_send_message_token_expired(bootstrap):
     chat.oauth = mock_oauth
 
     # Mock 401 response (token expired)
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "https://api.kick.com/public/v1/chat", status=401, payload={"message": "Unauthorized"}
         )

--- a/tests/kick/test_kick_integration.py
+++ b/tests/kick/test_kick_integration.py
@@ -6,8 +6,7 @@ import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import pytest_asyncio
-from aiointercept import aiointercept
+from utils_aiohttp import simulate_client_exception  # pylint: disable=import-error
 
 import nowplaying.kick.chat  # pylint: disable=import-error,no-name-in-module
 import nowplaying.kick.launch  # pylint: disable=import-error,no-name-in-module
@@ -62,29 +61,21 @@ def mock_chat_with_oauth(kick_integration_config):  # pylint: disable=redefined-
     return chat, stopevent
 
 
-@pytest_asyncio.fixture
-async def mock_aiohttp_success():
+@pytest.fixture
+def mock_aiohttp_success(aiointercept_mock):
     """Fixture that mocks successful aiohttp responses using aiointercept."""
-    async with aiointercept(mock_external_urls=True) as mock:
-        # Setup default success responses for common endpoints (repeat=True for multiple calls)
-        mock.post(
-            "https://api.kick.com/public/v1/chat",
-            status=200,
-            payload={"success": True},
-            repeat=True,
-        )
-        yield mock
-
-
-@pytest_asyncio.fixture
-async def mock_responses():
-    """Fixture that provides aiointercept for mocking HTTP calls."""
-    async with aiointercept(mock_external_urls=True) as mock:
-        yield mock
+    # Setup default success responses for common endpoints (repeat=True for multiple calls)
+    aiointercept_mock.post(
+        "https://api.kick.com/public/v1/chat",
+        status=200,
+        payload={"success": True},
+        repeat=True,
+    )
+    return aiointercept_mock
 
 
 @pytest.mark.asyncio
-async def test_full_authentication_flow(kick_integration_config, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_full_authentication_flow(kick_integration_config, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test complete OAuth2 authentication flow."""
     config = kick_integration_config
 
@@ -105,7 +96,7 @@ async def test_full_authentication_flow(kick_integration_config, mock_responses)
         "refresh_token": "test_refresh_token",
     }
 
-    mock_responses.post(f"{OAUTH_HOST}/oauth/token", status=200, payload=mock_token_response)
+    aiointercept_mock.post(f"{OAUTH_HOST}/oauth/token", status=200, payload=mock_token_response)
 
     result = await oauth.exchange_code_for_token("test_auth_code", oauth.state)
 
@@ -128,7 +119,7 @@ async def test_full_authentication_flow(kick_integration_config, mock_responses)
 
 
 @pytest.mark.asyncio
-async def test_chat_with_oauth_integration(mock_chat_with_oauth, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_chat_with_oauth_integration(mock_chat_with_oauth, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test chat integration with OAuth2."""
     chat, _ = mock_chat_with_oauth
 
@@ -144,7 +135,7 @@ async def test_chat_with_oauth_integration(mock_chat_with_oauth, mock_responses)
         assert chat.authenticated
 
     # Mock message sending endpoint
-    mock_responses.post(
+    aiointercept_mock.post(
         "https://api.kick.com/public/v1/chat",
         status=200,
         payload={"data": {"is_sent": True}, "message": "OK"},
@@ -195,7 +186,7 @@ def test_settings_integration_scenarios(kick_integration_config, settings_type):
 
 
 @pytest.mark.asyncio
-async def test_token_refresh_integration(kick_integration_config, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_token_refresh_integration(kick_integration_config, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test token refresh across components."""
     config = kick_integration_config
     config.cparser.setValue("kick/accesstoken", "expired_token")
@@ -209,7 +200,7 @@ async def test_token_refresh_integration(kick_integration_config, mock_responses
         "refresh_token": "new_refresh_token",
     }
 
-    mock_responses.post(f"{OAUTH_HOST}/oauth/token", status=200, payload=mock_refresh_response)
+    aiointercept_mock.post(f"{OAUTH_HOST}/oauth/token", status=200, payload=mock_refresh_response)
 
     result = await oauth.refresh_access_token_async("valid_refresh_token")
 
@@ -299,10 +290,8 @@ async def test_error_handling_scenarios(  # pylint: disable=redefined-outer-name
         oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
         oauth.code_verifier = "test_verifier"
 
-        # Use aiointercept to mock network error
-        async with aiointercept(mock_external_urls=True) as mock:
-            mock.post(f"{OAUTH_HOST}/oauth/token", exception=True)
-
+        # Simulate a network error
+        with simulate_client_exception(Exception("Network error")):
             if expected_behavior == "raises_exception":
                 with pytest.raises(Exception):
                     await oauth.exchange_code_for_token("test_code")
@@ -403,18 +392,17 @@ def test_ui_widget_integration_scenarios(widget_type):
 
 
 @pytest.mark.asyncio
-async def test_malformed_api_responses(kick_integration_config):  # pylint: disable=redefined-outer-name
+async def test_malformed_api_responses(kick_integration_config, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test handling of malformed API responses."""
     config = kick_integration_config
     oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
     oauth.code_verifier = "test_verifier"
 
     # Test malformed JSON response using aiointercept
-    async with aiointercept(mock_external_urls=True) as mock:
-        mock.post(f"{OAUTH_HOST}/oauth/token", status=200, body="invalid json content")
+    aiointercept_mock.post(f"{OAUTH_HOST}/oauth/token", status=200, body="invalid json content")
 
-        with pytest.raises(Exception):
-            await oauth.exchange_code_for_token("test_code")
+    with pytest.raises(Exception):
+        await oauth.exchange_code_for_token("test_code")
 
 
 @pytest.mark.asyncio
@@ -430,13 +418,8 @@ async def test_network_timeouts(kick_integration_config):  # pylint: disable=red
     mock_oauth.get_stored_tokens.return_value = ("valid_token", "refresh_token")
     chat.oauth = mock_oauth
 
-    # Test timeout during message sending using aiointercept
-    async with aiointercept(mock_external_urls=True) as mock:
-        mock.post(
-            "https://api.kick.com/public/v1/chat",
-            exception=True,
-        )
-
+    # Test timeout during message sending
+    with simulate_client_exception(TimeoutError("Request timed out")):
         result = await chat._send_message("Test message")  # pylint: disable=protected-access
         assert result is False
 

--- a/tests/kick/test_kick_integration.py
+++ b/tests/kick/test_kick_integration.py
@@ -6,7 +6,8 @@ import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aioresponses import aioresponses
+import pytest_asyncio
+from aiointercept import aiointercept
 
 import nowplaying.kick.chat  # pylint: disable=import-error,no-name-in-module
 import nowplaying.kick.launch  # pylint: disable=import-error,no-name-in-module
@@ -61,10 +62,10 @@ def mock_chat_with_oauth(kick_integration_config):  # pylint: disable=redefined-
     return chat, stopevent
 
 
-@pytest.fixture
-def mock_aiohttp_success():
-    """Fixture that mocks successful aiohttp responses using aioresponses."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_aiohttp_success():
+    """Fixture that mocks successful aiohttp responses using aiointercept."""
+    async with aiointercept(mock_external_urls=True) as mock:
         # Setup default success responses for common endpoints (repeat=True for multiple calls)
         mock.post(
             "https://api.kick.com/public/v1/chat",
@@ -75,10 +76,10 @@ def mock_aiohttp_success():
         yield mock
 
 
-@pytest.fixture
-def mock_responses():
-    """Fixture that provides aioresponses for mocking HTTP calls."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_responses():
+    """Fixture that provides aiointercept for mocking HTTP calls."""
+    async with aiointercept(mock_external_urls=True) as mock:
         yield mock
 
 
@@ -298,9 +299,9 @@ async def test_error_handling_scenarios(  # pylint: disable=redefined-outer-name
         oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
         oauth.code_verifier = "test_verifier"
 
-        # Use aioresponses to mock network error
-        with aioresponses() as mock:
-            mock.post(f"{OAUTH_HOST}/oauth/token", exception=Exception("Network error"))
+        # Use aiointercept to mock network error
+        async with aiointercept(mock_external_urls=True) as mock:
+            mock.post(f"{OAUTH_HOST}/oauth/token", exception=True)
 
             if expected_behavior == "raises_exception":
                 with pytest.raises(Exception):
@@ -408,8 +409,8 @@ async def test_malformed_api_responses(kick_integration_config):  # pylint: disa
     oauth = nowplaying.kick.oauth2.KickOAuth2(config)  # pylint: disable=no-member
     oauth.code_verifier = "test_verifier"
 
-    # Test malformed JSON response using aioresponses
-    with aioresponses() as mock:
+    # Test malformed JSON response using aiointercept
+    async with aiointercept(mock_external_urls=True) as mock:
         mock.post(f"{OAUTH_HOST}/oauth/token", status=200, body="invalid json content")
 
         with pytest.raises(Exception):
@@ -429,11 +430,11 @@ async def test_network_timeouts(kick_integration_config):  # pylint: disable=red
     mock_oauth.get_stored_tokens.return_value = ("valid_token", "refresh_token")
     chat.oauth = mock_oauth
 
-    # Test timeout during message sending using aioresponses
-    with aioresponses() as mock:
+    # Test timeout during message sending using aiointercept
+    async with aiointercept(mock_external_urls=True) as mock:
         mock.post(
             "https://api.kick.com/public/v1/chat",
-            exception=TimeoutError("Request timed out"),
+            exception=True,
         )
 
         result = await chat._send_message("Test message")  # pylint: disable=protected-access

--- a/tests/kick/test_kick_oauth2.py
+++ b/tests/kick/test_kick_oauth2.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Unit tests for Kick OAuth2 functionality - REFACTORED VERSION."""
 
-import asyncio
 import base64
 import hashlib
 import re
 from unittest.mock import patch
 
 import pytest
-from aioresponses import aioresponses
+import pytest_asyncio
+from aiointercept import aiointercept
 
 import nowplaying.kick.oauth2  # pylint: disable=import-error,no-name-in-module
 from nowplaying.kick.constants import OAUTH_HOST  # pylint: disable=import-error,no-name-in-module
@@ -37,10 +37,10 @@ def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
     return oauth
 
 
-@pytest.fixture
-def mock_responses():
-    """Fixture that provides aioresponses for mocking HTTP calls."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_responses():
+    """Fixture that provides aiointercept for mocking HTTP calls."""
+    async with aiointercept(mock_external_urls=True) as mock:
         yield mock
 
 
@@ -420,10 +420,12 @@ async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disa
     """Test network timeout handling."""
     oauth = oauth_with_pkce
 
-    # Mock a timeout by using an exception
-    mock_responses.post(f"{OAUTH_HOST}/oauth/token", exception=TimeoutError("Request timed out"))
+    # aiointercept can only simulate a dropped connection, not a specific
+    # exception type, so this covers network failure generally rather than
+    # timeouts specifically.
+    mock_responses.post(f"{OAUTH_HOST}/oauth/token", exception=True)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(Exception):
         await oauth.exchange_code_for_token("test_code", oauth.state)
 
 

--- a/tests/kick/test_kick_oauth2.py
+++ b/tests/kick/test_kick_oauth2.py
@@ -7,8 +7,7 @@ import re
 from unittest.mock import patch
 
 import pytest
-import pytest_asyncio
-from aiointercept import aiointercept
+from utils_aiohttp import simulate_client_exception  # pylint: disable=import-error
 
 import nowplaying.kick.oauth2  # pylint: disable=import-error,no-name-in-module
 from nowplaying.kick.constants import OAUTH_HOST  # pylint: disable=import-error,no-name-in-module
@@ -35,13 +34,6 @@ def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
     oauth = configured_oauth
     oauth._generate_pkce_parameters()  # pylint: disable=protected-access
     return oauth
-
-
-@pytest_asyncio.fixture
-async def mock_responses():
-    """Fixture that provides aiointercept for mocking HTTP calls."""
-    async with aiointercept(mock_external_urls=True) as mock:
-        yield mock
 
 
 # Basic OAuth2 functionality tests
@@ -190,7 +182,7 @@ def test_open_browser_for_auth_scenarios(mock_open, configured_oauth, browser_su
 @pytest.mark.asyncio
 async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-outer-name
     configured_oauth,
-    mock_responses,
+    aiointercept_mock,
     has_verifier,
     state_matches,
     response_status,
@@ -208,7 +200,7 @@ async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-o
 
     if should_succeed:
         # Success case - setup mock and verify result
-        mock_responses.post(
+        aiointercept_mock.post(
             f"{OAUTH_HOST}/oauth/token", status=response_status, payload=response_data
         )
 
@@ -219,7 +211,7 @@ async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-o
 
     elif response_status != 200:
         # HTTP error case
-        mock_responses.post(f"{OAUTH_HOST}/oauth/token", status=response_status, body="Error")
+        aiointercept_mock.post(f"{OAUTH_HOST}/oauth/token", status=response_status, body="Error")
 
         with pytest.raises(Exception):
             await oauth.exchange_code_for_token("test_code", test_state)
@@ -248,7 +240,7 @@ async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-o
 async def test_refresh_access_token_scenarios(
     bootstrap,
     configured_oauth,
-    mock_responses,
+    aiointercept_mock,
     has_refresh_token,
     response_status,
     response_data,
@@ -264,7 +256,7 @@ async def test_refresh_access_token_scenarios(
         refresh_token = None
 
     if should_succeed:
-        mock_responses.post(
+        aiointercept_mock.post(
             f"{OAUTH_HOST}/oauth/token", status=response_status, payload=response_data
         )
 
@@ -275,7 +267,9 @@ async def test_refresh_access_token_scenarios(
     else:
         if has_refresh_token:
             # HTTP error case
-            mock_responses.post(f"{OAUTH_HOST}/oauth/token", status=response_status, body="Error")
+            aiointercept_mock.post(
+                f"{OAUTH_HOST}/oauth/token", status=response_status, body="Error"
+            )
 
         with pytest.raises((ValueError, Exception)):
             await oauth.refresh_access_token_async(refresh_token)
@@ -297,7 +291,7 @@ async def test_refresh_access_token_scenarios(
 @pytest.mark.asyncio
 async def test_validate_token_scenarios(
     configured_oauth,
-    mock_responses,
+    aiointercept_mock,
     response_status,  # pylint: disable=redefined-outer-name
     response_data,
     expected_result,
@@ -308,9 +302,9 @@ async def test_validate_token_scenarios(
     # Use the correct introspect endpoint and POST method
     introspect_url = "https://api.kick.com/public/v1/token/introspect"
     if response_status == 200:
-        mock_responses.post(introspect_url, status=response_status, payload=response_data)
+        aiointercept_mock.post(introspect_url, status=response_status, payload=response_data)
     else:
-        mock_responses.post(introspect_url, status=response_status, body="Error")
+        aiointercept_mock.post(introspect_url, status=response_status, body="Error")
 
     result = await oauth.validate_token_async("test_token")
     assert result == expected_result
@@ -368,7 +362,7 @@ def test_clear_stored_tokens(configured_oauth):  # pylint: disable=redefined-out
 )
 @pytest.mark.asyncio
 async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, too-many-arguments
-    bootstrap, mock_responses, has_client_id, has_token, response_status, should_clear_tokens
+    bootstrap, aiointercept_mock, has_client_id, has_token, response_status, should_clear_tokens
 ):
     """Test token revocation with various scenarios."""
     config = bootstrap
@@ -385,7 +379,7 @@ async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, 
         # Setup mock response for cases where we have credentials
         # Note: We need to use a regex pattern to match the URL with query parameters
         url_pattern = re.compile(rf"{re.escape(OAUTH_HOST)}/oauth/revoke\?.*")
-        mock_responses.post(url_pattern, status=response_status)
+        aiointercept_mock.post(url_pattern, status=response_status)
 
     # Should not raise exception in any case
     await oauth.revoke_token(token_to_revoke)
@@ -404,29 +398,25 @@ async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, 
 
 
 @pytest.mark.asyncio
-async def test_json_parsing_error(oauth_with_pkce, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_json_parsing_error(oauth_with_pkce, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test handling of JSON parsing errors."""
     oauth = oauth_with_pkce
 
     # Mock response with invalid JSON
-    mock_responses.post(f"{OAUTH_HOST}/oauth/token", status=200, body="invalid json content")
+    aiointercept_mock.post(f"{OAUTH_HOST}/oauth/token", status=200, body="invalid json content")
 
     with pytest.raises(Exception):
         await oauth.exchange_code_for_token("test_code")
 
 
 @pytest.mark.asyncio
-async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_network_timeout(oauth_with_pkce):  # pylint: disable=redefined-outer-name
     """Test network timeout handling."""
     oauth = oauth_with_pkce
 
-    # aiointercept can only simulate a dropped connection, not a specific
-    # exception type, so this covers network failure generally rather than
-    # timeouts specifically.
-    mock_responses.post(f"{OAUTH_HOST}/oauth/token", exception=True)
-
-    with pytest.raises(Exception):
-        await oauth.exchange_code_for_token("test_code", oauth.state)
+    with simulate_client_exception(TimeoutError("Request timed out")):
+        with pytest.raises(TimeoutError):
+            await oauth.exchange_code_for_token("test_code", oauth.state)
 
 
 def test_pkce_parameter_uniqueness(configured_oauth):  # pylint: disable=redefined-outer-name

--- a/tests/notifications/test_notifications_remote.py
+++ b/tests/notifications/test_notifications_remote.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from aiointercept import aiointercept
 
 import nowplaying.notifications.remote
 
@@ -35,7 +34,7 @@ async def test_remote_plugin_disabled(remote_plugin):  # pylint: disable=redefin
 
 
 @pytest.mark.asyncio
-async def test_remote_plugin_no_secret(remote_plugin):  # pylint: disable=redefined-outer-name
+async def test_remote_plugin_no_secret(remote_plugin, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """test remote plugin without secret configured"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
     remote_plugin.config.cparser.setValue("remote/remote_server", "localhost")
@@ -45,21 +44,20 @@ async def test_remote_plugin_no_secret(remote_plugin):  # pylint: disable=redefi
 
     metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
+    aiointercept_mock.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
 
-        await remote_plugin.notify_track_change(metadata)
+    await remote_plugin.notify_track_change(metadata)
 
-        # Verify the request was made
-        assert len(mock_resp.requests) == 1
-        first_key = list(mock_resp.requests.keys())[0]
-        request = mock_resp.requests[first_key][0]
-        # Should not have secret in the payload
-        assert "secret" not in await request.json()
+    # Verify the request was made
+    assert len(aiointercept_mock.requests) == 1
+    first_key = list(aiointercept_mock.requests.keys())[0]
+    request = aiointercept_mock.requests[first_key][0]
+    # Should not have secret in the payload
+    assert "secret" not in await request.json()
 
 
 @pytest.mark.asyncio
-async def test_remote_plugin_with_secret(remote_plugin):  # pylint: disable=redefined-outer-name
+async def test_remote_plugin_with_secret(remote_plugin, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """test remote plugin with secret configured"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
     remote_plugin.config.cparser.setValue("remote/remote_server", "localhost")
@@ -69,21 +67,20 @@ async def test_remote_plugin_with_secret(remote_plugin):  # pylint: disable=rede
 
     metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 456})
+    aiointercept_mock.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 456})
 
-        await remote_plugin.notify_track_change(metadata)
+    await remote_plugin.notify_track_change(metadata)
 
-        # Verify the request was made with secret
-        assert len(mock_resp.requests) == 1
-        first_key = list(mock_resp.requests.keys())[0]
-        request = mock_resp.requests[first_key][0]
-        payload = await request.json()
-        assert payload["secret"] == "test_secret_123"  # pragma: allowlist secret
+    # Verify the request was made with secret
+    assert len(aiointercept_mock.requests) == 1
+    first_key = list(aiointercept_mock.requests.keys())[0]
+    request = aiointercept_mock.requests[first_key][0]
+    payload = await request.json()
+    assert payload["secret"] == "test_secret_123"  # pragma: allowlist secret
 
 
 @pytest.mark.asyncio
-async def test_remote_plugin_auth_failure(remote_plugin):  # pylint: disable=redefined-outer-name
+async def test_remote_plugin_auth_failure(remote_plugin, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """test remote plugin with authentication failure"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
     remote_plugin.config.cparser.setValue("remote/remote_server", "localhost")
@@ -93,17 +90,16 @@ async def test_remote_plugin_auth_failure(remote_plugin):  # pylint: disable=red
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post(
-            "http://localhost:8899/v1/remoteinput", status=403, payload={"error": "Invalid secret"}
-        )
+    aiointercept_mock.post(
+        "http://localhost:8899/v1/remoteinput", status=403, payload={"error": "Invalid secret"}
+    )
 
-        # Should handle auth failure gracefully
-        await remote_plugin.notify_track_change(metadata)
+    # Should handle auth failure gracefully
+    await remote_plugin.notify_track_change(metadata)
 
 
 @pytest.mark.asyncio
-async def test_remote_plugin_server_error(remote_plugin):  # pylint: disable=redefined-outer-name
+async def test_remote_plugin_server_error(remote_plugin, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """test remote plugin with server error"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
     remote_plugin.config.cparser.setValue("remote/remote_server", "localhost")
@@ -113,19 +109,18 @@ async def test_remote_plugin_server_error(remote_plugin):  # pylint: disable=red
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post(
-            "http://localhost:8899/v1/remoteinput",
-            status=500,
-            payload={"error": "Internal server error"},
-        )
+    aiointercept_mock.post(
+        "http://localhost:8899/v1/remoteinput",
+        status=500,
+        payload={"error": "Internal server error"},
+    )
 
-        # Should handle server error gracefully
-        await remote_plugin.notify_track_change(metadata)
+    # Should handle server error gracefully
+    await remote_plugin.notify_track_change(metadata)
 
 
 @pytest.mark.asyncio
-async def test_remote_plugin_strips_blobs(remote_plugin):  # pylint: disable=redefined-outer-name
+async def test_remote_plugin_strips_blobs(remote_plugin, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """test that remote plugin strips binary blob data and local system data"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
     remote_plugin.config.cparser.setValue("remote/remote_server", "localhost")
@@ -150,38 +145,37 @@ async def test_remote_plugin_strips_blobs(remote_plugin):  # pylint: disable=red
         "discordguild": "My Discord Server",  # Should be kept
     }
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
+    aiointercept_mock.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
 
-        await remote_plugin.notify_track_change(metadata)
+    await remote_plugin.notify_track_change(metadata)
 
-        # Verify blob data and local system data was stripped
-        first_key = list(mock_resp.requests.keys())[0]
-        request = mock_resp.requests[first_key][0]
-        payload = await request.json()
+    # Verify blob data and local system data was stripped
+    first_key = list(aiointercept_mock.requests.keys())[0]
+    request = aiointercept_mock.requests[first_key][0]
+    payload = await request.json()
 
-        # Binary blob fields should be stripped
-        assert "coverimageraw" not in payload
-        assert "artistthumbnailraw" not in payload
+    # Binary blob fields should be stripped
+    assert "coverimageraw" not in payload
+    assert "artistthumbnailraw" not in payload
 
-        # Local system fields should be stripped
-        assert "dbid" not in payload
-        assert "httpport" not in payload
-        assert "hostname" not in payload
-        assert "hostfqdn" not in payload
-        assert "hostip" not in payload
-        assert "ipaddress" not in payload
-        assert "previoustrack" not in payload
-        assert "cache_warmed" not in payload
+    # Local system fields should be stripped
+    assert "dbid" not in payload
+    assert "httpport" not in payload
+    assert "hostname" not in payload
+    assert "hostfqdn" not in payload
+    assert "hostip" not in payload
+    assert "ipaddress" not in payload
+    assert "previoustrack" not in payload
+    assert "cache_warmed" not in payload
 
-        # Track data should remain
-        assert payload["artist"] == "Test Artist"
-        assert payload["title"] == "Test Title"
+    # Track data should remain
+    assert payload["artist"] == "Test Artist"
+    assert payload["title"] == "Test Title"
 
-        # Streaming channel data should be kept (not stripped)
-        assert payload["twitchchannel"] == "teststreamer"
-        assert payload["kickchannel"] == "kickstreamer"
-        assert payload["discordguild"] == "My Discord Server"
+    # Streaming channel data should be kept (not stripped)
+    assert payload["twitchchannel"] == "teststreamer"
+    assert payload["kickchannel"] == "kickstreamer"
+    assert payload["discordguild"] == "My Discord Server"
 
 
 def test_remote_plugin_strip_blobs_static():
@@ -684,6 +678,7 @@ async def test_remote_notification_verify_settingsui_manual_valid():
 @pytest.mark.asyncio
 async def test_remote_sets_charts_submitted_flag_when_charts_enabled(
     remote_plugin,  # pylint: disable=redefined-outer-name
+    aiointercept_mock,
 ):
     """remote plugin sets remote_charts_submitted when client has charts enabled"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
@@ -695,18 +690,18 @@ async def test_remote_sets_charts_submitted_flag_when_charts_enabled(
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
-        await remote_plugin.notify_track_change(metadata)
+    aiointercept_mock.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
+    await remote_plugin.notify_track_change(metadata)
 
-        request = mock_resp.requests[list(mock_resp.requests.keys())[0]][0]
-        payload = await request.json()
-        assert payload.get("remote_charts_submitted") is True
+    request = aiointercept_mock.requests[list(aiointercept_mock.requests.keys())[0]][0]
+    payload = await request.json()
+    assert payload.get("remote_charts_submitted") is True
 
 
 @pytest.mark.asyncio
 async def test_remote_omits_charts_submitted_flag_when_charts_disabled(
     remote_plugin,  # pylint: disable=redefined-outer-name
+    aiointercept_mock,
 ):
     """remote plugin does not set remote_charts_submitted when client has charts disabled"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
@@ -717,9 +712,8 @@ async def test_remote_omits_charts_submitted_flag_when_charts_disabled(
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
-        await remote_plugin.notify_track_change(metadata)
+    aiointercept_mock.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
+    await remote_plugin.notify_track_change(metadata)
 
-        request = mock_resp.requests[list(mock_resp.requests.keys())[0]][0]
-        assert "remote_charts_submitted" not in await request.json()
+    request = aiointercept_mock.requests[list(aiointercept_mock.requests.keys())[0]][0]
+    assert "remote_charts_submitted" not in await request.json()

--- a/tests/notifications/test_notifications_remote.py
+++ b/tests/notifications/test_notifications_remote.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.notifications.remote
 
@@ -45,7 +45,7 @@ async def test_remote_plugin_no_secret(remote_plugin):  # pylint: disable=redefi
 
     metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
 
         await remote_plugin.notify_track_change(metadata)
@@ -55,7 +55,7 @@ async def test_remote_plugin_no_secret(remote_plugin):  # pylint: disable=redefi
         first_key = list(mock_resp.requests.keys())[0]
         request = mock_resp.requests[first_key][0]
         # Should not have secret in the payload
-        assert "secret" not in request.kwargs["json"]
+        assert "secret" not in await request.json()
 
 
 @pytest.mark.asyncio
@@ -69,7 +69,7 @@ async def test_remote_plugin_with_secret(remote_plugin):  # pylint: disable=rede
 
     metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 456})
 
         await remote_plugin.notify_track_change(metadata)
@@ -78,7 +78,8 @@ async def test_remote_plugin_with_secret(remote_plugin):  # pylint: disable=rede
         assert len(mock_resp.requests) == 1
         first_key = list(mock_resp.requests.keys())[0]
         request = mock_resp.requests[first_key][0]
-        assert request.kwargs["json"]["secret"] == "test_secret_123"  # pragma: allowlist secret
+        payload = await request.json()
+        assert payload["secret"] == "test_secret_123"  # pragma: allowlist secret
 
 
 @pytest.mark.asyncio
@@ -92,7 +93,7 @@ async def test_remote_plugin_auth_failure(remote_plugin):  # pylint: disable=red
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "http://localhost:8899/v1/remoteinput", status=403, payload={"error": "Invalid secret"}
         )
@@ -112,7 +113,7 @@ async def test_remote_plugin_server_error(remote_plugin):  # pylint: disable=red
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post(
             "http://localhost:8899/v1/remoteinput",
             status=500,
@@ -149,7 +150,7 @@ async def test_remote_plugin_strips_blobs(remote_plugin):  # pylint: disable=red
         "discordguild": "My Discord Server",  # Should be kept
     }
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 123})
 
         await remote_plugin.notify_track_change(metadata)
@@ -157,7 +158,7 @@ async def test_remote_plugin_strips_blobs(remote_plugin):  # pylint: disable=red
         # Verify blob data and local system data was stripped
         first_key = list(mock_resp.requests.keys())[0]
         request = mock_resp.requests[first_key][0]
-        payload = request.kwargs["json"]
+        payload = await request.json()
 
         # Binary blob fields should be stripped
         assert "coverimageraw" not in payload
@@ -694,12 +695,13 @@ async def test_remote_sets_charts_submitted_flag_when_charts_enabled(
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
         await remote_plugin.notify_track_change(metadata)
 
         request = mock_resp.requests[list(mock_resp.requests.keys())[0]][0]
-        assert request.kwargs["json"].get("remote_charts_submitted") is True
+        payload = await request.json()
+        assert payload.get("remote_charts_submitted") is True
 
 
 @pytest.mark.asyncio
@@ -715,9 +717,9 @@ async def test_remote_omits_charts_submitted_flag_when_charts_disabled(
 
     metadata = {"artist": "Test Artist", "title": "Test Title"}
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.post("http://localhost:8899/v1/remoteinput", payload={"dbid": 1})
         await remote_plugin.notify_track_change(metadata)
 
         request = mock_resp.requests[list(mock_resp.requests.keys())[0]][0]
-        assert "remote_charts_submitted" not in request.kwargs["json"]
+        assert "remote_charts_submitted" not in await request.json()

--- a/tests/test_artistextras_lastfm.py
+++ b/tests/test_artistextras_lastfm.py
@@ -5,7 +5,6 @@ import os
 import urllib.parse
 
 import pytest
-from aioresponses import aioresponses
 from utils_artistextras import FakeImageCache, configuresettings, skip_no_lastfm_key
 
 import nowplaying.apicache
@@ -132,17 +131,16 @@ async def test_lastfm_no_artist(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_bio_and_website(bootstrap):
+async def test_lastfm_bio_and_website(bootstrap, aiointercept_mock):
     """successful fetch returns bio and website"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
 
-        result = await plugin.download_async(
-            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-            imagecache=imagecache,
-        )
+    result = await plugin.download_async(
+        {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+        imagecache=imagecache,
+    )
 
     assert result is not None
     assert result["artistlongbio"]
@@ -151,15 +149,14 @@ async def test_lastfm_bio_and_website(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_bio_stripped(bootstrap):
+async def test_lastfm_bio_stripped(bootstrap, aiointercept_mock):
     """Last.fm attribution is stripped from bio"""
     plugin, _ = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+    )
 
     assert result is not None
     assert "Read more on Last.fm" not in result["artistlongbio"]
@@ -167,17 +164,16 @@ async def test_lastfm_bio_stripped(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_bio_disabled(bootstrap):
+async def test_lastfm_bio_disabled(bootstrap, aiointercept_mock):
     """bio disabled returns only website"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/bio", False)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+        imagecache=imagecache,
+    )
 
     assert result is not None
     assert "artistlongbio" not in result
@@ -185,17 +181,16 @@ async def test_lastfm_bio_disabled(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_websites_disabled(bootstrap):
+async def test_lastfm_websites_disabled(bootstrap, aiointercept_mock):
     """websites disabled returns only bio"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/websites", False)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+        imagecache=imagecache,
+    )
 
     assert result is not None
     assert result["artistlongbio"]
@@ -203,20 +198,19 @@ async def test_lastfm_websites_disabled(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_existing_bio_not_overwritten(bootstrap):
+async def test_lastfm_existing_bio_not_overwritten(bootstrap, aiointercept_mock):
     """does not overwrite existing artistlongbio"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {
-                "artist": "Nine Inch Nails",
-                "imagecacheartist": "nineinchnails",
-                "artistlongbio": "already set",
-            },
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {
+            "artist": "Nine Inch Nails",
+            "imagecacheartist": "nineinchnails",
+            "artistlongbio": "already set",
+        },
+        imagecache=imagecache,
+    )
 
     # Only websites should be returned; bio was already set
     assert result is not None
@@ -225,25 +219,24 @@ async def test_lastfm_existing_bio_not_overwritten(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_api_error(bootstrap):
+async def test_lastfm_api_error(bootstrap, aiointercept_mock):
     """Last.fm API error response returns None"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
-    with aioresponses() as mockr:
-        mockr.get(
-            XYZ_URL,
-            payload={"error": 6, "message": "Artist not found"},
-        )
-        result = await plugin.download_async(
-            {"artist": "XYZ Nonexistent Artist XYZ", "imagecacheartist": "xyz"},
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(
+        XYZ_URL,
+        payload={"error": 6, "message": "Artist not found"},
+    )
+    result = await plugin.download_async(
+        {"artist": "XYZ Nonexistent Artist XYZ", "imagecacheartist": "xyz"},
+        imagecache=imagecache,
+    )
 
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_lastfm_http_error(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_lastfm_http_error(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """HTTP error returns None without raising"""
     plugin, imagecache = _setup_plugin(bootstrap)
 
@@ -251,12 +244,11 @@ async def test_lastfm_http_error(bootstrap, isolated_api_cache):  # pylint: disa
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
 
     try:
-        with aioresponses() as mockr:
-            mockr.get(NIN_URL, status=503)
-            result = await plugin.download_async(
-                {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_URL, status=503)
+        result = await plugin.download_async(
+            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+            imagecache=imagecache,
+        )
 
         assert result is None
     finally:
@@ -264,18 +256,17 @@ async def test_lastfm_http_error(bootstrap, isolated_api_cache):  # pylint: disa
 
 
 @pytest.mark.asyncio
-async def test_lastfm_both_disabled_returns_none(bootstrap):
+async def test_lastfm_both_disabled_returns_none(bootstrap, aiointercept_mock):
     """both bio and websites disabled returns None"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/bio", False)
     bootstrap.cparser.setValue("lastfm/websites", False)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+        imagecache=imagecache,
+    )
 
     assert result is None
 
@@ -289,7 +280,7 @@ def test_lastfm_providerinfo(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_lang_returned(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_lastfm_lang_returned(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """non-English lang is requested and bio uses that language"""
     original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -309,12 +300,11 @@ async def test_lastfm_lang_returned(bootstrap, isolated_api_cache):  # pylint: d
             }
         }
 
-        with aioresponses() as mockr:
-            mockr.get(de_url, payload=de_response)
-            result = await plugin.download_async(
-                {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(de_url, payload=de_response)
+        result = await plugin.download_async(
+            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert "Industrialrock" in result["artistlongbio"]
@@ -323,7 +313,7 @@ async def test_lastfm_lang_returned(bootstrap, isolated_api_cache):  # pylint: d
 
 
 @pytest.mark.asyncio
-async def test_lastfm_lang_fallback_to_en(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_lastfm_lang_fallback_to_en(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """empty bio in requested lang falls back to English when enabled"""
     original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -341,13 +331,12 @@ async def test_lastfm_lang_fallback_to_en(bootstrap, isolated_api_cache):  # pyl
             }
         }
 
-        with aioresponses() as mockr:
-            mockr.get(ko_url, payload=ko_response)
-            mockr.get(en_url, payload=NIN_RESPONSE)
-            result = await plugin.download_async(
-                {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(ko_url, payload=ko_response)
+        aiointercept_mock.get(en_url, payload=NIN_RESPONSE)
+        result = await plugin.download_async(
+            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert result["artistlongbio"]
@@ -357,7 +346,7 @@ async def test_lastfm_lang_fallback_to_en(bootstrap, isolated_api_cache):  # pyl
 
 
 @pytest.mark.asyncio
-async def test_lastfm_lang_no_fallback(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_lastfm_lang_no_fallback(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """empty bio in requested lang returns no bio when fallback is disabled"""
     original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -374,12 +363,11 @@ async def test_lastfm_lang_no_fallback(bootstrap, isolated_api_cache):  # pylint
             }
         }
 
-        with aioresponses() as mockr:
-            mockr.get(ko_url, payload=ko_response)
-            result = await plugin.download_async(
-                {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(ko_url, payload=ko_response)
+        result = await plugin.download_async(
+            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+            imagecache=imagecache,
+        )
 
         # website should still be returned even with no bio
         assert result is not None
@@ -475,22 +463,21 @@ async def test_lastfm_live_lang_fallback(bootstrap, isolated_api_cache):  # pyli
 
 
 @pytest.mark.asyncio
-async def test_lastfm_coverart_queued(bootstrap):
+async def test_lastfm_coverart_queued(bootstrap, aiointercept_mock):
     """album cover art URL is queued in imagecache when album is present"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
-        result = await plugin.download_async(
-            {
-                "artist": "Nine Inch Nails",
-                "album": "The Downward Spiral",
-                "imagecacheartist": "nineinchnails",
-            },
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    aiointercept_mock.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
+    result = await plugin.download_async(
+        {
+            "artist": "Nine Inch Nails",
+            "album": "The Downward Spiral",
+            "imagecacheartist": "nineinchnails",
+        },
+        imagecache=imagecache,
+    )
 
     assert result is not None
     identifier = "Nine Inch Nails_The Downward Spiral"
@@ -499,43 +486,41 @@ async def test_lastfm_coverart_queued(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_coverart_disabled(bootstrap):
+async def test_lastfm_coverart_disabled(bootstrap, aiointercept_mock):
     """album cover art is not fetched when coverart setting is disabled"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", False)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {
-                "artist": "Nine Inch Nails",
-                "album": "The Downward Spiral",
-                "imagecacheartist": "nineinchnails",
-            },
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {
+            "artist": "Nine Inch Nails",
+            "album": "The Downward Spiral",
+            "imagecacheartist": "nineinchnails",
+        },
+        imagecache=imagecache,
+    )
 
     assert result is not None
     assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
 
 
 @pytest.mark.asyncio
-async def test_lastfm_coverart_skipped_when_coverimageraw_present(bootstrap):
+async def test_lastfm_coverart_skipped_when_coverimageraw_present(bootstrap, aiointercept_mock):
     """album cover art fetch is skipped when coverimageraw already in metadata"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {
-                "artist": "Nine Inch Nails",
-                "album": "The Downward Spiral",
-                "imagecacheartist": "nineinchnails",
-                "coverimageraw": b"\xff\xd8\xff",
-            },
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {
+            "artist": "Nine Inch Nails",
+            "album": "The Downward Spiral",
+            "imagecacheartist": "nineinchnails",
+            "coverimageraw": b"\xff\xd8\xff",
+        },
+        imagecache=imagecache,
+    )
 
     assert result is not None
     # No album.getinfo call was made; imagecache should not have front_cover queued
@@ -543,24 +528,23 @@ async def test_lastfm_coverart_skipped_when_coverimageraw_present(bootstrap):
 
 
 @pytest.mark.asyncio
-async def test_lastfm_coverart_no_album(bootstrap):
+async def test_lastfm_coverart_no_album(bootstrap, aiointercept_mock):
     """album cover art fetch is skipped when no album in metadata"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        result = await plugin.download_async(
-            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    result = await plugin.download_async(
+        {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+        imagecache=imagecache,
+    )
 
     assert result is not None
     assert not imagecache.urls
 
 
 @pytest.mark.asyncio
-async def test_lastfm_coverart_album_api_error(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_lastfm_coverart_album_api_error(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """album API error does not prevent artist data from being returned"""
     original_cache = nowplaying.apicache._global_cache_instance  # pylint: disable=protected-access
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -569,17 +553,16 @@ async def test_lastfm_coverart_album_api_error(bootstrap, isolated_api_cache):  
         plugin, imagecache = _setup_plugin(bootstrap)
         bootstrap.cparser.setValue("lastfm/coverart", True)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_URL, payload=NIN_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload={"error": 6, "message": "Album not found"})
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+        aiointercept_mock.get(NIN_ALBUM_URL, payload={"error": 6, "message": "Album not found"})
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert result.get("artistlongbio") or result.get("artistwebsites")
@@ -589,25 +572,24 @@ async def test_lastfm_coverart_album_api_error(bootstrap, isolated_api_cache):  
 
 
 @pytest.mark.asyncio
-async def test_lastfm_coverart_with_album_mbid(bootstrap):
+async def test_lastfm_coverart_with_album_mbid(bootstrap, aiointercept_mock):
     """album cover art uses MBID-based URL when musicbrainzalbumid is present"""
     plugin, imagecache = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
     album_mbid = "12345678-1234-1234-1234-123456789abc"
     mbid_url = _album_mbid_url(album_mbid)
 
-    with aioresponses() as mockr:
-        mockr.get(NIN_URL, payload=NIN_RESPONSE)
-        mockr.get(mbid_url, payload=NIN_ALBUM_RESPONSE)
-        result = await plugin.download_async(
-            {
-                "artist": "Nine Inch Nails",
-                "album": "The Downward Spiral",
-                "imagecacheartist": "nineinchnails",
-                "musicbrainzalbumid": album_mbid,
-            },
-            imagecache=imagecache,
-        )
+    aiointercept_mock.get(NIN_URL, payload=NIN_RESPONSE)
+    aiointercept_mock.get(mbid_url, payload=NIN_ALBUM_RESPONSE)
+    result = await plugin.download_async(
+        {
+            "artist": "Nine Inch Nails",
+            "album": "The Downward Spiral",
+            "imagecacheartist": "nineinchnails",
+            "musicbrainzalbumid": album_mbid,
+        },
+        imagecache=imagecache,
+    )
 
     assert result is not None
     identifier = "Nine Inch Nails_The Downward Spiral"

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -6,7 +6,6 @@ import logging
 import time
 
 import pytest
-from aioresponses import aioresponses
 from utils_artistextras import (
     FakeImageCache,
     configureplugins,
@@ -274,7 +273,7 @@ async def test_theaudiodb_api_call_count(bootstrap, isolated_api_cache):  # pyli
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_429_rate_limit_handling(bootstrap):
+async def test_theaudiodb_429_rate_limit_handling(bootstrap, aiointercept_mock):
     """test that theaudiodb handles 429 rate limits with proper cooldown"""
 
     plugin, _ = _setup_theaudiodb_plugin_no_key(bootstrap)
@@ -282,74 +281,71 @@ async def test_theaudiodb_429_rate_limit_handling(bootstrap):
     # Reset rate limit state
     nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-    with aioresponses() as mockr:
-        # Mock 429 response
-        mockr.get(
-            f"{TADB_BASE_URL}/search.php?s=test",
-            status=429,
-        )
+    # Mock 429 response
+    aiointercept_mock.get(
+        f"{TADB_BASE_URL}/search.php?s=test",
+        status=429,
+    )
 
-        # First call should trigger rate limit exception
-        with pytest.raises(nowplaying.artistextras.theaudiodb.RateLimitException):
-            await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test")
+    # First call should trigger rate limit exception
+    with pytest.raises(nowplaying.artistextras.theaudiodb.RateLimitException):
+        await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test")
 
-        # Rate limit should now be set for 60 seconds
-        assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until > time.time()
+    # Rate limit should now be set for 60 seconds
+    assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until > time.time()
 
-        # Second call should be blocked without making HTTP request
-        result2 = await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test2")
-        assert result2 is None
+    # Second call should be blocked without making HTTP request
+    result2 = await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test2")
+    assert result2 is None
 
-        # Only one HTTP request should have been made (first one, second was blocked)
-        assert len(mockr.requests) == 1
+    # Only one HTTP request should have been made (first one, second was blocked)
+    assert len(aiointercept_mock.requests) == 1
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_429_cooldown_expiry(bootstrap):
+async def test_theaudiodb_429_cooldown_expiry(bootstrap, aiointercept_mock):
     """test that theaudiodb rate limit cooldown expires after 60 seconds"""
     plugin, _ = _setup_theaudiodb_plugin_no_key(bootstrap)
 
     # Set rate limit in the past (expired)
     nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = time.time() - 1
 
-    with aioresponses() as mockr:
-        # Mock successful response after cooldown
-        mockr.get(
-            f"{TADB_BASE_URL}/search.php?s=test",
-            payload={"test": "data"},
-        )
+    # Mock successful response after cooldown
+    aiointercept_mock.get(
+        f"{TADB_BASE_URL}/search.php?s=test",
+        payload={"test": "data"},
+    )
 
-        result = await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test")
-        assert result == {"test": "data"}
+    result = await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test")
+    assert result == {"test": "data"}
 
-        # HTTP request should have been made (cooldown expired)
-        assert len(mockr.requests) == 1
+    # HTTP request should have been made (cooldown expired)
+    assert len(aiointercept_mock.requests) == 1
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_other_http_errors(bootstrap):
+async def test_theaudiodb_other_http_errors(bootstrap, aiointercept_mock):
     """test that theaudiodb handles other HTTP errors (non-429) properly"""
     plugin, _ = _setup_theaudiodb_plugin_no_key(bootstrap)
 
     # Reset rate limit state
     nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-    with aioresponses() as mockr:
-        # Mock 404 response
-        mockr.get(
-            f"{TADB_BASE_URL}/search.php?s=notfound",
-            status=404,
-        )
+    # Mock 404 response
+    aiointercept_mock.get(
+        f"{TADB_BASE_URL}/search.php?s=notfound",
+        status=404,
+    )
 
-        result = await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=notfound")
-        assert result is None
+    result = await plugin._fetch_async(DEFAULT_THEAUDIODB_API_KEY, "search.php?s=notfound")
+    assert result is None
 
-        # Rate limit should NOT be set for non-429 errors
-        assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until == 0
+    # Rate limit should NOT be set for non-429 errors
+    assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until == 0
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_429_not_cached(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_429_not_cached(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """test that theaudiodb 429 responses are not cached"""
     plugin, _ = _setup_theaudiodb_plugin_no_key(bootstrap)
 
@@ -361,34 +357,33 @@ async def test_theaudiodb_429_not_cached(bootstrap, isolated_api_cache):  # pyli
         # Reset rate limit state
         nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
 
-        with aioresponses() as mockr:
-            # Mock 429 response
-            mockr.get(
-                f"{TADB_BASE_URL}/search.php?s=test",
-                status=429,
-            )
+        # Mock 429 response
+        aiointercept_mock.get(
+            f"{TADB_BASE_URL}/search.php?s=test",
+            status=429,
+        )
 
-            # Cached fetch should handle the rate limit exception and return None
-            result = await plugin._fetch_cached(
-                DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
-            )
-            assert result is None
+        # Cached fetch should handle the rate limit exception and return None
+        result = await plugin._fetch_cached(
+            DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
+        )
+        assert result is None
 
-            # Rate limit should be set
-            assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until > time.time()
+        # Rate limit should be set
+        assert nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until > time.time()
 
-            # Clear rate limit and add successful response
-            nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
-            mockr.get(
-                f"{TADB_BASE_URL}/search.php?s=test",
-                payload={"test": "data"},
-            )
+        # Clear rate limit and add successful response
+        nowplaying.artistextras.theaudiodb.Plugin._rate_limit_until = 0
+        aiointercept_mock.get(
+            f"{TADB_BASE_URL}/search.php?s=test",
+            payload={"test": "data"},
+        )
 
-            # Now it should work and get the real data (not cached 429)
-            result2 = await plugin._fetch_cached(
-                DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
-            )
-            assert result2 == {"test": "data"}
+        # Now it should work and get the real data (not cached 429)
+        result2 = await plugin._fetch_cached(
+            DEFAULT_THEAUDIODB_API_KEY, "search.php?s=test", "testartist"
+        )
+        assert result2 == {"test": "data"}
     finally:
         # Restore original cache
         nowplaying.apicache.set_cache_instance(original_cache)
@@ -435,7 +430,7 @@ NIN_ALBUM_RESPONSE_HQ = {
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_queued(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_queued(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """album cover art URL is queued in imagecache when album is present"""
     original_cache = nowplaying.apicache._global_cache_instance
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -444,17 +439,16 @@ async def test_theaudiodb_coverart_queued(bootstrap, isolated_api_cache):  # pyl
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        aiointercept_mock.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
         assert result is not None
         identifier = "Nine Inch Nails_The Downward Spiral"
@@ -465,7 +459,7 @@ async def test_theaudiodb_coverart_queued(bootstrap, isolated_api_cache):  # pyl
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """strAlbumThumbHQ is preferred over strAlbumThumb when available"""
     original_cache = nowplaying.apicache._global_cache_instance
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -474,17 +468,16 @@ async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_api_cache):  #
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE_HQ)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        aiointercept_mock.get(NIN_ALBUM_URL, payload=NIN_ALBUM_RESPONSE_HQ)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
         assert result is not None
         identifier = "Nine Inch Nails_The Downward Spiral"
@@ -494,7 +487,7 @@ async def test_theaudiodb_coverart_prefers_hq(bootstrap, isolated_api_cache):  #
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_disabled(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_disabled(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """album cover art is not fetched when coverart setting is disabled"""
     original_cache = nowplaying.apicache._global_cache_instance
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -503,16 +496,15 @@ async def test_theaudiodb_coverart_disabled(bootstrap, isolated_api_cache):  # p
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", False)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
@@ -522,7 +514,7 @@ async def test_theaudiodb_coverart_disabled(bootstrap, isolated_api_cache):  # p
 
 @pytest.mark.asyncio
 async def test_theaudiodb_coverart_skipped_when_coverimageraw_present(  # pylint: disable=redefined-outer-name
-    bootstrap, isolated_api_cache
+    bootstrap, isolated_api_cache, aiointercept_mock
 ):
     """album cover art fetch is skipped when coverimageraw already in metadata"""
     original_cache = nowplaying.apicache._global_cache_instance
@@ -532,17 +524,16 @@ async def test_theaudiodb_coverart_skipped_when_coverimageraw_present(  # pylint
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                    "coverimageraw": b"\xff\xd8\xff",
-                },
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+                "coverimageraw": b"\xff\xd8\xff",
+            },
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls
@@ -551,7 +542,7 @@ async def test_theaudiodb_coverart_skipped_when_coverimageraw_present(  # pylint
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_no_album(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_no_album(bootstrap, isolated_api_cache, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """album cover art fetch is skipped when no album in metadata"""
     original_cache = nowplaying.apicache._global_cache_instance
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -560,12 +551,11 @@ async def test_theaudiodb_coverart_no_album(bootstrap, isolated_api_cache):  # p
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            result = await plugin.download_async(
-                {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        result = await plugin.download_async(
+            {"artist": "Nine Inch Nails", "imagecacheartist": "nineinchnails"},
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert not any("front_cover" in imagecache.urls.get(k, {}) for k in imagecache.urls)
@@ -574,7 +564,9 @@ async def test_theaudiodb_coverart_no_album(bootstrap, isolated_api_cache):  # p
 
 
 @pytest.mark.asyncio
-async def test_theaudiodb_coverart_album_api_error(bootstrap, isolated_api_cache):  # pylint: disable=redefined-outer-name
+async def test_theaudiodb_coverart_album_api_error(  # pylint: disable=redefined-outer-name
+    bootstrap, isolated_api_cache, aiointercept_mock
+):
     """album API error does not prevent artist data from being returned"""
     original_cache = nowplaying.apicache._global_cache_instance
     nowplaying.apicache.set_cache_instance(isolated_api_cache)
@@ -583,17 +575,16 @@ async def test_theaudiodb_coverart_album_api_error(bootstrap, isolated_api_cache
         plugin, imagecache = _setup_theaudiodb_plugin_no_key(bootstrap)
         bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-        with aioresponses() as mockr:
-            mockr.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
-            mockr.get(NIN_ALBUM_URL, payload={"album": None})
-            result = await plugin.download_async(
-                {
-                    "artist": "Nine Inch Nails",
-                    "album": "The Downward Spiral",
-                    "imagecacheartist": "nineinchnails",
-                },
-                imagecache=imagecache,
-            )
+        aiointercept_mock.get(NIN_ARTIST_URL, payload=NIN_ARTIST_RESPONSE)
+        aiointercept_mock.get(NIN_ALBUM_URL, payload={"album": None})
+        result = await plugin.download_async(
+            {
+                "artist": "Nine Inch Nails",
+                "album": "The Downward Spiral",
+                "imagecacheartist": "nineinchnails",
+            },
+            imagecache=imagecache,
+        )
 
         assert result is not None
         assert "Nine Inch Nails_The Downward Spiral" not in imagecache.urls

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -9,12 +9,13 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
-from aioresponses import aioresponses
+from aiointercept import aiointercept
+from utils_aiohttp import simulate_client_exception
 
 import nowplaying.inputs.jriver  # pylint: disable=import-error,no-name-in-module
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(loop_scope="function")
 async def jriver_plugin_with_session():
     """Create JRiver plugin with real aiohttp session for testing"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
@@ -268,7 +269,7 @@ async def test_test_connection_success():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Alive",
             body="""<Response Status="OK">
@@ -292,7 +293,7 @@ async def test_test_connection_wrong_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Alive",
             body="""<Response Status="OK">
@@ -315,7 +316,7 @@ async def test_test_connection_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Alive", status=404)
 
         result = await plugin._test_connection()  # pylint: disable=protected-access
@@ -333,9 +334,9 @@ async def test_test_connection_network_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Alive", exception=Exception("Connection failed")
+            "http://localhost:52199/MCWS/v1/Alive", exception=True
         )
 
         result = await plugin._test_connection()  # pylint: disable=protected-access
@@ -355,7 +356,7 @@ async def test_authenticate_success():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(
             url,
@@ -395,7 +396,7 @@ async def test_authenticate_no_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(
             url,
@@ -422,7 +423,7 @@ async def test_authenticate_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
         mock_resp.get(url, status=401)
 
@@ -449,8 +450,8 @@ async def test_getplayingtrack_success(jriver_plugin_with_session):  # pylint: d
     plugin.base_url = "http://localhost:52199/MCWS/v1"
     plugin.token = "testtoken"
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the URL pattern, including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the URL pattern, including query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info?Token=testtoken",
             body="""<Response Status="OK">
@@ -479,7 +480,7 @@ async def test_getplayingtrack_minimal_data():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info",
             body="""
@@ -508,7 +509,7 @@ async def test_getplayingtrack_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", status=500)
 
         result = await plugin.getplayingtrack()
@@ -526,9 +527,9 @@ async def test_getplayingtrack_network_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info", exception=Exception("Network error")
+            "http://localhost:52199/MCWS/v1/Playback/Info", exception=True
         )
 
         result = await plugin.getplayingtrack()
@@ -546,7 +547,7 @@ async def test_getplayingtrack_parse_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body="invalid xml content")
 
         result = await plugin.getplayingtrack()
@@ -564,7 +565,7 @@ async def test_getplayingtrack_with_xml_declaration():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # This simulates the actual JRiver response format with XML declaration
         jriver_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Response Status="OK">
@@ -600,8 +601,8 @@ async def test_getplayingtrack_with_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL including query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123",
             body='<Response Status="OK"></Response>',
@@ -622,8 +623,8 @@ async def test_getplayingtrack_without_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL without query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL without query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info",
             body='<Response Status="OK"></Response>',
@@ -644,8 +645,8 @@ async def test_getplayingtrack_with_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL including query parameters
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/Playback/Info?AccessKey=myaccesskey123",
             body='<Response Status="OK"></Response>',
@@ -667,8 +668,8 @@ async def test_getplayingtrack_with_token_and_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        # aioresponses matches the exact URL including query parameters
+    async with aiointercept(mock_external_urls=True) as mock_resp:
+        # aiointercept matches the exact URL including query parameters
         # Note: order of parameters in URL may vary, so we test the call was made correctly
         url = "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123&AccessKey=myaccesskey123"  # pylint: disable=line-too-long
         mock_resp.get(url, body='<Response Status="OK"></Response>')
@@ -688,7 +689,7 @@ async def test_get_filename_with_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&AccessKey=myaccesskey123"
         mock_resp.get(
             url,
@@ -714,7 +715,7 @@ async def test_get_filename_with_token_and_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         url = (
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&"
             "Token=mytoken123&AccessKey=myaccesskey123"
@@ -865,7 +866,7 @@ async def test_get_filename_success(jriver_plugin_with_session):  # pylint: disa
     plugin.base_url = "http://localhost:52199/MCWS/v1"
     plugin.token = "testtoken"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&Token=testtoken",
             body="""<Response Status="OK">
@@ -889,7 +890,7 @@ async def test_get_filename_not_found():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
             body="""
@@ -915,7 +916,7 @@ async def test_get_filename_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get("http://localhost:52199/MCWS/v1/File/GetInfo?File=12345", status=404)
 
         result = await plugin._get_filename("12345")  # pylint: disable=protected-access
@@ -933,7 +934,7 @@ async def test_get_filename_mpl_format():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # This simulates the actual JRiver MPL response format
         mpl_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <MPL Version="2.0" Title="MCWS - Files - 6096105472" PathSeparator="/">
@@ -963,7 +964,7 @@ async def test_get_filename_response_format():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # Test the old Response format for backwards compatibility
         response_format = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Response Status="OK">
@@ -990,14 +991,10 @@ async def test_test_connection_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Alive",
-            exception=aiohttp.ClientConnectorError(
-                connection_key=None, os_error=OSError("Connection refused")
-            ),
-        )
-
+    connector_error = aiohttp.ClientConnectorError(
+        connection_key=None, os_error=OSError("Connection refused")
+    )
+    with simulate_client_exception(connector_error):
         result = await plugin._test_connection()  # pylint: disable=protected-access
         assert not result
 
@@ -1013,9 +1010,7 @@ async def test_test_connection_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        mock_resp.get("http://localhost:52199/MCWS/v1/Alive", exception=aiohttp.ClientTimeout())
-
+    with simulate_client_exception(TimeoutError("Request timed out")):
         result = await plugin._test_connection()  # pylint: disable=protected-access
         assert not result
 
@@ -1033,15 +1028,10 @@ async def test_authenticate_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
-        mock_resp.get(
-            url,
-            exception=aiohttp.ClientConnectorError(
-                connection_key=None, os_error=OSError("Connection refused")
-            ),
-        )
-
+    connector_error = aiohttp.ClientConnectorError(
+        connection_key=None, os_error=OSError("Connection refused")
+    )
+    with simulate_client_exception(connector_error):
         result = await plugin._authenticate()  # pylint: disable=protected-access
         assert not result
 
@@ -1059,10 +1049,7 @@ async def test_authenticate_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
-        mock_resp.get(url, exception=aiohttp.ClientTimeout())
-
+    with simulate_client_exception(TimeoutError("Request timed out")):
         result = await plugin._authenticate()  # pylint: disable=protected-access
         assert not result
 
@@ -1078,14 +1065,10 @@ async def test_getplayingtrack_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info",
-            exception=aiohttp.ClientConnectorError(
-                connection_key=None, os_error=OSError("Connection refused")
-            ),
-        )
-
+    connector_error = aiohttp.ClientConnectorError(
+        connection_key=None, os_error=OSError("Connection refused")
+    )
+    with simulate_client_exception(connector_error):
         result = await plugin.getplayingtrack()
         assert result is None
 
@@ -1101,11 +1084,7 @@ async def test_getplayingtrack_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info", exception=aiohttp.ClientTimeout()
-        )
-
+    with simulate_client_exception(TimeoutError("Request timed out")):
         result = await plugin.getplayingtrack()
         assert result is None
 
@@ -1121,7 +1100,7 @@ async def test_getplayingtrack_xml_none_safety():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # Return completely empty response that will cause XML parsing error
         mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body="")
 
@@ -1141,14 +1120,10 @@ async def test_get_filename_jriver_not_running():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
-            exception=aiohttp.ClientConnectorError(
-                connection_key=None, os_error=OSError("Connection refused")
-            ),
-        )
-
+    connector_error = aiohttp.ClientConnectorError(
+        connection_key=None, os_error=OSError("Connection refused")
+    )
+    with simulate_client_exception(connector_error):
         result = await plugin._get_filename("12345")  # pylint: disable=protected-access
         assert result is None
 
@@ -1164,12 +1139,7 @@ async def test_get_filename_timeout():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    with aioresponses() as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
-            exception=aiohttp.ClientTimeout(),
-        )
-
+    with simulate_client_exception(TimeoutError("Request timed out")):
         result = await plugin._get_filename("12345")  # pylint: disable=protected-access
         assert result is None
 
@@ -1188,7 +1158,7 @@ async def test_auto_recovery_success():
         patch.object(plugin, "_test_connection", return_value=True),
         patch.object(plugin, "_authenticate", return_value=True),
     ):
-        with aioresponses() as mock_resp:
+        async with aiointercept(mock_external_urls=True) as mock_resp:
             mock_resp.get(
                 "http://localhost:52199/MCWS/v1/Playback/Info",
                 body='<Response><Item Name="Artist">Test Artist</Item>'
@@ -1230,14 +1200,10 @@ async def test_connection_error_sets_failed_state():
     plugin.session = aiohttp.ClientSession()
     plugin._connection_failed = False  # pylint: disable=protected-access
 
-    with aioresponses() as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info",
-            exception=aiohttp.ClientConnectorError(
-                connection_key=None, os_error=OSError("Connection refused")
-            ),
-        )
-
+    connector_error = aiohttp.ClientConnectorError(
+        connection_key=None, os_error=OSError("Connection refused")
+    )
+    with simulate_client_exception(connector_error):
         result = await plugin.getplayingtrack()
 
         assert result is None

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
-from aiointercept import aiointercept
 from utils_aiohttp import simulate_client_exception
 
 import nowplaying.inputs.jriver  # pylint: disable=import-error,no-name-in-module
@@ -260,7 +259,7 @@ async def test_start_session_kept_open_on_auth_failure(jriver_bootstrap):  # pyl
 
 
 @pytest.mark.asyncio
-async def test_test_connection_success():
+async def test_test_connection_success(aiointercept_mock):
     """Test successful connection test"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -269,22 +268,21 @@ async def test_test_connection_success():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Alive",
-            body="""<Response Status="OK">
-                        <Item Name="AccessKey">testkey</Item>
-                      </Response>""",
-        )
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Alive",
+        body="""<Response Status="OK">
+                    <Item Name="AccessKey">testkey</Item>
+                  </Response>""",
+    )
 
-        result = await plugin._test_connection()  # pylint: disable=protected-access
-        assert result
+    result = await plugin._test_connection()  # pylint: disable=protected-access
+    assert result
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_test_connection_wrong_access_key():
+async def test_test_connection_wrong_access_key(aiointercept_mock):
     """Test connection test with wrong access key"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -293,22 +291,21 @@ async def test_test_connection_wrong_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Alive",
-            body="""<Response Status="OK">
-                        <Item Name="AccessKey">correctkey</Item>
-                      </Response>""",
-        )
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Alive",
+        body="""<Response Status="OK">
+                    <Item Name="AccessKey">correctkey</Item>
+                  </Response>""",
+    )
 
-        result = await plugin._test_connection()  # pylint: disable=protected-access
-        assert not result
+    result = await plugin._test_connection()  # pylint: disable=protected-access
+    assert not result
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_test_connection_http_error():
+async def test_test_connection_http_error(aiointercept_mock):
     """Test connection test with HTTP error"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -316,11 +313,10 @@ async def test_test_connection_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get("http://localhost:52199/MCWS/v1/Alive", status=404)
+    aiointercept_mock.get("http://localhost:52199/MCWS/v1/Alive", status=404)
 
-        result = await plugin._test_connection()  # pylint: disable=protected-access
-        assert not result
+    result = await plugin._test_connection()  # pylint: disable=protected-access
+    assert not result
 
     await plugin.session.close()
 
@@ -334,11 +330,7 @@ async def test_test_connection_network_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Alive", exception=True
-        )
-
+    with simulate_client_exception(Exception("Connection failed")):
         result = await plugin._test_connection()  # pylint: disable=protected-access
         assert not result
 
@@ -346,7 +338,7 @@ async def test_test_connection_network_error():
 
 
 @pytest.mark.asyncio
-async def test_authenticate_success():
+async def test_authenticate_success(aiointercept_mock):
     """Test successful authentication"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -356,20 +348,19 @@ async def test_authenticate_success():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
-        mock_resp.get(
-            url,
-            body="""
-              <Response Status="OK">
-                  <Item Name="Token">abc123token</Item>
-              </Response>
-              """,
-        )
+    url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
+    aiointercept_mock.get(
+        url,
+        body="""
+          <Response Status="OK">
+              <Item Name="Token">abc123token</Item>
+          </Response>
+          """,
+    )
 
-        result = await plugin._authenticate()  # pylint: disable=protected-access
-        assert result
-        assert plugin.token == "abc123token"
+    result = await plugin._authenticate()  # pylint: disable=protected-access
+    assert result
+    assert plugin.token == "abc123token"
 
     await plugin.session.close()
 
@@ -386,7 +377,7 @@ async def test_authenticate_no_credentials():
 
 
 @pytest.mark.asyncio
-async def test_authenticate_no_token():
+async def test_authenticate_no_token(aiointercept_mock):
     """Test authentication with no token in response"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -396,24 +387,23 @@ async def test_authenticate_no_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
-        mock_resp.get(
-            url,
-            body="""
-              <Response Status="OK">
-              </Response>
-              """,
-        )
+    url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
+    aiointercept_mock.get(
+        url,
+        body="""
+          <Response Status="OK">
+          </Response>
+          """,
+    )
 
-        result = await plugin._authenticate()  # pylint: disable=protected-access
-        assert not result
+    result = await plugin._authenticate()  # pylint: disable=protected-access
+    assert not result
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_authenticate_http_error():
+async def test_authenticate_http_error(aiointercept_mock):
     """Test authentication with HTTP error"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -423,12 +413,11 @@ async def test_authenticate_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
-        mock_resp.get(url, status=401)
+    url = "http://localhost:52199/MCWS/v1/Authenticate?Username=testuser&Password=testpass"
+    aiointercept_mock.get(url, status=401)
 
-        result = await plugin._authenticate()  # pylint: disable=protected-access
-        assert not result
+    result = await plugin._authenticate()  # pylint: disable=protected-access
+    assert not result
 
     await plugin.session.close()
 
@@ -444,35 +433,34 @@ async def test_getplayingtrack_no_base_url():
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_success(jriver_plugin_with_session):  # pylint: disable=redefined-outer-name
+async def test_getplayingtrack_success(jriver_plugin_with_session, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test successful getplayingtrack"""
     plugin = jriver_plugin_with_session
     plugin.base_url = "http://localhost:52199/MCWS/v1"
     plugin.token = "testtoken"
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # aiointercept matches the URL pattern, including query parameters
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info?Token=testtoken",
-            body="""<Response Status="OK">
-                        <Item Name="State">Playing</Item>
-                        <Item Name="Artist">The Beatles</Item>
-                        <Item Name="Album">Abbey Road</Item>
-                        <Item Name="Name">Come Together</Item>
-                        <Item Name="DurationMS">240000</Item>
-                      </Response>""",
-        )
+    # aiointercept matches the URL pattern, including query parameters
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Playback/Info?Token=testtoken",
+        body="""<Response Status="OK">
+                    <Item Name="State">Playing</Item>
+                    <Item Name="Artist">The Beatles</Item>
+                    <Item Name="Album">Abbey Road</Item>
+                    <Item Name="Name">Come Together</Item>
+                    <Item Name="DurationMS">240000</Item>
+                  </Response>""",
+    )
 
-        result = await plugin.getplayingtrack()
+    result = await plugin.getplayingtrack()
 
-        assert result["artist"] == "The Beatles"
-        assert result["album"] == "Abbey Road"
-        assert result["title"] == "Come Together"
-        assert result["duration"] == 240  # 240000ms / 1000
+    assert result["artist"] == "The Beatles"
+    assert result["album"] == "Abbey Road"
+    assert result["title"] == "Come Together"
+    assert result["duration"] == 240  # 240000ms / 1000
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_minimal_data():
+async def test_getplayingtrack_minimal_data(aiointercept_mock):
     """Test getplayingtrack with minimal data"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -480,28 +468,27 @@ async def test_getplayingtrack_minimal_data():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info",
-            body="""
-              <Response Status="OK">
-                  <Item Name="Name">Unknown Track</Item>
-              </Response>
-              """,
-        )
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Playback/Info",
+        body="""
+          <Response Status="OK">
+              <Item Name="Name">Unknown Track</Item>
+          </Response>
+          """,
+    )
 
-        result = await plugin.getplayingtrack()
+    result = await plugin.getplayingtrack()
 
-        assert result["title"] == "Unknown Track"
-        assert result.get("artist") is None
-        assert result.get("album") is None
-        assert result.get("duration") is None
+    assert result["title"] == "Unknown Track"
+    assert result.get("artist") is None
+    assert result.get("album") is None
+    assert result.get("duration") is None
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_http_error():
+async def test_getplayingtrack_http_error(aiointercept_mock):
     """Test getplayingtrack with HTTP error"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -509,11 +496,10 @@ async def test_getplayingtrack_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", status=500)
+    aiointercept_mock.get("http://localhost:52199/MCWS/v1/Playback/Info", status=500)
 
-        result = await plugin.getplayingtrack()
-        assert result is None
+    result = await plugin.getplayingtrack()
+    assert result is None
 
     await plugin.session.close()
 
@@ -527,11 +513,7 @@ async def test_getplayingtrack_network_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info", exception=True
-        )
-
+    with simulate_client_exception(Exception("Network error")):
         result = await plugin.getplayingtrack()
         assert result is None
 
@@ -539,7 +521,7 @@ async def test_getplayingtrack_network_error():
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_parse_error():
+async def test_getplayingtrack_parse_error(aiointercept_mock):
     """Test getplayingtrack with XML parse error"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -547,17 +529,18 @@ async def test_getplayingtrack_parse_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body="invalid xml content")
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Playback/Info", body="invalid xml content"
+    )
 
-        result = await plugin.getplayingtrack()
-        assert result == {}  # Parse errors return empty dict, not None
+    result = await plugin.getplayingtrack()
+    assert result == {}  # Parse errors return empty dict, not None
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_with_xml_declaration():
+async def test_getplayingtrack_with_xml_declaration(aiointercept_mock):
     """Test getplayingtrack with XML encoding declaration (real JRiver format)"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -565,9 +548,8 @@ async def test_getplayingtrack_with_xml_declaration():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # This simulates the actual JRiver response format with XML declaration
-        jriver_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+    # This simulates the actual JRiver response format with XML declaration
+    jriver_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Response Status="OK">
 <Item Name="ZoneID">0</Item>
 <Item Name="State">2</Item>
@@ -579,20 +561,20 @@ async def test_getplayingtrack_with_xml_declaration():
 <Item Name="Status">Playing</Item>
 </Response>"""
 
-        mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body=jriver_response)
+    aiointercept_mock.get("http://localhost:52199/MCWS/v1/Playback/Info", body=jriver_response)
 
-        result = await plugin.getplayingtrack()
-        assert result is not None
-        assert result["artist"] == "Information Society"
-        assert result["album"] == "Don't Be Afraid"
-        assert result["title"] == "Are 'Friends' Electric? 2.0"
-        assert result["duration"] == 341  # 341342ms / 1000
+    result = await plugin.getplayingtrack()
+    assert result is not None
+    assert result["artist"] == "Information Society"
+    assert result["album"] == "Don't Be Afraid"
+    assert result["title"] == "Are 'Friends' Electric? 2.0"
+    assert result["duration"] == 341  # 341342ms / 1000
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_with_token():
+async def test_getplayingtrack_with_token(aiointercept_mock):
     """Test getplayingtrack includes token in request"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -601,20 +583,19 @@ async def test_getplayingtrack_with_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # aiointercept matches the exact URL including query parameters
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123",
-            body='<Response Status="OK"></Response>',
-        )
+    # aiointercept matches the exact URL including query parameters
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123",
+        body='<Response Status="OK"></Response>',
+    )
 
-        await plugin.getplayingtrack()
+    await plugin.getplayingtrack()
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_without_token():
+async def test_getplayingtrack_without_token(aiointercept_mock):
     """Test getplayingtrack without token"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -623,20 +604,19 @@ async def test_getplayingtrack_without_token():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # aiointercept matches the exact URL without query parameters
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info",
-            body='<Response Status="OK"></Response>',
-        )
+    # aiointercept matches the exact URL without query parameters
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Playback/Info",
+        body='<Response Status="OK"></Response>',
+    )
 
-        await plugin.getplayingtrack()
+    await plugin.getplayingtrack()
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_with_access_key():
+async def test_getplayingtrack_with_access_key(aiointercept_mock):
     """Test getplayingtrack includes access_key in request"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -645,20 +625,19 @@ async def test_getplayingtrack_with_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # aiointercept matches the exact URL including query parameters
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/Playback/Info?AccessKey=myaccesskey123",
-            body='<Response Status="OK"></Response>',
-        )
+    # aiointercept matches the exact URL including query parameters
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Playback/Info?AccessKey=myaccesskey123",
+        body='<Response Status="OK"></Response>',
+    )
 
-        await plugin.getplayingtrack()
+    await plugin.getplayingtrack()
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_with_token_and_access_key():
+async def test_getplayingtrack_with_token_and_access_key(aiointercept_mock):
     """Test getplayingtrack includes both token and access_key in request"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -668,19 +647,18 @@ async def test_getplayingtrack_with_token_and_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # aiointercept matches the exact URL including query parameters
-        # Note: order of parameters in URL may vary, so we test the call was made correctly
-        url = "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123&AccessKey=myaccesskey123"  # pylint: disable=line-too-long
-        mock_resp.get(url, body='<Response Status="OK"></Response>')
+    # aiointercept matches the exact URL including query parameters
+    # Note: order of parameters in URL may vary, so we test the call was made correctly
+    url = "http://localhost:52199/MCWS/v1/Playback/Info?Token=mytoken123&AccessKey=myaccesskey123"  # pylint: disable=line-too-long
+    aiointercept_mock.get(url, body='<Response Status="OK"></Response>')
 
-        await plugin.getplayingtrack()
+    await plugin.getplayingtrack()
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_get_filename_with_access_key():
+async def test_get_filename_with_access_key(aiointercept_mock):
     """Test _get_filename includes access_key in request"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -689,23 +667,22 @@ async def test_get_filename_with_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        url = "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&AccessKey=myaccesskey123"
-        mock_resp.get(
-            url,
-            body="""<Response Status="OK">
-                        <Item Name="Filename">test.mp3</Item>
-                      </Response>""",
-        )
+    url = "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&AccessKey=myaccesskey123"
+    aiointercept_mock.get(
+        url,
+        body="""<Response Status="OK">
+                    <Item Name="Filename">test.mp3</Item>
+                  </Response>""",
+    )
 
-        result = await plugin._get_filename("12345")  # pylint: disable=protected-access
-        assert result == "test.mp3"
+    result = await plugin._get_filename("12345")  # pylint: disable=protected-access
+    assert result == "test.mp3"
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_get_filename_with_token_and_access_key():
+async def test_get_filename_with_token_and_access_key(aiointercept_mock):
     """Test _get_filename includes both token and access_key in request"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -715,20 +692,19 @@ async def test_get_filename_with_token_and_access_key():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        url = (
-            "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&"
-            "Token=mytoken123&AccessKey=myaccesskey123"
-        )
-        mock_resp.get(
-            url,
-            body="""<Response Status="OK">
-                        <Item Name="Filename">test.mp3</Item>
-                      </Response>""",
-        )
+    url = (
+        "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&"
+        "Token=mytoken123&AccessKey=myaccesskey123"
+    )
+    aiointercept_mock.get(
+        url,
+        body="""<Response Status="OK">
+                    <Item Name="Filename">test.mp3</Item>
+                  </Response>""",
+    )
 
-        result = await plugin._get_filename("12345")  # pylint: disable=protected-access
-        assert result == "test.mp3"
+    result = await plugin._get_filename("12345")  # pylint: disable=protected-access
+    assert result == "test.mp3"
 
     await plugin.session.close()
 
@@ -860,29 +836,28 @@ def test_ipv6_url_construction():
 
 
 @pytest.mark.asyncio
-async def test_get_filename_success(jriver_plugin_with_session):  # pylint: disable=redefined-outer-name
+async def test_get_filename_success(jriver_plugin_with_session, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test successful filename retrieval"""
     plugin = jriver_plugin_with_session
     plugin.base_url = "http://localhost:52199/MCWS/v1"
     plugin.token = "testtoken"
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&Token=testtoken",
-            body="""<Response Status="OK">
-                        <Item Name="FileKey">12345</Item>
-                        <Item Name="Name">Come Together</Item>
-                        <Item Name="Artist">The Beatles</Item>
-                        <Item Name="Filename">C:\\Music\\The Beatles\\Abbey Road\\Come Together.mp3</Item>
-                      </Response>""",
-        )
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345&Token=testtoken",
+        body="""<Response Status="OK">
+                    <Item Name="FileKey">12345</Item>
+                    <Item Name="Name">Come Together</Item>
+                    <Item Name="Artist">The Beatles</Item>
+                    <Item Name="Filename">C:\\Music\\The Beatles\\Abbey Road\\Come Together.mp3</Item>
+                  </Response>""",
+    )
 
-        result = await plugin._get_filename("12345")  # pylint: disable=protected-access
-        assert result == "C:\\Music\\The Beatles\\Abbey Road\\Come Together.mp3"
+    result = await plugin._get_filename("12345")  # pylint: disable=protected-access
+    assert result == "C:\\Music\\The Beatles\\Abbey Road\\Come Together.mp3"
 
 
 @pytest.mark.asyncio
-async def test_get_filename_not_found():
+async def test_get_filename_not_found(aiointercept_mock):
     """Test filename retrieval when no filename in response"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -890,25 +865,24 @@ async def test_get_filename_not_found():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
-            body="""
-              <Response Status="OK">
-                  <Item Name="FileKey">12345</Item>
-                  <Item Name="Name">Come Together</Item>
-              </Response>
-              """,
-        )
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/File/GetInfo?File=12345",
+        body="""
+          <Response Status="OK">
+              <Item Name="FileKey">12345</Item>
+              <Item Name="Name">Come Together</Item>
+          </Response>
+          """,
+    )
 
-        result = await plugin._get_filename("12345")  # pylint: disable=protected-access
-        assert result is None
+    result = await plugin._get_filename("12345")  # pylint: disable=protected-access
+    assert result is None
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_get_filename_http_error():
+async def test_get_filename_http_error(aiointercept_mock):
     """Test filename retrieval with HTTP error"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -916,17 +890,16 @@ async def test_get_filename_http_error():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get("http://localhost:52199/MCWS/v1/File/GetInfo?File=12345", status=404)
+    aiointercept_mock.get("http://localhost:52199/MCWS/v1/File/GetInfo?File=12345", status=404)
 
-        result = await plugin._get_filename("12345")  # pylint: disable=protected-access
-        assert result is None
+    result = await plugin._get_filename("12345")  # pylint: disable=protected-access
+    assert result is None
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_get_filename_mpl_format():
+async def test_get_filename_mpl_format(aiointercept_mock):
     """Test _get_filename with MPL format response (real JRiver format)"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -934,9 +907,8 @@ async def test_get_filename_mpl_format():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # This simulates the actual JRiver MPL response format
-        mpl_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+    # This simulates the actual JRiver MPL response format
+    mpl_response = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <MPL Version="2.0" Title="MCWS - Files - 6096105472" PathSeparator="/">
 <Item>
 <Field Name="Key">477</Field>
@@ -947,16 +919,18 @@ async def test_get_filename_mpl_format():
 </Item>
 </MPL>"""
 
-        mock_resp.get("http://localhost:52199/MCWS/v1/File/GetInfo?File=477", body=mpl_response)
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/File/GetInfo?File=477", body=mpl_response
+    )
 
-        result = await plugin._get_filename("477")  # pylint: disable=protected-access
-        assert result == "/Users/aw/Music/Artist/Album/Song.mp3"
+    result = await plugin._get_filename("477")  # pylint: disable=protected-access
+    assert result == "/Users/aw/Music/Artist/Album/Song.mp3"
 
     await plugin.session.close()
 
 
 @pytest.mark.asyncio
-async def test_get_filename_response_format():
+async def test_get_filename_response_format(aiointercept_mock):
     """Test _get_filename with Response format (compatibility)"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -964,19 +938,20 @@ async def test_get_filename_response_format():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # Test the old Response format for backwards compatibility
-        response_format = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+    # Test the old Response format for backwards compatibility
+    response_format = """<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Response Status="OK">
 <Item Name="FileKey">477</Item>
 <Item Name="Filename">/Users/aw/Music/Artist/Album/Song.mp3</Item>
 <Item Name="Name">Song Title</Item>
 </Response>"""
 
-        mock_resp.get("http://localhost:52199/MCWS/v1/File/GetInfo?File=477", body=response_format)
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/File/GetInfo?File=477", body=response_format
+    )
 
-        result = await plugin._get_filename("477")  # pylint: disable=protected-access
-        assert result == "/Users/aw/Music/Artist/Album/Song.mp3"
+    result = await plugin._get_filename("477")  # pylint: disable=protected-access
+    assert result == "/Users/aw/Music/Artist/Album/Song.mp3"
 
     await plugin.session.close()
 
@@ -1092,7 +1067,7 @@ async def test_getplayingtrack_timeout():
 
 
 @pytest.mark.asyncio
-async def test_getplayingtrack_xml_none_safety():
+async def test_getplayingtrack_xml_none_safety(aiointercept_mock):
     """Test getplayingtrack with XML parsing error (safety check)"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -1100,13 +1075,12 @@ async def test_getplayingtrack_xml_none_safety():
     # Create real aiohttp session for testing
     plugin.session = aiohttp.ClientSession()
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # Return completely empty response that will cause XML parsing error
-        mock_resp.get("http://localhost:52199/MCWS/v1/Playback/Info", body="")
+    # Return completely empty response that will cause XML parsing error
+    aiointercept_mock.get("http://localhost:52199/MCWS/v1/Playback/Info", body="")
 
-        result = await plugin.getplayingtrack()
-        # Should return empty dict when XML parsing fails, not crash
-        assert result == {}
+    result = await plugin.getplayingtrack()
+    # Should return empty dict when XML parsing fails, not crash
+    assert result == {}
 
     await plugin.session.close()
 
@@ -1147,7 +1121,7 @@ async def test_get_filename_timeout():
 
 
 @pytest.mark.asyncio
-async def test_auto_recovery_success():
+async def test_auto_recovery_success(aiointercept_mock):
     """Test successful auto-recovery when JRiver comes back online"""
     plugin = nowplaying.inputs.jriver.Plugin()  # pylint: disable=no-member
     plugin.base_url = "http://localhost:52199/MCWS/v1"
@@ -1158,19 +1132,18 @@ async def test_auto_recovery_success():
         patch.object(plugin, "_test_connection", return_value=True),
         patch.object(plugin, "_authenticate", return_value=True),
     ):
-        async with aiointercept(mock_external_urls=True) as mock_resp:
-            mock_resp.get(
-                "http://localhost:52199/MCWS/v1/Playback/Info",
-                body='<Response><Item Name="Artist">Test Artist</Item>'
-                '<Item Name="Name">Test Title</Item></Response>',
-            )
+        aiointercept_mock.get(
+            "http://localhost:52199/MCWS/v1/Playback/Info",
+            body='<Response><Item Name="Artist">Test Artist</Item>'
+            '<Item Name="Name">Test Title</Item></Response>',
+        )
 
-            result = await plugin.getplayingtrack()
+        result = await plugin.getplayingtrack()
 
-            assert result is not None
-            assert result["artist"] == "Test Artist"
-            assert result["title"] == "Test Title"
-            assert not plugin._connection_failed  # pylint: disable=protected-access
+        assert result is not None
+        assert result["artist"] == "Test Artist"
+        assert result["title"] == "Test Title"
+        assert not plugin._connection_failed  # pylint: disable=protected-access
 
     await plugin.session.close()
 

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest.mock
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.inputs.serato
 import nowplaying.utils.sqlite
@@ -553,7 +553,7 @@ async def test_streaming_track_artwork(bootstrap, serato_master_db):  # pylint: 
 
         fake_image = b"\x89PNG\r\n\x1a\n"  # PNG magic bytes
 
-        with aioresponses() as mock_resp:
+        async with aiointercept(mock_external_urls=True) as mock_resp:
             mock_resp.get(artwork_url, status=200, body=fake_image)
 
             try:
@@ -601,7 +601,7 @@ async def test_streaming_track_is_video(bootstrap, serato_master_db):  # pylint:
         plugin.setmixmode("newest")
         await plugin.start()
 
-        with aioresponses() as mock_resp:
+        async with aiointercept(mock_external_urls=True) as mock_resp:
             mock_resp.get("https://example.com/artwork.jpg", status=200, body=b"\x89PNG\r\n\x1a\n")
 
             try:

--- a/tests/test_serato.py
+++ b/tests/test_serato.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest.mock
 
 import pytest
-from aiointercept import aiointercept
 
 import nowplaying.inputs.serato
 import nowplaying.utils.sqlite
@@ -516,7 +515,7 @@ async def test_require_played_false_includes_unplayed(bootstrap, serato_master_d
 
 
 @pytest.mark.asyncio
-async def test_streaming_track_artwork(bootstrap, serato_master_db):  # pylint: disable=redefined-outer-name
+async def test_streaming_track_artwork(bootstrap, serato_master_db, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test that streaming tracks get coverimageraw from type_specific_data, not filename"""
     artwork_url = "https://example.com/artwork.jpg"
     type_specific_data = '{"cover_id": "' + artwork_url + '", "is_video": false}'
@@ -553,24 +552,23 @@ async def test_streaming_track_artwork(bootstrap, serato_master_db):  # pylint: 
 
         fake_image = b"\x89PNG\r\n\x1a\n"  # PNG magic bytes
 
-        async with aiointercept(mock_external_urls=True) as mock_resp:
-            mock_resp.get(artwork_url, status=200, body=fake_image)
+        aiointercept_mock.get(artwork_url, status=200, body=fake_image)
 
-            try:
-                track = await plugin.getplayingtrack()
+        try:
+            track = await plugin.getplayingtrack()
 
-                assert track is not None
-                assert track["artist"] == "Streaming Artist"
-                assert "filename" not in track
-                assert "_streaming_artwork_url" not in track
-                assert track.get("coverimageraw") == fake_image
+            assert track is not None
+            assert track["artist"] == "Streaming Artist"
+            assert "filename" not in track
+            assert "_streaming_artwork_url" not in track
+            assert track.get("coverimageraw") == fake_image
 
-            finally:
-                await plugin.stop()
+        finally:
+            await plugin.stop()
 
 
 @pytest.mark.asyncio
-async def test_streaming_track_is_video(bootstrap, serato_master_db):  # pylint: disable=redefined-outer-name
+async def test_streaming_track_is_video(bootstrap, serato_master_db, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test that streaming tracks with is_video=true set has_video on the track"""
     type_specific_data = '{"cover_id": "https://example.com/artwork.jpg", "is_video": true}'
 
@@ -601,14 +599,15 @@ async def test_streaming_track_is_video(bootstrap, serato_master_db):  # pylint:
         plugin.setmixmode("newest")
         await plugin.start()
 
-        async with aiointercept(mock_external_urls=True) as mock_resp:
-            mock_resp.get("https://example.com/artwork.jpg", status=200, body=b"\x89PNG\r\n\x1a\n")
+        aiointercept_mock.get(
+            "https://example.com/artwork.jpg", status=200, body=b"\x89PNG\r\n\x1a\n"
+        )
 
-            try:
-                track = await plugin.getplayingtrack()
+        try:
+            track = await plugin.getplayingtrack()
 
-                assert track is not None
-                assert track.get("has_video") is True
+            assert track is not None
+            assert track.get("has_video") is True
 
-            finally:
-                await plugin.stop()
+        finally:
+            await plugin.stop()

--- a/tests/twitch/test_twitch_oauth2.py
+++ b/tests/twitch/test_twitch_oauth2.py
@@ -6,8 +6,7 @@ import hashlib
 from unittest.mock import patch
 
 import pytest
-import pytest_asyncio
-from aiointercept import aiointercept
+from utils_aiohttp import simulate_client_exception  # pylint: disable=import-error
 
 import nowplaying.twitch.oauth2  # pylint: disable=import-error,no-name-in-module
 from nowplaying.twitch.constants import API_HOST, OAUTH_HOST
@@ -35,13 +34,6 @@ def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
     oauth = configured_oauth
     oauth._generate_pkce_parameters()  # pylint: disable=protected-access
     return oauth
-
-
-@pytest_asyncio.fixture
-async def mock_responses():
-    """Fixture that provides aiointercept for mocking HTTP calls."""
-    async with aiointercept(mock_external_urls=True) as mock:
-        yield mock
 
 
 # Basic OAuth2 functionality tests
@@ -210,7 +202,7 @@ def test_open_browser_for_auth_scenarios(mock_open, configured_oauth, browser_su
 @pytest.mark.asyncio
 async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-outer-name
     configured_oauth,
-    mock_responses,
+    aiointercept_mock,
     has_verifier,
     state_matches,
     response_status,
@@ -228,7 +220,7 @@ async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-o
 
     if should_succeed:
         # Success case - setup mock and verify result
-        mock_responses.post(
+        aiointercept_mock.post(
             f"{OAUTH_HOST}/oauth2/token", status=response_status, payload=response_data
         )
 
@@ -239,7 +231,7 @@ async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-o
 
     elif response_status != 200:
         # HTTP error case
-        mock_responses.post(f"{OAUTH_HOST}/oauth2/token", status=response_status, body="Error")
+        aiointercept_mock.post(f"{OAUTH_HOST}/oauth2/token", status=response_status, body="Error")
 
         with pytest.raises(Exception):
             await oauth.exchange_code_for_token("test_code", test_state)
@@ -268,7 +260,7 @@ async def test_exchange_code_for_token_scenarios(  # pylint: disable=redefined-o
 async def test_refresh_access_token_scenarios(
     bootstrap,
     configured_oauth,
-    mock_responses,
+    aiointercept_mock,
     has_refresh_token,
     response_status,
     response_data,
@@ -284,7 +276,7 @@ async def test_refresh_access_token_scenarios(
         refresh_token = None
 
     if should_succeed:
-        mock_responses.post(
+        aiointercept_mock.post(
             f"{OAUTH_HOST}/oauth2/token", status=response_status, payload=response_data
         )
 
@@ -295,7 +287,9 @@ async def test_refresh_access_token_scenarios(
     else:
         if has_refresh_token:
             # HTTP error case
-            mock_responses.post(f"{OAUTH_HOST}/oauth2/token", status=response_status, body="Error")
+            aiointercept_mock.post(
+                f"{OAUTH_HOST}/oauth2/token", status=response_status, body="Error"
+            )
 
         with pytest.raises((ValueError, Exception)):
             await oauth.refresh_access_token_async(refresh_token)
@@ -317,7 +311,7 @@ async def test_refresh_access_token_scenarios(
 @pytest.mark.asyncio
 async def test_validate_token_scenarios(
     configured_oauth,
-    mock_responses,
+    aiointercept_mock,
     response_status,  # pylint: disable=redefined-outer-name
     response_data,
     expected_result,
@@ -326,11 +320,13 @@ async def test_validate_token_scenarios(
     oauth = configured_oauth
 
     if response_status == 200:
-        mock_responses.get(
+        aiointercept_mock.get(
             f"{OAUTH_HOST}/oauth2/validate", status=response_status, payload=response_data
         )
     else:
-        mock_responses.get(f"{OAUTH_HOST}/oauth2/validate", status=response_status, body="Error")
+        aiointercept_mock.get(
+            f"{OAUTH_HOST}/oauth2/validate", status=response_status, body="Error"
+        )
 
     result = await oauth.validate_token_async("test_token")
     assert result == expected_result
@@ -351,15 +347,15 @@ async def test_validate_token_scenarios(
 )
 @pytest.mark.asyncio
 async def test_get_user_info_scenarios(
-    configured_oauth, mock_responses, response_status, response_data, expected_result
+    configured_oauth, aiointercept_mock, response_status, response_data, expected_result
 ):
     """Test user info retrieval with various responses."""
     oauth = configured_oauth
 
     if response_status == 200:
-        mock_responses.get(f"{API_HOST}/users", status=response_status, payload=response_data)
+        aiointercept_mock.get(f"{API_HOST}/users", status=response_status, payload=response_data)
     else:
-        mock_responses.get(f"{API_HOST}/users", status=response_status, body="Error")
+        aiointercept_mock.get(f"{API_HOST}/users", status=response_status, body="Error")
 
     result = await oauth.get_user_info_async("test_token")
     assert result == expected_result
@@ -417,7 +413,7 @@ def test_clear_stored_tokens(configured_oauth):  # pylint: disable=redefined-out
 )
 @pytest.mark.asyncio
 async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, too-many-arguments
-    bootstrap, mock_responses, has_client_id, has_token, response_status, should_clear_tokens
+    bootstrap, aiointercept_mock, has_client_id, has_token, response_status, should_clear_tokens
 ):
     """Test token revocation with various scenarios."""
     config = bootstrap
@@ -432,7 +428,7 @@ async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, 
 
     if has_client_id and has_token:
         # Setup mock response for cases where we have credentials
-        mock_responses.post(f"{OAUTH_HOST}/oauth2/revoke", status=response_status)
+        aiointercept_mock.post(f"{OAUTH_HOST}/oauth2/revoke", status=response_status)
 
     # Should not raise exception in any case
     await oauth.revoke_token(token_to_revoke)
@@ -451,29 +447,25 @@ async def test_revoke_token_scenarios(  # pylint: disable=redefined-outer-name, 
 
 
 @pytest.mark.asyncio
-async def test_json_parsing_error(oauth_with_pkce, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_json_parsing_error(oauth_with_pkce, aiointercept_mock):  # pylint: disable=redefined-outer-name
     """Test handling of JSON parsing errors."""
     oauth = oauth_with_pkce
 
     # Mock response with invalid JSON
-    mock_responses.post(f"{OAUTH_HOST}/oauth2/token", status=200, body="invalid json content")
+    aiointercept_mock.post(f"{OAUTH_HOST}/oauth2/token", status=200, body="invalid json content")
 
     with pytest.raises(Exception):
         await oauth.exchange_code_for_token("test_code")
 
 
 @pytest.mark.asyncio
-async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disable=redefined-outer-name
+async def test_network_timeout(oauth_with_pkce):  # pylint: disable=redefined-outer-name
     """Test network timeout handling."""
     oauth = oauth_with_pkce
 
-    # aiointercept can only simulate a dropped connection, not a specific
-    # exception type, so this covers network failure generally rather than
-    # timeouts specifically.
-    mock_responses.post(f"{OAUTH_HOST}/oauth2/token", exception=True)
-
-    with pytest.raises(Exception):
-        await oauth.exchange_code_for_token("test_code", oauth.state)
+    with simulate_client_exception(TimeoutError("Request timed out")):
+        with pytest.raises(TimeoutError):
+            await oauth.exchange_code_for_token("test_code", oauth.state)
 
 
 def test_pkce_parameter_uniqueness(configured_oauth):  # pylint: disable=redefined-outer-name

--- a/tests/twitch/test_twitch_oauth2.py
+++ b/tests/twitch/test_twitch_oauth2.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Unit tests for Twitch OAuth2 functionality - following Kick OAuth2 test pattern."""
 
-import asyncio
 import base64
 import hashlib
 from unittest.mock import patch
 
 import pytest
-from aioresponses import aioresponses
+import pytest_asyncio
+from aiointercept import aiointercept
 
 import nowplaying.twitch.oauth2  # pylint: disable=import-error,no-name-in-module
 from nowplaying.twitch.constants import API_HOST, OAUTH_HOST
@@ -37,10 +37,10 @@ def oauth_with_pkce(configured_oauth):  # pylint: disable=redefined-outer-name
     return oauth
 
 
-@pytest.fixture
-def mock_responses():
-    """Fixture that provides aioresponses for mocking HTTP calls."""
-    with aioresponses() as mock:
+@pytest_asyncio.fixture
+async def mock_responses():
+    """Fixture that provides aiointercept for mocking HTTP calls."""
+    async with aiointercept(mock_external_urls=True) as mock:
         yield mock
 
 
@@ -467,10 +467,12 @@ async def test_network_timeout(oauth_with_pkce, mock_responses):  # pylint: disa
     """Test network timeout handling."""
     oauth = oauth_with_pkce
 
-    # Mock a timeout by using an exception
-    mock_responses.post(f"{OAUTH_HOST}/oauth2/token", exception=TimeoutError("Request timed out"))
+    # aiointercept can only simulate a dropped connection, not a specific
+    # exception type, so this covers network failure generally rather than
+    # timeouts specifically.
+    mock_responses.post(f"{OAUTH_HOST}/oauth2/token", exception=True)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(Exception):
         await oauth.exchange_code_for_token("test_code", oauth.state)
 
 

--- a/tests/twitch/test_twitch_utils.py
+++ b/tests/twitch/test_twitch_utils.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from aiointercept import aiointercept
+from utils_aiohttp import simulate_client_exception  # pylint: disable=import-error
 
 import nowplaying.twitch.oauth2
 import nowplaying.twitch.utils
@@ -351,46 +351,44 @@ async def test_cache_token_del(bootstrap):
 
 # User image retrieval tests using aiointercept
 @pytest.mark.asyncio
-async def test_get_user_image_success():
+async def test_get_user_image_success(aiointercept_mock):
     """Test successful user image retrieval."""
     mock_oauth = Mock()
     mock_oauth.access_token = "test_token"
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        # Mock user data response
-        mock_resp.get(
-            "https://api.twitch.tv/helix/users?login=test_user",
-            payload={"data": [{"profile_image_url": "https://example.com/image.png"}]},
-        )
+    # Mock user data response
+    aiointercept_mock.get(
+        "https://api.twitch.tv/helix/users?login=test_user",
+        payload={"data": [{"profile_image_url": "https://example.com/image.png"}]},
+    )
 
-        # Mock image response
-        mock_resp.get("https://example.com/image.png", body=b"fake_image_data")
+    # Mock image response
+    aiointercept_mock.get("https://example.com/image.png", body=b"fake_image_data")
 
-        with patch("nowplaying.utils.image2png", return_value=b"png_data") as mock_image2png:
-            result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "test_user")
+    with patch("nowplaying.utils.image2png", return_value=b"png_data") as mock_image2png:
+        result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "test_user")
 
-            assert result == b"png_data"
-            mock_image2png.assert_called_once_with(b"fake_image_data")
+        assert result == b"png_data"
+        mock_image2png.assert_called_once_with(b"fake_image_data")
 
 
 @pytest.mark.asyncio
-async def test_get_user_image_no_user():
+async def test_get_user_image_no_user(aiointercept_mock):
     """Test user image retrieval with no user found."""
     mock_oauth = Mock()
     mock_oauth.access_token = "test_token"
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "https://api.twitch.tv/helix/users?login=nonexistent_user",
-            payload={"data": []},  # No user found
-        )
+    aiointercept_mock.get(
+        "https://api.twitch.tv/helix/users?login=nonexistent_user",
+        payload={"data": []},  # No user found
+    )
 
-        result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "nonexistent_user")
-        assert result is None
+    result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "nonexistent_user")
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -401,11 +399,6 @@ async def test_get_user_image_error():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    async with aiointercept(mock_external_urls=True) as mock_resp:
-        mock_resp.get(
-            "https://api.twitch.tv/helix/users?login=test_user",
-            exception=True,
-        )
-
+    with simulate_client_exception(Exception("Network error")):
         result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "test_user")
         assert result is None

--- a/tests/twitch/test_twitch_utils.py
+++ b/tests/twitch/test_twitch_utils.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 import nowplaying.twitch.oauth2
 import nowplaying.twitch.utils
@@ -349,7 +349,7 @@ async def test_cache_token_del(bootstrap):
         assert bootstrap.cparser.value("twitchbot/refreshtoken") is None
 
 
-# User image retrieval tests using aioresponses
+# User image retrieval tests using aiointercept
 @pytest.mark.asyncio
 async def test_get_user_image_success():
     """Test successful user image retrieval."""
@@ -358,7 +358,7 @@ async def test_get_user_image_success():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         # Mock user data response
         mock_resp.get(
             "https://api.twitch.tv/helix/users?login=test_user",
@@ -383,7 +383,7 @@ async def test_get_user_image_no_user():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "https://api.twitch.tv/helix/users?login=nonexistent_user",
             payload={"data": []},  # No user found
@@ -401,10 +401,10 @@ async def test_get_user_image_error():
     mock_oauth.client_id = "test_client"
     mock_oauth.api_host = "https://api.twitch.tv/helix"
 
-    with aioresponses() as mock_resp:
+    async with aiointercept(mock_external_urls=True) as mock_resp:
         mock_resp.get(
             "https://api.twitch.tv/helix/users?login=test_user",
-            exception=Exception("Network error"),
+            exception=True,
         )
 
         result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "test_user")

--- a/tests/utils_aiohttp.py
+++ b/tests/utils_aiohttp.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Test utilities for simulating specific aiohttp client-side exceptions.
+
+aiointercept (unlike aioresponses) can only simulate a dropped connection via
+exception=True, which always surfaces to the client as the base
+aiohttp.ClientConnectionError. Production code that branches on a more
+specific exception type (aiohttp.ClientConnectorError, TimeoutError,
+aiohttp.ServerTimeoutError, ...) can't be exercised precisely through that
+mechanism, so tests that need to validate one of those specific except
+branches should patch the request call directly with simulate_client_exception
+instead.
+"""
+
+import contextlib
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+
+@contextlib.contextmanager
+def simulate_client_exception(exc: BaseException) -> Generator[None]:
+    """Make the next aiohttp.ClientSession request raise *exc*.
+
+    Patches aiohttp.ClientSession._request directly, so no real socket
+    connection is attempted and the raised exception's type is preserved
+    exactly, unlike aiointercept's exception=True which always raises
+    aiohttp.ClientConnectionError.
+    """
+    with patch("aiohttp.ClientSession._request", AsyncMock(side_effect=exc)):
+        yield


### PR DESCRIPTION
## Summary by Sourcery

Replace aioresponses-based HTTP mocking with aiointercept-based fixtures and utilities across tests to improve reliability of async network simulations.

CI:
- Increase timeout limits for macOS, Windows, and Linux test workflows to reduce flakiness in long-running test suites.

Tests:
- Update JRiver, Last.fm, TheAudioDB, remote notification, Kick, Twitch, and Serato tests to use shared aiointercept fixtures instead of aioresponses for HTTP mocking.
- Introduce simulate_client_exception helper to precisely exercise aiohttp client-side exception branches in tests.
- Add a shared session-scoped aiointercept fixture and a per-test clearing aiointercept_mock fixture to stabilize async HTTP mocking across platforms.

Chores:
- Adjust pytest-asyncio fixtures to use explicit loop_scope settings for better event loop management in async tests.