### PR TITLE
feat: delete a single request by artist/title/requester

### DIFF
--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -462,6 +462,41 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         except sqlite3.OperationalError:
             logging.exception("Failed to erase all requests after retries")
 
+    async def erase_by_identity(
+        self, artist: str | None, title: str | None, requester: str | None = None
+    ) -> int:
+        """remove requests matching a normalized artist/title (and requester, if given)"""
+        if not self.databasefile.exists():
+            logging.error("%s does not exist, refusing to erase.", self.databasefile)
+            return 0
+        normalizedartist = self._normalize(artist)
+        normalizedtitle = self._normalize(title)
+        if requester:
+            sql = (
+                "DELETE FROM userrequest "
+                "WHERE normalizedartist=? AND normalizedtitle=? AND username=?"
+            )
+            params = (normalizedartist, normalizedtitle, requester)
+        else:
+            sql = "DELETE FROM userrequest WHERE normalizedartist=? AND normalizedtitle=?"
+            params = (normalizedartist, normalizedtitle)
+
+        async def _do_erase_by_identity():
+            async with aiosqlite.connect(self.databasefile, timeout=30) as connection:
+                connection.row_factory = sqlite3.Row
+                cursor = await connection.cursor()
+                await cursor.execute(sql, params)
+                await connection.commit()
+                return cursor.rowcount
+
+        try:
+            return await nowplaying.utils.sqlite.retry_sqlite_operation_async(
+                _do_erase_by_identity
+            )
+        except sqlite3.OperationalError:
+            logging.exception("Failed to erase requests by identity after retries")
+            return 0
+
     async def erase_gifwords_id(self, reqid: int):
         """remove entry from gifwords"""
         if not self.databasefile.exists():

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -99,10 +99,16 @@ class RequestsHandler:
         return web.json_response({"deleted": reqid})
 
     async def clear_requests_handler(self, request: web.Request) -> web.Response:
-        """DELETE /v1/requests — clear the entire queue"""
+        """DELETE /v1/requests — clear the queue, or one request when artist/title given"""
         if not self._authorized(request, request.query.get("secret", "")):
             return web.json_response({"error": "Invalid or missing secret"}, status=403)
         if not self._requests_enabled(request):
             return web.json_response({"error": "Requests are disabled"}, status=403)
+        artist = request.query.get("artist", "")
+        title = request.query.get("title", "")
+        requester = request.query.get("requester", "")
+        if artist or title or requester:
+            deleted = await self._requests(request).erase_by_identity(artist, title, requester)
+            return web.json_response({"deleted": deleted})
         await self._requests(request).erase_all()
         return web.json_response({"cleared": True})

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -115,6 +115,27 @@ async def test_erase_all(trackrequestbootstrap):  # pylint: disable=redefined-ou
 
 
 @pytest.mark.asyncio
+async def test_erase_by_identity(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """erase_by_identity removes only the matching requester's request for a track"""
+    trackrequest = trackrequestbootstrap
+    await trackrequest.erase_all()
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    await trackrequest.enqueue_request(
+        requester="viewer2", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Nirvana", title="Breed"
+    )
+    deleted = await trackrequest.erase_by_identity("Radiohead", "Creep", "viewer1")
+    assert deleted == 1
+    remaining = [row async for row in trackrequest.get_all_generator()]
+    assert len(remaining) == 2
+    assert not any(r["username"] == "viewer1" and r["title"] == "Creep" for r in remaining)
+
+
+@pytest.mark.asyncio
 async def test_user_track_request_bounds_pathological_input(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """a long adversarial input is length-bounded so regex parsing can't ReDoS"""
     trackrequest = trackrequestbootstrap

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -177,3 +177,42 @@ async def test_requests_delete_and_clear(getwebserver):  # pylint: disable=redef
         ) as req:
             items = (await req.json())["requests"]
             assert items == []
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_delete_by_identity(getwebserver):  # pylint: disable=redefined-outer-name
+    """DELETE with artist/title/requester removes only that requester's request"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
+        for requester in ("viewer1", "viewer2"):
+            async with session.post(
+                f"http://localhost:{port}{REQUEST_URL}",
+                json={"requester": requester, "artist": "Radiohead", "title": "Creep"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as req:
+                assert req.status == 200
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}",
+            params={"artist": "Radiohead", "title": "Creep", "requester": "viewer1"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+            assert (await req.json())["deleted"] == 1
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            items = (await req.json())["requests"]
+            assert len(items) == 1
+            assert items[0]["requester"] == "viewer2"


### PR DESCRIPTION
Backs the plugin's removeSongRequest hook: a mod removing one request in Lumia can drop it from WNP's queue. Lumia hands the plugin the track's artist/title/requester (not a reqid), so add erase_by_identity matching the existing normalized columns, and let DELETE /v1/requests target one row when those query params are present (no params still clears all). No schema change.

## Summary by Sourcery

Support deleting a single track request by artist/title/requester via the existing requests API and storage layer.

New Features:
- Add erase_by_identity API to remove track requests matching normalized artist/title and optionally requester.
- Allow DELETE /v1/requests to target a single request when artist/title/requester query parameters are supplied.

Tests:
- Add unit tests for erase_by_identity behavior in the trackrequests module.
- Add webserver tests to verify DELETE /v1/requests deletes only the matching request while leaving other requests intact.