### PR TITLE
feat: accept auth secret via X-WNP-Client-Auth header

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,10 +11,18 @@ Where `hostname` and `port` match your webserver configuration.
 
 ## Authentication
 
-Some endpoints require authentication via a secret key. When configured, include the secret in your request:
+Some endpoints require authentication via a secret key, configured as the webserver's shared secret.
+When one is set, present it using the `X-WNP-Client-Auth` header:
 
-- **GET requests**: Add `&secret=your_api_key` to query parameters
-- **POST requests**: Include `"secret": "your_api_key"` in JSON body
+```http
+X-WNP-Client-Auth: your_api_key
+```
+
+The header works on every authenticated endpoint and every method.
+
+Clients that cannot set request headers may instead pass the secret as a `secret` query parameter
+or JSON body field. Avoid this where you have the choice: query strings are recorded in webserver
+access logs, proxy logs, and browser history.
 
 ## Endpoints
 
@@ -41,25 +49,29 @@ Returns the currently playing track metadata.
 
 Accepts track metadata submissions from remote sources for the [Remote Input](../input/remote.md) system.
 
-**Authentication**: Optional secret key (if configured)
+**Authentication**: Optional secret key (if configured) via the `X-WNP-Client-Auth` header
 
 **Methods**: `GET`, `POST`
 
 #### POST Request (JSON)
 
-```json
+```http
+POST /v1/remoteinput
+X-WNP-Client-Auth: your_api_key
+Content-Type: application/json
+
 {
   "artist": "Artist Name",
   "title": "Track Title",
-  "album": "Album Name",
-  "secret": "your_api_key"
+  "album": "Album Name"
 }
 ```
 
 #### GET Request (Query Parameters)
 
-```url
-/v1/remoteinput?artist=Artist%20Name&title=Track%20Title&album=Album%20Name&secret=your_api_key
+```http
+GET /v1/remoteinput?artist=Artist%20Name&title=Track%20Title&album=Album%20Name
+X-WNP-Client-Auth: your_api_key
 ```
 
 #### Response Format

--- a/nowplaying/notifications/remote.py
+++ b/nowplaying/notifications/remote.py
@@ -10,6 +10,7 @@ import aiohttp
 
 import nowplaying.db
 import nowplaying.mdns_discovery
+import nowplaying.webserver.auth
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.types import TrackMetadata
 
@@ -52,10 +53,7 @@ class Plugin(NotificationPlugin):
         if not self.enabled:
             return
 
-        # Prepare metadata with secret for authentication
         remote_data = self._strip_blobs_metadata(metadata)
-        if self.key:
-            remote_data["secret"] = self.key
 
         # Signal that the client already submitted to charts so the server skips it
         if (
@@ -65,16 +63,19 @@ class Plugin(NotificationPlugin):
         ):
             remote_data["remote_charts_submitted"] = True
 
-        # Prepare debug data without secret
-        debug_data = dict(remote_data)
-        if "secret" in debug_data:
-            debug_data["secret"] = "***REDACTED***"
+        # The shared secret travels in the auth header, never in the payload.
+        # This requires a 6.0-or-newer server; older servers only read a body field.
+        headers: dict[str, str] = {}
+        if self.key:
+            headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER] = self.key
 
         try:
             async with (
                 aiohttp.ClientSession() as session,
                 session.post(
-                    f"http://{self.server}:{self.port}/v1/remoteinput", json=remote_data
+                    f"http://{self.server}:{self.port}/v1/remoteinput",
+                    json=remote_data,
+                    headers=headers,
                 ) as response,
             ):
                 logging.debug("Sending to %s:%s", self.server, self.port)
@@ -86,7 +87,11 @@ class Plugin(NotificationPlugin):
                     except Exception as exc:  # pylint: disable=broad-except
                         logging.warning("Failed to parse remote server response: %s", exc)
                 elif response.status == 403:
-                    logging.error("Remote server authentication failed - check remote secret")
+                    logging.error(
+                        "Remote server rejected our secret. Check that both machines use the "
+                        "same secret, and that the remote server is running What's Now Playing "
+                        "6.0 or newer (older servers cannot read the auth header)."
+                    )
                 elif response.status == 405:
                     logging.error("Remote server method not allowed - check endpoint")
                 else:

--- a/nowplaying/webserver/auth.py
+++ b/nowplaying/webserver/auth.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""shared client authentication for inbound webserver endpoints"""
+
+import logging
+from typing import TYPE_CHECKING
+
+import nowplaying.utils
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+    import nowplaying.config
+
+# Preferred way for clients to present the shared secret.  Headers stay out of
+# access logs, proxy logs, and browser history, unlike query parameters.
+CLIENT_AUTH_HEADER = "X-WNP-Client-Auth"
+
+# Return values for check_client_auth()
+AUTH_OK = "ok"
+AUTH_MISSING = "missing"
+AUTH_INVALID = "invalid"
+
+
+def check_client_auth(
+    request: "web.Request",
+    config: "nowplaying.config.ConfigFile",
+    legacy_secret: str = "",
+    source: str = "Request",
+) -> str:
+    """Validate a client-provided secret against the configured webserver key.
+
+    The secret is read from the CLIENT_AUTH_HEADER header when present,
+    otherwise from legacy_secret -- the query parameter or body field older
+    clients send.  Keeping the fallback means existing integrations continue
+    to work unchanged.
+
+    Args:
+        request: the inbound request (supplies headers and remote address)
+        config: config object holding the expected key
+        legacy_secret: secret pulled from a query param or body field, used
+            only when the header is absent
+        source: short description used in auth-failure log messages
+
+    Returns:
+        AUTH_OK when authorized, or when no key is configured (auth disabled);
+        AUTH_MISSING when a key is required but the client sent none;
+        AUTH_INVALID when the client sent a secret that does not match.
+    """
+    required = str(config.cparser.value("remote/remote_key", type=str, defaultValue="") or "")
+    if not required:
+        return AUTH_OK
+
+    provided = request.headers.get(CLIENT_AUTH_HEADER, "") or legacy_secret
+    if not provided:
+        logging.warning("%s without secret from %s", source, request.remote)
+        return AUTH_MISSING
+
+    if not nowplaying.utils.secure_compare(required, provided):
+        logging.warning("%s with invalid secret from %s", source, request.remote)
+        return AUTH_INVALID
+
+    return AUTH_OK

--- a/nowplaying/webserver/images_websocket.py
+++ b/nowplaying/webserver/images_websocket.py
@@ -108,7 +108,7 @@ class ImagesWebSocketHandler:  # pylint: disable=too-few-public-methods
         auth_result = nowplaying.webserver.auth.check_client_auth(
             request,
             request.app[self.config_key],
-            legacy_secret=str(data.get("secret", "")),
+            legacy_secret=str(data.get("secret") or ""),
             source="Images WebSocket hello",
         )
         if auth_result != nowplaying.webserver.auth.AUTH_OK:

--- a/nowplaying/webserver/images_websocket.py
+++ b/nowplaying/webserver/images_websocket.py
@@ -15,6 +15,7 @@ from aiohttp import web
 import nowplaying.preview.imagedata
 import nowplaying.utils
 import nowplaying.version  # pylint: disable=no-name-in-module, import-error
+import nowplaying.webserver.auth
 
 if TYPE_CHECKING:
     import nowplaying.config
@@ -101,28 +102,24 @@ class ImagesWebSocketHandler:  # pylint: disable=too-few-public-methods
 
         # Refresh config to get latest settings (important for testing)
         request.app[self.config_key].get()
-        if required_secret := request.app[self.config_key].cparser.value(
-            "remote/remote_key", type=str, defaultValue=""
-        ):
-            provided_secret = data.get("secret", "")
-            if not provided_secret:
-                logging.warning(
-                    "Remote metadata submission without secret from %s", request.remote
-                )
+        # Header (set during the WebSocket handshake) is preferred; the hello
+        # message "secret" field is the legacy path and the only option for
+        # browser clients, which cannot set custom handshake headers.
+        auth_result = nowplaying.webserver.auth.check_client_auth(
+            request,
+            request.app[self.config_key],
+            legacy_secret=str(data.get("secret", "")),
+            source="Images WebSocket hello",
+        )
+        if auth_result != nowplaying.webserver.auth.AUTH_OK:
+            if auth_result == nowplaying.webserver.auth.AUTH_MISSING:
                 await self._send_images_error(
                     websocket, "MISSING_SECRET", "Missing secret in request"
                 )
-                await websocket.close()
-                return
-
-            # Use constant-time comparison to prevent timing attacks
-            if not nowplaying.utils.secure_compare(required_secret, provided_secret):
-                logging.warning(
-                    "Remote metadata submission with invalid secret from %s", request.remote
-                )
+            else:
                 await self._send_images_error(websocket, "INVALID_SECRET", "Invalid secret")
-                await websocket.close()
-                return
+            await websocket.close()
+            return
 
         await websocket.send_json(
             {

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from aiohttp import web
 
 import nowplaying.trackrequests
-import nowplaying.utils
+import nowplaying.webserver.auth
 
 if TYPE_CHECKING:
     import nowplaying.config
@@ -32,14 +32,20 @@ class RequestsHandler:
         return self._requests_instance
 
     def _authorized(self, request: web.Request, provided_secret: str) -> bool:
-        """reuse the webserver's shared secret (empty key disables auth)"""
-        request.app[self.config_key].get()
-        required = request.app[self.config_key].cparser.value(
-            "remote/remote_key", type=str, defaultValue=""
+        """reuse the webserver's shared secret (empty key disables auth)
+
+        Prefers the X-WNP-Client-Auth header; provided_secret is the legacy
+        query-parameter or body value and is only used when the header is absent.
+        """
+        config = request.app[self.config_key]
+        config.get()
+        result = nowplaying.webserver.auth.check_client_auth(
+            request,
+            config,
+            legacy_secret=provided_secret,
+            source=f"Request queue API ({request.method} {request.path})",
         )
-        if not required:
-            return True
-        return bool(provided_secret) and nowplaying.utils.secure_compare(required, provided_secret)
+        return result == nowplaying.webserver.auth.AUTH_OK
 
     def _requests_enabled(self, request: web.Request) -> bool:
         return request.app[self.config_key].cparser.value("settings/requests", type=bool)

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -22,6 +22,7 @@ import nowplaying.upgrades
 import nowplaying.utils
 import nowplaying.utils.templatepaths
 import nowplaying.version  # pylint: disable=no-name-in-module,import-error
+import nowplaying.webserver.auth
 from nowplaying.types import TrackMetadata
 
 # Minimum required versions for known remote agents.
@@ -616,27 +617,27 @@ class StaticContentHandler:  # pylint: disable=too-many-public-methods
         """Common processing for remote metadata submissions"""
         # Refresh config to get latest settings (important for testing)
         request.app[self.config_key].get()
-        if required_secret := request.app[self.config_key].cparser.value(
-            "remote/remote_key", type=str, defaultValue=""
-        ):
-            provided_secret = metadata.get("secret", "")
-            if not provided_secret:
-                logging.warning(
-                    "Remote metadata submission without secret from %s", request.remote
-                )
-                return web.json_response({"error": "Missing secret in request"}, status=403)
-
-            # Use constant-time comparison to prevent timing attacks
-            if not nowplaying.utils.secure_compare(required_secret, provided_secret):
-                logging.warning(
-                    "Remote metadata submission with invalid secret from %s", request.remote
-                )
-                return web.json_response({"error": "Invalid secret"}, status=403)
+        # Header is preferred; the metadata "secret" field is the legacy path
+        auth_result = nowplaying.webserver.auth.check_client_auth(
+            request,
+            request.app[self.config_key],
+            legacy_secret=str(metadata.get("secret", "")),
+            source="Remote metadata submission",
+        )
+        if auth_result == nowplaying.webserver.auth.AUTH_MISSING:
+            return web.json_response({"error": "Missing secret in request"}, status=403)
+        if auth_result != nowplaying.webserver.auth.AUTH_OK:
+            return web.json_response({"error": "Invalid secret"}, status=403)
 
         if upgrade_response := self._check_agent_version(metadata):
             return upgrade_response
 
-        logging.info("Got %s raw metadata from %s: %s ", source, request.host, metadata)
+        # Redact before logging: on GET the secret arrives as a query parameter,
+        # so logging the raw dict would write it to debug.log in the clear
+        loggable = dict(metadata)
+        if "secret" in loggable:
+            loggable["secret"] = "***REDACTED***"  # noqa: S105
+        logging.info("Got %s raw metadata from %s: %s ", source, request.host, loggable)
 
         # Start with a copy of the metadata
         clean_metadata: TrackMetadata = metadata.copy()

--- a/nowplaying/webserver/static_handlers.py
+++ b/nowplaying/webserver/static_handlers.py
@@ -621,7 +621,7 @@ class StaticContentHandler:  # pylint: disable=too-many-public-methods
         auth_result = nowplaying.webserver.auth.check_client_auth(
             request,
             request.app[self.config_key],
-            legacy_secret=str(metadata.get("secret", "")),
+            legacy_secret=str(metadata.get("secret") or ""),
             source="Remote metadata submission",
         )
         if auth_result == nowplaying.webserver.auth.AUTH_MISSING:

--- a/tests/notifications/test_notifications_remote.py
+++ b/tests/notifications/test_notifications_remote.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 
 import nowplaying.notifications.remote
+import nowplaying.webserver.auth
 
 
 @pytest_asyncio.fixture
@@ -54,11 +55,13 @@ async def test_remote_plugin_no_secret(remote_plugin, aiointercept_mock):  # pyl
     request = aiointercept_mock.requests[first_key][0]
     # Should not have secret in the payload
     assert "secret" not in await request.json()
+    # No key configured means no auth header either
+    assert nowplaying.webserver.auth.CLIENT_AUTH_HEADER not in request.headers
 
 
 @pytest.mark.asyncio
 async def test_remote_plugin_with_secret(remote_plugin, aiointercept_mock):  # pylint: disable=redefined-outer-name
-    """test remote plugin with secret configured"""
+    """the secret is sent as an auth header and never placed in the payload"""
     remote_plugin.config.cparser.setValue("remote/enabled", True)
     remote_plugin.config.cparser.setValue("remote/remote_server", "localhost")
     remote_plugin.config.cparser.setValue("remote/remote_port", 8899)
@@ -71,12 +74,15 @@ async def test_remote_plugin_with_secret(remote_plugin, aiointercept_mock):  # p
 
     await remote_plugin.notify_track_change(metadata)
 
-    # Verify the request was made with secret
+    # Verify the request carried the secret in the header, not the body
     assert len(aiointercept_mock.requests) == 1
     first_key = list(aiointercept_mock.requests.keys())[0]
     request = aiointercept_mock.requests[first_key][0]
-    payload = await request.json()
-    assert payload["secret"] == "test_secret_123"  # pragma: allowlist secret
+    assert (
+        request.headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER]
+        == "test_secret_123"  # pragma: allowlist secret
+    )
+    assert "secret" not in await request.json()
 
 
 @pytest.mark.asyncio

--- a/tests/webserver/test_webserver_auth.py
+++ b/tests/webserver/test_webserver_auth.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 import nowplaying.webserver.auth
 
-SECRET = "correct-horse-battery-staple"
+SECRET = "correct-horse-battery-staple"  # pragma: allowlist secret
 
 
 def _request(headers: dict[str, str] | None = None) -> web.Request:

--- a/tests/webserver/test_webserver_auth.py
+++ b/tests/webserver/test_webserver_auth.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""tests for shared inbound client authentication"""
+
+import aiohttp.test_utils
+import pytest
+from aiohttp import web
+
+import nowplaying.webserver.auth
+
+SECRET = "correct-horse-battery-staple"
+
+
+def _request(headers: dict[str, str] | None = None) -> web.Request:
+    """build a mocked GET request carrying the given headers"""
+    return aiohttp.test_utils.make_mocked_request("GET", "/v1/requests", headers=headers or {})
+
+
+@pytest.mark.parametrize(
+    "configured,header,legacy,expected",
+    [
+        # No key configured: auth is disabled, everything passes
+        ("", None, None, nowplaying.webserver.auth.AUTH_OK),
+        ("", "anything", None, nowplaying.webserver.auth.AUTH_OK),
+        ("", None, "anything", nowplaying.webserver.auth.AUTH_OK),
+        # Header only
+        (SECRET, SECRET, None, nowplaying.webserver.auth.AUTH_OK),
+        (SECRET, "wrong", None, nowplaying.webserver.auth.AUTH_INVALID),
+        # Legacy query/body field only (backwards compatibility)
+        (SECRET, None, SECRET, nowplaying.webserver.auth.AUTH_OK),
+        (SECRET, None, "wrong", nowplaying.webserver.auth.AUTH_INVALID),
+        # Nothing supplied at all
+        (SECRET, None, None, nowplaying.webserver.auth.AUTH_MISSING),
+        (SECRET, "", "", nowplaying.webserver.auth.AUTH_MISSING),
+        # Both supplied: the header decides, so a bad header fails even when
+        # the legacy value would have passed (no silent downgrade)
+        (SECRET, SECRET, "wrong", nowplaying.webserver.auth.AUTH_OK),
+        (SECRET, "wrong", SECRET, nowplaying.webserver.auth.AUTH_INVALID),
+    ],
+)
+def test_check_client_auth(bootstrap, configured, header, legacy, expected):
+    """the configured key, header, and legacy field combine into one verdict"""
+    config = bootstrap
+    config.cparser.setValue("remote/remote_key", configured)
+    headers = {} if header is None else {nowplaying.webserver.auth.CLIENT_AUTH_HEADER: header}
+
+    result = nowplaying.webserver.auth.check_client_auth(
+        _request(headers), config, legacy_secret="" if legacy is None else legacy
+    )
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "X-WNP-Client-Auth",
+        "x-wnp-client-auth",
+        "X-WNP-CLIENT-AUTH",
+    ],
+)
+def test_check_client_auth_header_name_is_case_insensitive(bootstrap, header_name):
+    """HTTP header names are case-insensitive, so any casing must authenticate"""
+    config = bootstrap
+    config.cparser.setValue("remote/remote_key", SECRET)
+
+    result = nowplaying.webserver.auth.check_client_auth(_request({header_name: SECRET}), config)
+
+    assert result == nowplaying.webserver.auth.AUTH_OK
+
+
+@pytest.mark.parametrize("secret", ["pässwörd-ünïcode", "密码キー", "emoji-🎧-key"])
+def test_check_client_auth_accepts_non_ascii_secrets(bootstrap, secret):
+    """non-ASCII secrets must compare cleanly rather than raising TypeError"""
+    config = bootstrap
+    config.cparser.setValue("remote/remote_key", secret)
+
+    headers = {nowplaying.webserver.auth.CLIENT_AUTH_HEADER: secret}
+    assert (
+        nowplaying.webserver.auth.check_client_auth(_request(headers), config)
+        == nowplaying.webserver.auth.AUTH_OK
+    )
+
+    wrong = {nowplaying.webserver.auth.CLIENT_AUTH_HEADER: "not-the-secret"}
+    assert (
+        nowplaying.webserver.auth.check_client_auth(_request(wrong), config)
+        == nowplaying.webserver.auth.AUTH_INVALID
+    )

--- a/tests/webserver/test_webserver_consolidated.py
+++ b/tests/webserver/test_webserver_consolidated.py
@@ -6,6 +6,7 @@ import sys
 import aiohttp
 import pytest
 
+import nowplaying.webserver.auth
 from tests.webserver.conftest import wait_for_webserver_content_update, wait_for_webserver_ready
 
 
@@ -94,16 +95,18 @@ async def test_webserver_static_endpoints(getwebserver, endpoint):
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "secret_config,request_secret,expected_status",
+    "secret_config,request_secret,secret_location,expected_status",
     [
-        (None, None, 200),  # No secret configured - should accept any request
-        ("test_secret", "test_secret", 200),  # Correct secret
-        ("test_secret", "wrong_secret", 403),  # Wrong secret
-        ("test_secret", None, 403),  # Missing secret when required
+        (None, None, None, 200),  # No secret configured - should accept any request
+        ("test_secret", "test_secret", "header", 200),  # Correct secret via header
+        ("test_secret", "wrong_secret", "header", 403),  # Wrong secret via header
+        ("test_secret", "test_secret", "body", 200),  # Correct secret via legacy body field
+        ("test_secret", "wrong_secret", "body", 403),  # Wrong secret via legacy body field
+        ("test_secret", None, None, 403),  # Missing secret when required
     ],
 )
 async def test_webserver_remote_input_authentication(
-    getwebserver, secret_config, request_secret, expected_status
+    getwebserver, secret_config, request_secret, secret_location, expected_status
 ):
     """test remote input endpoint authentication scenarios"""
     config, metadb = getwebserver  # pylint: disable=unused-variable
@@ -121,13 +124,17 @@ async def test_webserver_remote_input_authentication(
 
     # Prepare test metadata
     test_metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
-    if request_secret:
+    headers = {}
+    if request_secret and secret_location == "header":
+        headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER] = request_secret
+    elif request_secret and secret_location == "body":
         test_metadata["secret"] = request_secret
 
     async with aiohttp.ClientSession() as session:
         async with session.post(
             f"http://localhost:{port}/v1/remoteinput",
             json=test_metadata,
+            headers=headers,
             timeout=aiohttp.ClientTimeout(total=10),
         ) as req:
             assert req.status == expected_status

--- a/tests/webserver/test_webserver_consolidated.py
+++ b/tests/webserver/test_webserver_consolidated.py
@@ -95,7 +95,7 @@ async def test_webserver_static_endpoints(getwebserver, endpoint):
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "secret_config,request_secret,secret_location,expected_status",
+    "secret_config,request_secret,auth_location,expected_status",
     [
         (None, None, None, 200),  # No secret configured - should accept any request
         ("test_secret", "test_secret", "header", 200),  # Correct secret via header
@@ -106,7 +106,7 @@ async def test_webserver_static_endpoints(getwebserver, endpoint):
     ],
 )
 async def test_webserver_remote_input_authentication(
-    getwebserver, secret_config, request_secret, secret_location, expected_status
+    getwebserver, secret_config, request_secret, auth_location, expected_status
 ):
     """test remote input endpoint authentication scenarios"""
     config, metadb = getwebserver  # pylint: disable=unused-variable
@@ -125,9 +125,9 @@ async def test_webserver_remote_input_authentication(
     # Prepare test metadata
     test_metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
     headers = {}
-    if request_secret and secret_location == "header":
+    if request_secret and auth_location == "header":
         headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER] = request_secret
-    elif request_secret and secret_location == "body":
+    elif request_secret and auth_location == "body":
         test_metadata["secret"] = request_secret
 
     async with aiohttp.ClientSession() as session:

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -65,7 +65,7 @@ async def test_requests_enqueue_and_list(getwebserver):  # pylint: disable=redef
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "secret_config,request_secret,secret_location,expected_status",
+    "secret_config,request_secret,auth_location,expected_status",
     [
         (None, None, None, 200),
         ("test_secret", "test_secret", "header", 200),
@@ -76,7 +76,7 @@ async def test_requests_enqueue_and_list(getwebserver):  # pylint: disable=redef
     ],
 )
 async def test_requests_authentication(
-    getwebserver, secret_config, request_secret, secret_location, expected_status
+    getwebserver, secret_config, request_secret, auth_location, expected_status
 ):  # pylint: disable=redefined-outer-name
     """POST /v1/requests honors the shared secret via header or legacy body field"""
     config, _ = getwebserver
@@ -88,9 +88,9 @@ async def test_requests_authentication(
 
     body = {"requester": "viewer1", "artist": "Radiohead", "title": "Creep"}
     headers = {}
-    if request_secret and secret_location == "header":
+    if request_secret and auth_location == "header":
         headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER] = request_secret
-    elif request_secret and secret_location == "body":
+    elif request_secret and auth_location == "body":
         body["secret"] = request_secret
 
     async with aiohttp.ClientSession() as session:

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -6,6 +6,7 @@ import sys
 import aiohttp
 import pytest
 
+import nowplaying.webserver.auth
 from tests.webserver.conftest import wait_for_webserver_ready
 
 REQUEST_URL = "/v1/requests"
@@ -64,18 +65,20 @@ async def test_requests_enqueue_and_list(getwebserver):  # pylint: disable=redef
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "secret_config,request_secret,expected_status",
+    "secret_config,request_secret,secret_location,expected_status",
     [
-        (None, None, 200),
-        ("test_secret", "test_secret", 200),
-        ("test_secret", "wrong_secret", 403),
-        ("test_secret", None, 403),
+        (None, None, None, 200),
+        ("test_secret", "test_secret", "header", 200),
+        ("test_secret", "wrong_secret", "header", 403),
+        ("test_secret", "test_secret", "body", 200),
+        ("test_secret", "wrong_secret", "body", 403),
+        ("test_secret", None, None, 403),
     ],
 )
 async def test_requests_authentication(
-    getwebserver, secret_config, request_secret, expected_status
+    getwebserver, secret_config, request_secret, secret_location, expected_status
 ):  # pylint: disable=redefined-outer-name
-    """POST /v1/requests honors the shared secret"""
+    """POST /v1/requests honors the shared secret via header or legacy body field"""
     config, _ = getwebserver
     config.cparser.setValue("settings/requests", True)
     if secret_config:
@@ -84,16 +87,61 @@ async def test_requests_authentication(
     port = await _ready(config)
 
     body = {"requester": "viewer1", "artist": "Radiohead", "title": "Creep"}
-    if request_secret:
+    headers = {}
+    if request_secret and secret_location == "header":
+        headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER] = request_secret
+    elif request_secret and secret_location == "body":
         body["secret"] = request_secret
 
     async with aiohttp.ClientSession() as session:
         async with session.post(
             f"http://localhost:{port}{REQUEST_URL}",
             json=body,
+            headers=headers,
             timeout=aiohttp.ClientTimeout(total=10),
         ) as req:
             assert req.status == expected_status
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_header_auth_avoids_query_string(getwebserver):  # pylint: disable=redefined-outer-name
+    """GET and DELETE authenticate via header, so the secret stays out of the URL"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.setValue("remote/remote_key", "test_secret")
+    config.cparser.sync()
+    port = await _ready(config)
+
+    headers = {nowplaying.webserver.auth.CLIENT_AUTH_HEADER: "test_secret"}
+    async with aiohttp.ClientSession() as session:
+        # No secret at all is rejected on the query-parameter endpoints
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 403
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}/999999",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            # authenticated, so we get past 403 to a genuine "no such request"
+            assert req.status == 404
 
 
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")


### PR DESCRIPTION
Inbound webserver endpoints now read the shared secret from an X-WNP-Client-Auth header instead of requiring it in a query parameter or JSON body. Query strings are recorded in access logs, proxy logs, and browser history, so a secret placed there tends to get written to disk somewhere unintended.

New nowplaying/webserver/auth.py centralizes the check for all three auth sites (remoteinput, the request-queue REST API, and the images WebSocket hello). It prefers the header and falls back to the legacy field, which clients that cannot set headers -- MegaSeg, Radiologik -- still need.

Remote Output now sends the secret as a header only. BREAKING: a 6.0 DJ machine cannot authenticate to a 5.x server, so multi-machine setups using a secret must upgrade together. The reverse direction still works, since servers retain the legacy fallback.

Also fixes two problems found along the way:

* _process_remote_metadata logged the raw metadata dict at INFO. On GET that dict is the query params, so a secret was written to debug.log in the clear -- the file users attach to bug reports. Now redacted.
* The request-queue API logged nothing on auth failure, making rejected requests invisible. Centralizing the check gives all three sites consistent warnings with the remote address.

## Summary by Sourcery

Centralize shared-secret authentication for inbound webserver endpoints and move clients to a header-based auth mechanism to keep secrets out of URLs and payloads.

New Features:
- Introduce a shared client authentication helper that validates the webserver secret via a dedicated X-WNP-Client-Auth header with legacy query/body fallback.

Bug Fixes:
- Redact remote metadata secrets from logs to avoid leaking shared secrets in debug output.
- Add consistent logging for authentication failures on the request-queue API and related endpoints.

Enhancements:
- Update remote notifications, remote input, request queue, and images WebSocket handlers to use the shared auth helper and prefer header-based secrets.
- Clarify API documentation to recommend X-WNP-Client-Auth for all authenticated endpoints and de-emphasize query/body secrets.
- Extend tests to cover header-based and legacy auth paths, case-insensitive header handling, and non-ASCII secrets.