### PR TITLE
feat: add song-request queue REST API for Lumia

### DIFF
--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -30,6 +30,7 @@ from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 from nowplaying.webserver.gifwords_websocket import GifwordsWebSocketHandler
 from nowplaying.webserver.guessgame_websocket import GuessgameWebSocketHandler
 from nowplaying.webserver.images_websocket import ImagesWebSocketHandler
+from nowplaying.webserver.requests_handlers import RequestsHandler
 from nowplaying.webserver.static_handlers import StaticContentHandler
 
 #
@@ -137,6 +138,8 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             metadata_key=METADATA_KEY,
             http_session_key=HTTP_SESSION_KEY,
         )
+
+        self.requests_handler = RequestsHandler(config_key=CONFIG_KEY)
 
         while not enabled and not nowplaying.utils.safe_stopevent_check(self.stopevent):
             try:
@@ -742,6 +745,10 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                 web.get("/request.htm", self.static_handler.requesterlaunch_htm_handler),
                 web.get("/internals", self.internals),
                 web.get("/v1/status", self.status),
+                web.get("/v1/requests", self.requests_handler.get_requests_handler),
+                web.post("/v1/requests", self.requests_handler.post_requests_handler),
+                web.delete("/v1/requests", self.requests_handler.clear_requests_handler),
+                web.delete("/v1/requests/{reqid}", self.requests_handler.delete_request_handler),
                 web.get("/ws", self.websocket_handler),
                 web.get("/wsstream", self.websocket_streamer),
                 web.get("/wsartistfanartstream", self.websocket_artistfanart_streamer),

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -114,17 +114,20 @@ artist
 """
 
 WEIRDAL_RE = re.compile(r'"weird al"', re.IGNORECASE)
+# These run only after user_track_request collapses whitespace to single spaces,
+# so separators are literal spaces rather than \s+/\s* next to a lazy capture
+# (that adjacency is a polynomial-ReDoS pattern; see CWE-1333).
 ARTIST_TITLE_RE = re.compile(
-    r'^\s*(?P<artist>.*?)\s+[-]+\s+"?(?P<title>.*?)"?\s*(?:for @(?P<requestedfor>\S+))?$'
+    r'^(?P<artist>.*?) [-]+ "?(?P<title>.*?)"?(?: for @(?P<requestedfor>\S+))?$'
 )
 TITLE_ARTIST_RE = re.compile(
-    r'^\s*"(?P<title>.*?)"\s+[-by]+\s+(?P<artist>.*?)\s*(?:for @(?P<requestedfor>\S+))?$'
+    r'^"(?P<title>.*?)" [-by]+ (?P<artist>.*?)(?: for @(?P<requestedfor>\S+))?$'
 )
 TITLE_RE = re.compile(r'^\s*"(?P<title>.*?)"\s*(?:for @(?P<requestedfor>\S+))?$')
 TWOFERTITLE_RE = re.compile(r'^\s*"?(?P<title>.*?)"?\s*(?:for @(?P<requestedfor>\S+))?$')
 
-# Bound parser input length: these patterns backtrack polynomially, so an
-# unbounded untrusted string (chat or the request API) could be a ReDoS vector.
+# Sane upper bound on request text from chat or the request API (defense in
+# depth; keeps stored requests reasonable and caps parser work).
 MAX_REQUEST_INPUT_LENGTH = 500
 
 KLIPY_BASE_URL = "https://api.klipy.com/v2/search"
@@ -965,7 +968,8 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             user_input = user_input.replace("-", " - ")
         if user_input := WEIRDAL_RE.sub("Weird Al", user_input):
             weirdal = True
-        if user_input[0] != '"' and (atmatch := ARTIST_TITLE_RE.search(user_input)):
+        user_input = re.sub(r"\s+", " ", user_input).strip()
+        if not user_input.startswith('"') and (atmatch := ARTIST_TITLE_RE.search(user_input)):
             artist = atmatch.group("artist").strip()
             title = atmatch.group("title").strip()
             requestedfor = atmatch.group("requestedfor")

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -114,14 +114,16 @@ artist
 """
 
 WEIRDAL_RE = re.compile(r'"weird al"', re.IGNORECASE)
-# These run only after user_track_request collapses whitespace to single spaces,
-# so separators are literal spaces rather than \s+/\s* next to a lazy capture
-# (that adjacency is a polynomial-ReDoS pattern; see CWE-1333).
+# These run only after user_track_request collapses whitespace to single spaces.
+# Separators are literal spaces (not \s+/\s* next to a lazy capture), and the
+# capture-plus-delimiter prefix is wrapped in an atomic group (?>...) so the
+# split commits to the first delimiter and can't backtrack across later ones.
+# Both avoid the polynomial-ReDoS pattern CodeQL flags (CWE-1333).
 ARTIST_TITLE_RE = re.compile(
-    r'^(?P<artist>.*?) [-]+ "?(?P<title>.*?)"?(?: for @(?P<requestedfor>\S+))?$'
+    r'^(?>(?P<artist>.*?) [-]+ )"?(?P<title>.*?)"?(?: for @(?P<requestedfor>\S+))?$'
 )
 TITLE_ARTIST_RE = re.compile(
-    r'^"(?P<title>.*?)" [-by]+ (?P<artist>.*?)(?: for @(?P<requestedfor>\S+))?$'
+    r'^(?>"(?P<title>.*?)" [-by]+ )(?P<artist>.*?)(?: for @(?P<requestedfor>\S+))?$'
 )
 TITLE_RE = re.compile(r'^\s*"(?P<title>.*?)"\s*(?:for @(?P<requestedfor>\S+))?$')
 TWOFERTITLE_RE = re.compile(r'^\s*"?(?P<title>.*?)"?\s*(?:for @(?P<requestedfor>\S+))?$')

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -123,6 +123,10 @@ TITLE_ARTIST_RE = re.compile(
 TITLE_RE = re.compile(r'^\s*"(?P<title>.*?)"\s*(?:for @(?P<requestedfor>\S+))?$')
 TWOFERTITLE_RE = re.compile(r'^\s*"?(?P<title>.*?)"?\s*(?:for @(?P<requestedfor>\S+))?$')
 
+# Bound parser input length: these patterns backtrack polynomially, so an
+# unbounded untrusted string (chat or the request API) could be a ReDoS vector.
+MAX_REQUEST_INPUT_LENGTH = 500
+
 KLIPY_BASE_URL = "https://api.klipy.com/v2/search"
 
 GIFWORDS_TEXT = ["keywords", "requester", "requestdisplayname", "imageurl"]
@@ -951,6 +955,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
     ) -> TrackRequestResult:
         """generic request"""
         logging.debug("%s generic requested %s", user, user_input)
+        user_input = user_input[:MAX_REQUEST_INPUT_LENGTH]
         artist = None
         title = None
         requestedfor = None

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-lines
 
 import asyncio
+import hashlib
 import logging
 import pathlib
 import re
@@ -68,6 +69,8 @@ USERREQUEST_TEXT = [
     "user_input",
     "normalizedartist",
     "normalizedtitle",
+    "user_platform",
+    "request_origin",
 ]
 
 USERREQUEST_BLOB = ["userimage"]
@@ -318,6 +321,12 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             return text
         return ""
 
+    @staticmethod
+    def track_id(artist: str | None, title: str | None) -> str:
+        """stable per-track id shared with Lumia; derived from normalized artist + title"""
+        normalized = Requests._normalize(artist) + "|" + Requests._normalize(title)
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
     async def add_to_db(self, data: UserTrackRequest):
         """add an entry to the db"""
         if not self.databasefile.exists():
@@ -425,6 +434,24 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             nowplaying.utils.sqlite.retry_sqlite_operation(_do_erase)
         except sqlite3.OperationalError:
             logging.exception("Failed to erase request ID %s after retries", reqid)
+
+    async def erase_all(self):
+        """remove every entry from the request queue"""
+        if not self.databasefile.exists():
+            logging.error("%s does not exist, refusing to erase.", self.databasefile)
+            return
+
+        async def _do_erase_all():
+            async with aiosqlite.connect(self.databasefile, timeout=30) as connection:
+                connection.row_factory = sqlite3.Row
+                cursor = await connection.cursor()
+                await cursor.execute("DELETE FROM userrequest;")
+                await connection.commit()
+
+        try:
+            await nowplaying.utils.sqlite.retry_sqlite_operation_async(_do_erase_all)
+        except sqlite3.OperationalError:
+            logging.exception("Failed to erase all requests after retries")
 
     async def erase_gifwords_id(self, reqid: int):
         """remove entry from gifwords"""
@@ -915,7 +942,12 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         return setting
 
     async def user_track_request(
-        self, setting: TrackRequestSetting, user: str, user_input: str
+        self,
+        setting: TrackRequestSetting,
+        user: str,
+        user_input: str,
+        request_origin: str = "wnp",
+        user_platform: str | None = "twitch",
     ) -> TrackRequestResult:
         """generic request"""
         logging.debug("%s generic requested %s", user, user_input)
@@ -953,6 +985,8 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             "displayname": setting.get("displayname"),
             "user_input": user_input,
             "userimage": setting.get("userimage"),
+            "request_origin": request_origin,
+            "user_platform": user_platform,
         }
 
         await self.add_to_db(data)
@@ -967,6 +1001,77 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             newdata |= data
 
         return newdata
+
+    async def _duplicate_request_exists(
+        self, username: str, artist: str | None, title: str | None, window_seconds: int
+    ) -> bool:
+        """true if the same user already requested this normalized track within the window"""
+        if not self.databasefile.exists():
+            return False
+        normalizedartist = self._normalize(artist)
+        normalizedtitle = self._normalize(title)
+        if not normalizedartist and not normalizedtitle:
+            return False
+
+        async def _do_lookup():
+            async with aiosqlite.connect(self.databasefile, timeout=30) as connection:
+                connection.row_factory = sqlite3.Row
+                cursor = await connection.cursor()
+                await cursor.execute(
+                    "SELECT reqid FROM userrequest WHERE username=? AND normalizedartist=? "
+                    "AND normalizedtitle=? AND timestamp > datetime('now', ?) LIMIT 1",
+                    (
+                        username,
+                        normalizedartist,
+                        normalizedtitle,
+                        f"-{int(window_seconds)} seconds",
+                    ),
+                )
+                return await cursor.fetchone()
+
+        try:
+            row = await nowplaying.utils.sqlite.retry_sqlite_operation_async(_do_lookup)
+        except sqlite3.OperationalError:
+            logging.exception("Duplicate-request lookup failed")
+            return False
+        return row is not None
+
+    async def enqueue_request(
+        self,
+        requester: str,
+        request_origin: str,
+        user_platform: str | None = None,
+        query: str | None = None,
+        artist: str | None = None,
+        title: str | None = None,
+        dedup_window: int = 30,
+    ) -> TrackRequestResult:
+        """create a request from an external source, reusing the generic parser; returns the trackid"""
+        if artist and title:
+            user_input = f"{artist} - {title}"
+        elif query:
+            user_input = query
+        elif artist:
+            user_input = artist
+        elif title:
+            user_input = title
+        else:
+            return {"accepted": False, "reason": "empty request"}
+
+        if (
+            artist
+            and title
+            and await self._duplicate_request_exists(requester, artist, title, dedup_window)
+        ):
+            return {"accepted": True, "deduped": True, "track_id": self.track_id(artist, title)}
+
+        result = await self.user_track_request(
+            {}, requester, user_input, request_origin=request_origin, user_platform=user_platform
+        )
+        result["accepted"] = True
+        result["deduped"] = False
+        result["track_id"] = self.track_id(result.get("requestartist"), result.get("requesttitle"))
+        return result
 
     async def _klipy_request(self, search_terms: str) -> GifWordsTrackRequest:
         """get an image from klipy for a given set of terms"""

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -941,7 +941,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
                     break
         return setting
 
-    async def user_track_request(
+    async def user_track_request(  # pylint: disable=too-many-arguments
         self,
         setting: TrackRequestSetting,
         user: str,
@@ -1036,7 +1036,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             return False
         return row is not None
 
-    async def enqueue_request(
+    async def enqueue_request(  # pylint: disable=too-many-arguments
         self,
         requester: str,
         request_origin: str,
@@ -1046,7 +1046,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         title: str | None = None,
         dedup_window: int = 30,
     ) -> TrackRequestResult:
-        """create a request from an external source, reusing the generic parser; returns the trackid"""
+        """create a request from an external source via the generic parser"""
         if artist and title:
             user_input = f"{artist} - {title}"
         elif query:

--- a/nowplaying/types.py
+++ b/nowplaying/types.py
@@ -141,6 +141,8 @@ class UserTrackRequest(BaseTrackRequest, total=False):
     user_input: str
     normalizedartist: str
     normalizedtitle: str
+    user_platform: str | None
+    request_origin: str | None
 
     # Blob fields
     userimage: bytes | None
@@ -168,6 +170,10 @@ class TrackRequestResult(TypedDict, total=False):
     requesterimageraw: bytes | None
     requestartist: str | None
     requesttitle: str | None
+    accepted: bool
+    deduped: bool
+    track_id: str
+    reason: str
 
 
 class TrackRequestSetting(TypedDict, total=False):

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -64,6 +64,8 @@ class RequestsHandler:
         """GET /v1/requests — the current queue snapshot for Lumia to mirror"""
         if not self._authorized(request, request.query.get("secret", "")):
             return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        if not self._requests_enabled(request):
+            return web.json_response({"requests": []})
         reqs = self._requests(request)
         items = []
         async for row in reqs.get_all_generator():
@@ -87,6 +89,8 @@ class RequestsHandler:
         """DELETE /v1/requests/{reqid} — remove a single queue entry"""
         if not self._authorized(request, request.query.get("secret", "")):
             return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        if not self._requests_enabled(request):
+            return web.json_response({"error": "Requests are disabled"}, status=403)
         try:
             reqid = int(request.match_info.get("reqid", ""))
         except ValueError:
@@ -98,5 +102,7 @@ class RequestsHandler:
         """DELETE /v1/requests — clear the entire queue"""
         if not self._authorized(request, request.query.get("secret", "")):
             return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        if not self._requests_enabled(request):
+            return web.json_response({"error": "Requests are disabled"}, status=403)
         await self._requests(request).erase_all()
         return web.json_response({"cleared": True})

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""aiohttp handlers for the Lumia song-request queue API"""
+
+import asyncio
+import secrets
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+import nowplaying.trackrequests
+
+if TYPE_CHECKING:
+    import nowplaying.config
+
+
+class RequestsHandler:
+    """REST handlers exposing the request queue to external song-request sources (Lumia)"""
+
+    def __init__(self, config_key: "web.AppKey[nowplaying.config.ConfigFile]"):
+        self.config_key = config_key
+
+    def _requests(self, request: web.Request) -> "nowplaying.trackrequests.Requests":
+        return nowplaying.trackrequests.Requests(request.app[self.config_key])
+
+    def _authorized(self, request: web.Request, provided_secret: str) -> bool:
+        """reuse the webserver's shared secret (empty key disables auth)"""
+        request.app[self.config_key].get()
+        required = request.app[self.config_key].cparser.value(
+            "remote/remote_key", type=str, defaultValue=""
+        )
+        if not required:
+            return True
+        return bool(provided_secret) and secrets.compare_digest(required, provided_secret)
+
+    def _requests_enabled(self, request: web.Request) -> bool:
+        return request.app[self.config_key].cparser.value("settings/requests", type=bool)
+
+    async def post_requests_handler(self, request: web.Request) -> web.Response:
+        """POST /v1/requests — enqueue a request handed off from Lumia"""
+        try:
+            body = await request.json()
+        except ValueError:
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+        if not self._authorized(request, str(body.get("secret", ""))):
+            return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        if not self._requests_enabled(request):
+            return web.json_response({"error": "Requests are disabled"}, status=403)
+        requester = body.get("requester")
+        if not requester:
+            return web.json_response({"error": "requester is required"}, status=400)
+        result = await self._requests(request).enqueue_request(
+            requester=requester,
+            request_origin="lumia",
+            user_platform=body.get("user_platform"),
+            query=body.get("query"),
+            artist=body.get("artist"),
+            title=body.get("title"),
+        )
+        if not result.get("accepted"):
+            return web.json_response(result, status=400)
+        return web.json_response(result)
+
+    async def get_requests_handler(self, request: web.Request) -> web.Response:
+        """GET /v1/requests — the current queue snapshot for Lumia to mirror"""
+        if not self._authorized(request, request.query.get("secret", "")):
+            return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        reqs = self._requests(request)
+        items = []
+        async for row in reqs.get_all_generator():
+            items.append(
+                {
+                    "request_id": row.get("reqid"),
+                    "track_id": nowplaying.trackrequests.Requests.track_id(
+                        row.get("artist"), row.get("title")
+                    ),
+                    "artist": row.get("artist"),
+                    "title": row.get("title"),
+                    "requester": row.get("username"),
+                    "user_platform": row.get("user_platform"),
+                    "request_origin": row.get("request_origin"),
+                    "timestamp": row.get("timestamp"),
+                }
+            )
+        return web.json_response({"requests": items})
+
+    async def delete_request_handler(self, request: web.Request) -> web.Response:
+        """DELETE /v1/requests/{reqid} — remove a single queue entry"""
+        if not self._authorized(request, request.query.get("secret", "")):
+            return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        try:
+            reqid = int(request.match_info.get("reqid", ""))
+        except ValueError:
+            return web.json_response({"error": "invalid request id"}, status=400)
+        await asyncio.to_thread(self._requests(request).erase_id, reqid)
+        return web.json_response({"deleted": reqid})
+
+    async def clear_requests_handler(self, request: web.Request) -> web.Response:
+        """DELETE /v1/requests — clear the entire queue"""
+        if not self._authorized(request, request.query.get("secret", "")):
+            return web.json_response({"error": "Invalid or missing secret"}, status=403)
+        await self._requests(request).erase_all()
+        return web.json_response({"cleared": True})

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -500,10 +500,14 @@ class StaticContentHandler:  # pylint: disable=too-many-public-methods
             accepted = False
         t = nowplaying.version.__VERSION_TUPLE__
         wnp_version = f"{t[0]}.{t[1]}.{t[2]}"
+        config = request.app[self.config_key]
         response: dict = {
             "wnp_version": wnp_version,
             "min_plugin_version": LUMIA_MIN_PLUGIN_VERSION,
             "accepted": accepted,
+            "capabilities": {
+                "requests": config.cparser.value("settings/requests", type=bool),
+            },
         }
         if not accepted:
             response["message"] = (

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -112,6 +112,17 @@ async def test_erase_all(trackrequestbootstrap):  # pylint: disable=redefined-ou
 
 
 @pytest.mark.asyncio
+async def test_user_track_request_bounds_pathological_input(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """a long adversarial input is length-bounded so regex parsing can't ReDoS"""
+    trackrequest = trackrequestbootstrap
+    evil = " " * 50000 + "- x"
+    data = await asyncio.wait_for(
+        trackrequest.user_track_request({"displayname": "t"}, "user", evil), timeout=5
+    )
+    assert data["requester"] == "user"
+
+
+@pytest.mark.asyncio
 async def test_trackrequest_artisttitlenoquote(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """artist - title"""
 

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -29,6 +29,88 @@ async def trackrequestbootstrap(bootstrap, getroot):  # pylint: disable=redefine
     await asyncio.sleep(2)
 
 
+def test_track_id_stable_and_normalized():
+    """track_id is deterministic and ignores case/whitespace differences"""
+    trackid = nowplaying.trackrequests.Requests.track_id("The Beatles", "Hey Jude")
+    assert trackid == nowplaying.trackrequests.Requests.track_id("The Beatles", "Hey Jude")
+    assert trackid == nowplaying.trackrequests.Requests.track_id("the beatles", "  hey   jude ")
+
+
+def test_track_id_distinct_tracks():
+    """different artist/title pairs produce different ids"""
+    assert nowplaying.trackrequests.Requests.track_id(
+        "The Beatles", "Hey Jude"
+    ) != nowplaying.trackrequests.Requests.track_id("Radiohead", "Creep")
+
+
+def test_track_id_handles_missing_fields():
+    """track_id tolerates None and empty values without raising"""
+    assert nowplaying.trackrequests.Requests.track_id(
+        None, None
+    ) == nowplaying.trackrequests.Requests.track_id("", "")
+
+
+@pytest.mark.asyncio
+async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """enqueue_request with structured artist/title tags origin/platform and returns trackid"""
+    trackrequest = trackrequestbootstrap
+    result = await trackrequest.enqueue_request(
+        requester="viewer1",
+        request_origin="lumia",
+        user_platform="kick",
+        artist="Radiohead",
+        title="Creep",
+    )
+    assert result["accepted"] is True
+    assert result["deduped"] is False
+    assert result["track_id"] == trackrequest.track_id("Radiohead", "Creep")
+    assert result["request_origin"] == "lumia"
+    assert result["user_platform"] == "kick"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_request_dedup(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """a second identical request from the same user within the window is deduped"""
+    trackrequest = trackrequestbootstrap
+    first = await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    assert first["deduped"] is False
+    second = await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    assert second["deduped"] is True
+    assert second["track_id"] == first["track_id"]
+
+
+@pytest.mark.asyncio
+async def test_enqueue_request_different_requester(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """the same song from a different requester is not deduped"""
+    trackrequest = trackrequestbootstrap
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    second = await trackrequest.enqueue_request(
+        requester="viewer2", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    assert second["deduped"] is False
+
+
+@pytest.mark.asyncio
+async def test_erase_all(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """erase_all clears the whole request queue"""
+    trackrequest = trackrequestbootstrap
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    await trackrequest.enqueue_request(
+        requester="viewer2", request_origin="lumia", artist="Nirvana", title="Breed"
+    )
+    await trackrequest.erase_all()
+    remaining = [row async for row in trackrequest.get_all_generator()]
+    assert remaining == []
+
+
 @pytest.mark.asyncio
 async def test_trackrequest_artisttitlenoquote(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """artist - title"""

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -54,6 +54,7 @@ def test_track_id_handles_missing_fields():
 async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """enqueue_request with structured artist/title tags origin/platform and returns trackid"""
     trackrequest = trackrequestbootstrap
+    await trackrequest.erase_all()
     result = await trackrequest.enqueue_request(
         requester="viewer1",
         request_origin="lumia",
@@ -72,6 +73,7 @@ async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: dis
 async def test_enqueue_request_dedup(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """a second identical request from the same user within the window is deduped"""
     trackrequest = trackrequestbootstrap
+    await trackrequest.erase_all()
     first = await trackrequest.enqueue_request(
         requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
     )
@@ -87,6 +89,7 @@ async def test_enqueue_request_dedup(trackrequestbootstrap):  # pylint: disable=
 async def test_enqueue_request_different_requester(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """the same song from a different requester is not deduped"""
     trackrequest = trackrequestbootstrap
+    await trackrequest.erase_all()
     await trackrequest.enqueue_request(
         requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
     )

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -94,7 +94,7 @@ async def test_requests_authentication(
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
 @pytest.mark.asyncio
 async def test_requests_disabled(getwebserver):  # pylint: disable=redefined-outer-name
-    """POST is refused when the request feature is disabled"""
+    """mutations are refused when disabled; the read returns an empty queue"""
     config, _ = getwebserver
     config.cparser.setValue("settings/requests", False)
     config.cparser.sync()
@@ -107,6 +107,17 @@ async def test_requests_disabled(getwebserver):  # pylint: disable=redefined-out
             timeout=aiohttp.ClientTimeout(total=10),
         ) as req:
             assert req.status == 403
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 403
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+            assert (await req.json())["requests"] == []
 
 
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Webserver tests for the Lumia song-request queue API"""
+
+import sys
+
+import aiohttp
+import pytest
+
+from tests.webserver.conftest import wait_for_webserver_ready
+
+REQUEST_URL = "/v1/requests"
+
+
+async def _ready(config):
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+    return port
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_enqueue_and_list(getwebserver):  # pylint: disable=redefined-outer-name
+    """a Lumia-originated request is enqueued and appears in the queue snapshot"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"http://localhost:{port}{REQUEST_URL}",
+            json={
+                "requester": "viewer1",
+                "user_platform": "kick",
+                "artist": "Radiohead",
+                "title": "Creep",
+            },
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+            data = await req.json()
+            assert data["accepted"] is True
+            assert data["track_id"]
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+            data = await req.json()
+            items = data["requests"]
+            assert any(item["title"] == "Creep" for item in items)
+            match = next(item for item in items if item["title"] == "Creep")
+            assert match["request_origin"] == "lumia"
+            assert match["user_platform"] == "kick"
+            assert match["requester"] == "viewer1"
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "secret_config,request_secret,expected_status",
+    [
+        (None, None, 200),
+        ("test_secret", "test_secret", 200),
+        ("test_secret", "wrong_secret", 403),
+        ("test_secret", None, 403),
+    ],
+)
+async def test_requests_authentication(
+    getwebserver, secret_config, request_secret, expected_status
+):  # pylint: disable=redefined-outer-name
+    """POST /v1/requests honors the shared secret"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    if secret_config:
+        config.cparser.setValue("remote/remote_key", secret_config)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    body = {"requester": "viewer1", "artist": "Radiohead", "title": "Creep"}
+    if request_secret:
+        body["secret"] = request_secret
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"http://localhost:{port}{REQUEST_URL}",
+            json=body,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == expected_status
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_disabled(getwebserver):  # pylint: disable=redefined-outer-name
+    """POST is refused when the request feature is disabled"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", False)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"http://localhost:{port}{REQUEST_URL}",
+            json={"requester": "viewer1", "artist": "Radiohead", "title": "Creep"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 403
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_delete_and_clear(getwebserver):  # pylint: disable=redefined-outer-name
+    """single delete removes one entry; clear empties the queue"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        for artist, title in (("Radiohead", "Creep"), ("Nirvana", "Breed")):
+            async with session.post(
+                f"http://localhost:{port}{REQUEST_URL}",
+                json={"requester": "viewer1", "artist": artist, "title": title},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as req:
+                assert req.status == 200
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            items = (await req.json())["requests"]
+            assert len(items) == 2
+            victim = items[0]["request_id"]
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}/{victim}",
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            items = (await req.json())["requests"]
+            assert len(items) == 1
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            items = (await req.json())["requests"]
+            assert items == []

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -28,6 +28,11 @@ async def test_requests_enqueue_and_list(getwebserver):  # pylint: disable=redef
     port = await _ready(config)
 
     async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
         async with session.post(
             f"http://localhost:{port}{REQUEST_URL}",
             json={
@@ -130,6 +135,11 @@ async def test_requests_delete_and_clear(getwebserver):  # pylint: disable=redef
     port = await _ready(config)
 
     async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
         for artist, title in (("Radiohead", "Creep"), ("Nirvana", "Breed")):
             async with session.post(
                 f"http://localhost:{port}{REQUEST_URL}",


### PR DESCRIPTION

## Summary by Sourcery

Expose the track request queue via a Lumia-focused REST API and align internal request tracking with stable per-track identifiers and provenance metadata.

New Features:
- Add a stable track_id derived from normalized artist/title for use in external integrations.
- Introduce a generic enqueue_request interface to create requests from structured input and enforce deduplication within a time window.
- Expose the song-request queue over HTTP with /v1/requests GET/POST/DELETE endpoints secured by the existing shared secret and a requests-enabled setting.
- Advertise request-queue capabilities in the Lumia version handshake so plugins can detect support.

Bug Fixes:
- Harden artist/title parsing with bounded input length and non-backtracking regexes to mitigate potential ReDoS issues.

Enhancements:
- Extend user track request records with user_platform and request_origin fields to track request provenance across platforms.
- Add an erase_all operation to clear the entire request queue in one call.

Tests:
- Add unit tests for track_id determinism, enqueue_request behavior, deduplication, and erase_all queue clearing.
- Add webserver integration tests covering Lumia request enqueue/list, authentication, enable/disable behavior, and single/whole-queue deletion.