### PR TITLE
feat: single-request delete; drop version-handshake capabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ pushes fail with "can not upload new objects to public fork".
 
 ## Architecture Overview
 
-This is a Python 3.10/Qt6 desktop application for streaming DJs to display "now
+This is a Python 3.11/Qt6 desktop application for streaming DJs to display "now
 playing" information from various DJ software.
 
 ### Core Components

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -626,7 +626,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         if (
             not expected_state
             or not received_state
-            or not secrets.compare_digest(received_state, str(expected_state))
+            or not nowplaying.utils.secure_compare(received_state, str(expected_state))
         ):
             logging.warning("%s implicit: state mismatch/missing, possible CSRF", service_name)
             html = load_tmpl(f"{template_prefix}_csrf_error.htm", service_name=service_name)

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -446,8 +446,8 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             logging.exception("Failed to erase request ID %s after retries", reqid)
             return 0
 
-    async def erase_all(self):
-        """remove every entry from the request queue"""
+    async def erase_all_requests(self):
+        """remove every entry from the request queue (userrequest table only, not gifwords)"""
         if not self.databasefile.exists():
             logging.error("%s does not exist, refusing to erase.", self.databasefile)
             return

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -462,6 +462,47 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         except sqlite3.OperationalError:
             logging.exception("Failed to erase all requests after retries")
 
+    async def erase_by_identity(
+        self, artist: str | None, title: str | None, requester: str | None = None
+    ) -> int:
+        """remove requests matching a normalized artist AND title (and requester, if given)"""
+        if not self.databasefile.exists():
+            logging.error("%s does not exist, refusing to erase.", self.databasefile)
+            return 0
+        normalizedartist = self._normalize(artist)
+        normalizedtitle = self._normalize(title)
+        if not normalizedartist or not normalizedtitle:
+            # identity requires both; refuse rather than match rows with empty fields
+            logging.warning(
+                "erase_by_identity needs both artist and title, got %r / %r", artist, title
+            )
+            return 0
+        if requester:
+            sql = (
+                "DELETE FROM userrequest "
+                "WHERE normalizedartist=? AND normalizedtitle=? AND username=?"
+            )
+            params = (normalizedartist, normalizedtitle, requester)
+        else:
+            sql = "DELETE FROM userrequest WHERE normalizedartist=? AND normalizedtitle=?"
+            params = (normalizedartist, normalizedtitle)
+
+        async def _do_erase_by_identity():
+            async with aiosqlite.connect(self.databasefile, timeout=30) as connection:
+                connection.row_factory = sqlite3.Row
+                cursor = await connection.cursor()
+                await cursor.execute(sql, params)
+                await connection.commit()
+                return cursor.rowcount
+
+        try:
+            return await nowplaying.utils.sqlite.retry_sqlite_operation_async(
+                _do_erase_by_identity
+            )
+        except sqlite3.OperationalError:
+            logging.exception("Failed to erase requests by identity after retries")
+            return 0
+
     async def erase_gifwords_id(self, reqid: int):
         """remove entry from gifwords"""
         if not self.databasefile.exists():

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -425,11 +425,11 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             except sqlite3.OperationalError as error:
                 logging.error(error)
 
-    def erase_id(self, reqid: int):
-        """remove entry from requests"""
+    def erase_id(self, reqid: int) -> int:
+        """remove entry from requests; returns the number of rows removed"""
         if not self.databasefile.exists():
             logging.error("%s does not exist, refusing to erase.", self.databasefile)
-            return
+            return 0
 
         def _do_erase():
             with nowplaying.utils.sqlite.sqlite_connection(
@@ -438,11 +438,13 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
                 cursor = connection.cursor()
                 cursor.execute("DELETE FROM userrequest WHERE reqid=?;", (reqid,))
                 connection.commit()
+                return cursor.rowcount
 
         try:
-            nowplaying.utils.sqlite.retry_sqlite_operation(_do_erase)
+            return nowplaying.utils.sqlite.retry_sqlite_operation(_do_erase)
         except sqlite3.OperationalError:
             logging.exception("Failed to erase request ID %s after retries", reqid)
+            return 0
 
     async def erase_all(self):
         """remove every entry from the request queue"""
@@ -465,7 +467,11 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
     async def erase_by_identity(
         self, artist: str | None, title: str | None, requester: str | None = None
     ) -> int:
-        """remove requests matching a normalized artist AND title (and requester, if given)"""
+        """remove requests matching a normalized artist AND title; returns rows removed.
+
+        When requester is given, only that requester's row is removed. When it is
+        omitted/empty, EVERY requester's row for that track is removed (a queue-owner
+        bulk clear for one song)."""
         if not self.databasefile.exists():
             logging.error("%s does not exist, refusing to erase.", self.databasefile)
             return 0
@@ -1098,24 +1104,41 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         title: str | None = None,
         dedup_window: int = 30,
     ) -> TrackRequestResult:
-        """create a request from an external source via the generic parser"""
-        if artist and title:
-            user_input = f"{artist} - {title}"
-        elif query:
-            user_input = query
-        elif artist:
-            user_input = artist
-        elif title:
-            user_input = title
-        else:
-            return {"accepted": False, "reason": "empty request"}
+        """create a request from an external source.
 
-        if (
-            artist
-            and title
-            and await self._duplicate_request_exists(requester, artist, title, dedup_window)
-        ):
-            return {"accepted": True, "deduped": True, "track_id": self.track_id(artist, title)}
+        Structured artist+title are stored verbatim (NOT round-tripped through the chat
+        parser, which would redistribute an artist/title containing ' - '). A bare query
+        is parsed by the chat parser."""
+        if artist and title:
+            if await self._duplicate_request_exists(requester, artist, title, dedup_window):
+                return {
+                    "accepted": True,
+                    "deduped": True,
+                    "track_id": self.track_id(artist, title),
+                }
+            data: UserTrackRequest = {
+                "username": requester,
+                "artist": artist,
+                "title": title,
+                "type": "Generic",
+                "request_origin": request_origin,
+                "user_platform": user_platform,
+            }
+            await self.add_to_db(data)
+            return {
+                "accepted": True,
+                "deduped": False,
+                "track_id": self.track_id(artist, title),
+                "requester": requester,
+                "requestartist": artist,
+                "requesttitle": title,
+                "request_origin": request_origin,
+                "user_platform": user_platform,
+            }
+
+        user_input = query or artist or title
+        if not user_input:
+            return {"accepted": False, "reason": "empty request"}
 
         result = await self.user_track_request(
             {}, requester, user_input, request_origin=request_origin, user_platform=user_platform

--- a/nowplaying/types.py
+++ b/nowplaying/types.py
@@ -174,6 +174,8 @@ class TrackRequestResult(TypedDict, total=False):
     deduped: bool
     track_id: str
     reason: str
+    request_origin: str | None
+    user_platform: str | None
 
 
 class TrackRequestSetting(TypedDict, total=False):

--- a/nowplaying/utils/__init__.py
+++ b/nowplaying/utils/__init__.py
@@ -6,6 +6,7 @@ import base64
 import io
 import logging
 import os
+import secrets
 import ssl
 import sys
 import time
@@ -38,6 +39,13 @@ TRANSPARENT_PNG = (
 )
 
 TRANSPARENT_PNG_BIN = base64.b64decode(TRANSPARENT_PNG)
+
+
+def secure_compare(left: str, right: str) -> bool:
+    """constant-time compare of two secrets, tolerating non-ASCII (compares utf-8 bytes).
+
+    secrets.compare_digest raises TypeError on non-ASCII str, so encode first."""
+    return secrets.compare_digest(str(left).encode("utf-8"), str(right).encode("utf-8"))
 
 
 def safe_stopevent_check(stopevent: asyncio.Event | None) -> bool:

--- a/nowplaying/webserver/images_websocket.py
+++ b/nowplaying/webserver/images_websocket.py
@@ -116,7 +116,7 @@ class ImagesWebSocketHandler:  # pylint: disable=too-few-public-methods
                 return
 
             # Use constant-time comparison to prevent timing attacks
-            if not secrets.compare_digest(required_secret, provided_secret):
+            if not nowplaying.utils.secure_compare(required_secret, provided_secret):
                 logging.warning(
                     "Remote metadata submission with invalid secret from %s", request.remote
                 )

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -2,12 +2,12 @@
 """aiohttp handlers for the Lumia song-request queue API"""
 
 import asyncio
-import secrets
 from typing import TYPE_CHECKING
 
 from aiohttp import web
 
 import nowplaying.trackrequests
+import nowplaying.utils
 
 if TYPE_CHECKING:
     import nowplaying.config
@@ -18,9 +18,18 @@ class RequestsHandler:
 
     def __init__(self, config_key: "web.AppKey[nowplaying.config.ConfigFile]"):
         self.config_key = config_key
+        self._requests_instance: "nowplaying.trackrequests.Requests | None" = None
 
     def _requests(self, request: web.Request) -> "nowplaying.trackrequests.Requests":
-        return nowplaying.trackrequests.Requests(request.app[self.config_key])
+        # Requests() runs a synchronous _migrate_db() (sqlite connect + PRAGMA, possibly
+        # ALTER) in its constructor, so build it once and reuse it rather than paying that
+        # cost on the event loop on every API hit. request.app[config_key] is a single
+        # stable object and Requests reads config live via cparser, so caching is safe.
+        if self._requests_instance is None:
+            self._requests_instance = nowplaying.trackrequests.Requests(
+                request.app[self.config_key]
+            )
+        return self._requests_instance
 
     def _authorized(self, request: web.Request, provided_secret: str) -> bool:
         """reuse the webserver's shared secret (empty key disables auth)"""
@@ -30,7 +39,7 @@ class RequestsHandler:
         )
         if not required:
             return True
-        return bool(provided_secret) and secrets.compare_digest(required, provided_secret)
+        return bool(provided_secret) and nowplaying.utils.secure_compare(required, provided_secret)
 
     def _requests_enabled(self, request: web.Request) -> bool:
         return request.app[self.config_key].cparser.value("settings/requests", type=bool)
@@ -120,5 +129,5 @@ class RequestsHandler:
                 {"error": "artist and title are both required to delete a single request"},
                 status=400,
             )
-        await self._requests(request).erase_all()
+        await self._requests(request).erase_all_requests()
         return web.json_response({"cleared": True})

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -99,10 +99,22 @@ class RequestsHandler:
         return web.json_response({"deleted": reqid})
 
     async def clear_requests_handler(self, request: web.Request) -> web.Response:
-        """DELETE /v1/requests — clear the entire queue"""
+        """DELETE /v1/requests — clear the queue, or one request when artist/title given"""
         if not self._authorized(request, request.query.get("secret", "")):
             return web.json_response({"error": "Invalid or missing secret"}, status=403)
         if not self._requests_enabled(request):
             return web.json_response({"error": "Requests are disabled"}, status=403)
+        artist = request.query.get("artist", "")
+        title = request.query.get("title", "")
+        requester = request.query.get("requester", "")
+        if artist and title:
+            deleted = await self._requests(request).erase_by_identity(artist, title, requester)
+            return web.json_response({"deleted": deleted})
+        if artist or title or requester:
+            # partial identity is ambiguous — don't guess, and don't fall through to clear-all
+            return web.json_response(
+                {"error": "artist and title are both required to delete a single request"},
+                status=400,
+            )
         await self._requests(request).erase_all()
         return web.json_response({"cleared": True})

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -95,8 +95,10 @@ class RequestsHandler:
             reqid = int(request.match_info.get("reqid", ""))
         except ValueError:
             return web.json_response({"error": "invalid request id"}, status=400)
-        await asyncio.to_thread(self._requests(request).erase_id, reqid)
-        return web.json_response({"deleted": reqid})
+        deleted = await asyncio.to_thread(self._requests(request).erase_id, reqid)
+        if not deleted:
+            return web.json_response({"error": "no such request"}, status=404)
+        return web.json_response({"deleted": deleted, "request_id": reqid})
 
     async def clear_requests_handler(self, request: web.Request) -> web.Response:
         """DELETE /v1/requests — clear the queue, or one request when artist/title given"""
@@ -109,6 +111,8 @@ class RequestsHandler:
         requester = request.query.get("requester", "")
         if artist and title:
             deleted = await self._requests(request).erase_by_identity(artist, title, requester)
+            if not deleted:
+                return web.json_response({"error": "no matching request"}, status=404)
             return web.json_response({"deleted": deleted})
         if artist or title or requester:
             # partial identity is ambiguous — don't guess, and don't fall through to clear-all

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -500,14 +500,10 @@ class StaticContentHandler:  # pylint: disable=too-many-public-methods
             accepted = False
         t = nowplaying.version.__VERSION_TUPLE__
         wnp_version = f"{t[0]}.{t[1]}.{t[2]}"
-        config = request.app[self.config_key]
         response: dict = {
             "wnp_version": wnp_version,
             "min_plugin_version": LUMIA_MIN_PLUGIN_VERSION,
             "accepted": accepted,
-            "capabilities": {
-                "requests": config.cparser.value("settings/requests", type=bool),
-            },
         }
         if not accepted:
             response["message"] = (

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -6,7 +6,6 @@ import base64
 import ipaddress
 import logging
 import os
-import secrets
 import socket
 import urllib.parse
 import uuid
@@ -628,7 +627,7 @@ class StaticContentHandler:  # pylint: disable=too-many-public-methods
                 return web.json_response({"error": "Missing secret in request"}, status=403)
 
             # Use constant-time comparison to prevent timing attacks
-            if not secrets.compare_digest(required_secret, provided_secret):
+            if not nowplaying.utils.secure_compare(required_secret, provided_secret):
                 logging.warning(
                     "Remote metadata submission with invalid secret from %s", request.remote
                 )

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -24,11 +24,16 @@ async def trackrequestbootstrap(bootstrap, getroot):  # pylint: disable=redefine
         getroot, playlistpath
     )
     config.cparser.sync()
-    # upgrade=True forces a fresh request.db per test; it lives at a shared testsuite
-    # cache location and is otherwise never reset, so requests would leak across tests.
-    yield nowplaying.trackrequests.Requests(
+    # request.db lives at a shared testsuite cache location and is otherwise never reset,
+    # so give each test a clean slate. upgrade=True recreates the file; erase_all()
+    # then guarantees empty rows even when the unlink was skipped (e.g. a locked file on
+    # Windows only logs a warning). NOTE: safe only because the suite runs sequentially —
+    # a pytest-xdist (-n) run would need per-worker isolation of this file.
+    requests = nowplaying.trackrequests.Requests(
         stopevent=stopevent, config=config, testmode=True, upgrade=True
     )
+    await requests.erase_all()
+    yield requests
     stopevent.set()
     await asyncio.sleep(2)
 
@@ -147,6 +152,34 @@ async def test_erase_by_identity_requires_both(trackrequestbootstrap):  # pylint
     assert await trackrequest.erase_by_identity("", "", "viewer1") == 0
     remaining = [row async for row in trackrequest.get_all_generator()]
     assert len(remaining) == 1
+
+
+@pytest.mark.asyncio
+async def test_erase_by_identity_all_requesters(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """omitting requester removes every requester's row for that track"""
+    trackrequest = trackrequestbootstrap
+    for viewer in ("viewer1", "viewer2"):
+        await trackrequest.enqueue_request(
+            requester=viewer, request_origin="lumia", artist="Radiohead", title="Creep"
+        )
+    assert await trackrequest.erase_by_identity("Radiohead", "Creep") == 2
+    remaining = [row async for row in trackrequest.get_all_generator()]
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_enqueue_request_preserves_separator(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """a structured artist/title with ' - ' is stored verbatim and stays deletable"""
+    trackrequest = trackrequestbootstrap
+    result = await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Slow - Fast", title="Song"
+    )
+    assert result["requestartist"] == "Slow - Fast"
+    assert result["requesttitle"] == "Song"
+    rows = [row async for row in trackrequest.get_all_generator()]
+    assert rows[0]["artist"] == "Slow - Fast"
+    assert rows[0]["title"] == "Song"
+    assert await trackrequest.erase_by_identity("Slow - Fast", "Song", "viewer1") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -24,7 +24,11 @@ async def trackrequestbootstrap(bootstrap, getroot):  # pylint: disable=redefine
         getroot, playlistpath
     )
     config.cparser.sync()
-    yield nowplaying.trackrequests.Requests(stopevent=stopevent, config=config, testmode=True)
+    # upgrade=True forces a fresh request.db per test; it lives at a shared testsuite
+    # cache location and is otherwise never reset, so requests would leak across tests.
+    yield nowplaying.trackrequests.Requests(
+        stopevent=stopevent, config=config, testmode=True, upgrade=True
+    )
     stopevent.set()
     await asyncio.sleep(2)
 
@@ -54,7 +58,6 @@ def test_track_id_handles_missing_fields():
 async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """enqueue_request with structured artist/title tags origin/platform and returns trackid"""
     trackrequest = trackrequestbootstrap
-    await trackrequest.erase_all()
     result = await trackrequest.enqueue_request(
         requester="viewer1",
         request_origin="lumia",
@@ -73,7 +76,6 @@ async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: dis
 async def test_enqueue_request_dedup(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """a second identical request from the same user within the window is deduped"""
     trackrequest = trackrequestbootstrap
-    await trackrequest.erase_all()
     first = await trackrequest.enqueue_request(
         requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
     )
@@ -89,7 +91,6 @@ async def test_enqueue_request_dedup(trackrequestbootstrap):  # pylint: disable=
 async def test_enqueue_request_different_requester(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """the same song from a different requester is not deduped"""
     trackrequest = trackrequestbootstrap
-    await trackrequest.erase_all()
     await trackrequest.enqueue_request(
         requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
     )
@@ -112,6 +113,40 @@ async def test_erase_all(trackrequestbootstrap):  # pylint: disable=redefined-ou
     await trackrequest.erase_all()
     remaining = [row async for row in trackrequest.get_all_generator()]
     assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_erase_by_identity(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """erase_by_identity removes only the matching requester's request for a track"""
+    trackrequest = trackrequestbootstrap
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    await trackrequest.enqueue_request(
+        requester="viewer2", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Nirvana", title="Breed"
+    )
+    deleted = await trackrequest.erase_by_identity("Radiohead", "Creep", "viewer1")
+    assert deleted == 1
+    remaining = [row async for row in trackrequest.get_all_generator()]
+    assert len(remaining) == 2
+    assert not any(r["username"] == "viewer1" and r["title"] == "Creep" for r in remaining)
+
+
+@pytest.mark.asyncio
+async def test_erase_by_identity_requires_both(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """erase_by_identity refuses (deletes nothing) when artist or title is missing"""
+    trackrequest = trackrequestbootstrap
+    await trackrequest.enqueue_request(
+        requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
+    )
+    assert await trackrequest.erase_by_identity("", "Creep", "viewer1") == 0
+    assert await trackrequest.erase_by_identity("Radiohead", "", "viewer1") == 0
+    assert await trackrequest.erase_by_identity("", "", "viewer1") == 0
+    remaining = [row async for row in trackrequest.get_all_generator()]
+    assert len(remaining) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -25,14 +25,14 @@ async def trackrequestbootstrap(bootstrap, getroot):  # pylint: disable=redefine
     )
     config.cparser.sync()
     # request.db lives at a shared testsuite cache location and is otherwise never reset,
-    # so give each test a clean slate. upgrade=True recreates the file; erase_all()
+    # so give each test a clean slate. upgrade=True recreates the file; erase_all_requests()
     # then guarantees empty rows even when the unlink was skipped (e.g. a locked file on
     # Windows only logs a warning). NOTE: safe only because the suite runs sequentially —
     # a pytest-xdist (-n) run would need per-worker isolation of this file.
     requests = nowplaying.trackrequests.Requests(
         stopevent=stopevent, config=config, testmode=True, upgrade=True
     )
-    await requests.erase_all()
+    await requests.erase_all_requests()
     yield requests
     stopevent.set()
     await asyncio.sleep(2)
@@ -106,8 +106,8 @@ async def test_enqueue_request_different_requester(trackrequestbootstrap):  # py
 
 
 @pytest.mark.asyncio
-async def test_erase_all(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
-    """erase_all clears the whole request queue"""
+async def test_erase_all_requests(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """erase_all_requests clears the whole request queue"""
     trackrequest = trackrequestbootstrap
     await trackrequest.enqueue_request(
         requester="viewer1", request_origin="lumia", artist="Radiohead", title="Creep"
@@ -115,7 +115,7 @@ async def test_erase_all(trackrequestbootstrap):  # pylint: disable=redefined-ou
     await trackrequest.enqueue_request(
         requester="viewer2", request_origin="lumia", artist="Nirvana", title="Breed"
     )
-    await trackrequest.erase_all()
+    await trackrequest.erase_all_requests()
     remaining = [row async for row in trackrequest.get_all_generator()]
     assert remaining == []
 

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -160,6 +160,9 @@ async def test_requests_delete_and_clear(getwebserver):  # pylint: disable=redef
             timeout=aiohttp.ClientTimeout(total=10),
         ) as req:
             assert req.status == 200
+            body = await req.json()
+            assert body["deleted"] == 1
+            assert body["request_id"] == victim
 
         async with session.get(
             f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
@@ -251,3 +254,32 @@ async def test_requests_delete_partial_identity_rejected(getwebserver):  # pylin
             f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
         ) as req:
             assert len((await req.json())["requests"]) == 1
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_delete_no_match_404(getwebserver):  # pylint: disable=redefined-outer-name
+    """deleting a nonexistent request is a 404, not a silent deleted:0 — by id and by identity"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}",
+            params={"artist": "Nobody", "title": "Nothing", "requester": "ghost"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 404
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}/999999",
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 404

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -177,3 +177,77 @@ async def test_requests_delete_and_clear(getwebserver):  # pylint: disable=redef
         ) as req:
             items = (await req.json())["requests"]
             assert items == []
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_delete_by_identity(getwebserver):  # pylint: disable=redefined-outer-name
+    """DELETE with artist/title/requester removes only that requester's request"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
+        for requester in ("viewer1", "viewer2"):
+            async with session.post(
+                f"http://localhost:{port}{REQUEST_URL}",
+                json={"requester": requester, "artist": "Radiohead", "title": "Creep"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as req:
+                assert req.status == 200
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}",
+            params={"artist": "Radiohead", "title": "Creep", "requester": "viewer1"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+            assert (await req.json())["deleted"] == 1
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            items = (await req.json())["requests"]
+            assert len(items) == 1
+            assert items[0]["requester"] == "viewer2"
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_delete_partial_identity_rejected(getwebserver):  # pylint: disable=redefined-outer-name
+    """a partial identity (no artist+title) is a 400, never a broad delete or a clear-all"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
+        async with session.post(
+            f"http://localhost:{port}{REQUEST_URL}",
+            json={"requester": "viewer1", "artist": "Radiohead", "title": "Creep"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}",
+            params={"requester": "viewer1"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 400
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert len((await req.json())["requests"]) == 1


### PR DESCRIPTION
Follow-up to the song-request API (#1812).

- erase_by_identity + DELETE /v1/requests?artist=&title=&requester= backs the plugin's removeSongRequest (Lumia hands us artist/title/ requester, not a reqid). Requires both artist and title — a partial identity returns 400 rather than a broad or clear-all delete — and erase_by_identity refuses an empty identity as defense in depth.
- Drop the capabilities object from /v1/lumia/version: it added nothing the request endpoints don't self-enforce (403 disabled / 404 old build) and couldn't change the plugin's static source declaration; wnp_version is the availability signal.
- Test isolation: request.db lives at a shared testsuite cache location and was never reset between tests, leaking requests across them (and into the fuzzy-match tests). Give each test a fresh db via the fixture; drop the now-redundant per-test clears.

## Summary by Sourcery

Add single-request deletion support to the song-request API and tighten version/requests signaling and test isolation.

New Features:
- Support deleting an individual song request via DELETE /v1/requests when artist, title, and optional requester are provided.
- Introduce an erase_by_identity API on track requests to remove requests matching a specific track (and requester, if given).

Enhancements:
- Ensure partial identities for request deletion are rejected with a 400 response rather than performing a broad or clear-all delete.
- Remove the capabilities payload from the /v1/lumia/version endpoint, relying on wnp_version and existing request endpoint behavior as the availability signal.

Tests:
- Give each track-request test a fresh request.db via the bootstrap fixture instead of manual per-test clears to prevent cross-test leakage.
- Add tests covering single-request deletion behavior and partial-identity rejection at both the webserver and trackrequests layers.