### PR TITLE
fix: cache cover art for tracks with no album tag

### DIFF
--- a/nowplaying/metadata/processors.py
+++ b/nowplaying/metadata/processors.py
@@ -29,6 +29,13 @@ from nowplaying.types import TrackMetadata
 import nowplaying.datacache
 import nowplaying.datacache.colors
 
+# Cover art is cached per album so embedded and network art share a lookup key.
+# Tracks with no album tag fall back to an artist+title key under a separate
+# data_type: a self-titled album with a title track ("Weezer", "Bad") would
+# otherwise produce the same key as the album itself.
+ALBUM_COVER_TYPE = "front_cover"
+TRACK_COVER_TYPE = "track_cover"
+
 NOTE_RE = re.compile("N(?i:ote):")
 YOUTUBE_COMMENT_MATCH_RE = re.compile(r"^https?://(?:www\.)?youtube\.com/watch\?v=")
 YOUTUBE_TITLE_MATCH_RE = re.compile(r"^[^\s]+_-_[^\s]+")
@@ -145,20 +152,45 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         self._finalize_metadata()
         return self.metadata
 
-    async def _process_cover_images(self) -> None:
-        """Store embedded cover art in datacache or restore a cached image when none is embedded.
+    def _cover_cache_key(self) -> tuple[str, str, str] | None:
+        """Return (normalized key, human-readable identifier, data_type) for cover art.
 
-        Normalize artist+album separately then join — mirrors queue_front_cover() in
-        artistextras/__init__.py so the lookup key matches what network-art plugins store.
+        Album art normalizes artist+album separately then joins — mirrors
+        queue_front_cover() in artistextras/__init__.py so the lookup key matches
+        what network-art plugins store.  Tracks with no album tag (promos, white
+        labels, untagged rips) fall back to artist+title so their embedded art is
+        still cached and still found on replay; that key lives under a separate
+        data_type to avoid colliding with a same-named album.
+
+        Returns None when there is nothing usable to key on.
         """
-        if not (self.metadata.get("artist") and self.metadata.get("album")):
+        artist = self.metadata.get("artist")
+        norm_artist = nowplaying.utils.normalize(artist, sizecheck=0, nospaces=True)
+        if not norm_artist:
+            return None
+
+        if (album := self.metadata.get("album")) and (
+            norm_album := nowplaying.utils.normalize(album, sizecheck=0, nospaces=True)
+        ):
+            return f"{norm_artist}_{norm_album}", f"{artist}_{album}", ALBUM_COVER_TYPE
+
+        if (title := self.metadata.get("title")) and (
+            norm_title := nowplaying.utils.normalize(title, sizecheck=0, nospaces=True)
+        ):
+            return f"{norm_artist}_{norm_title}", f"{artist}_{title}", TRACK_COVER_TYPE
+
+        return None
+
+    async def _process_cover_images(self) -> None:
+        """Store embedded cover art in datacache, or restore a cached image when none is
+        embedded."""
+        if not (cachekey := self._cover_cache_key()):
+            self.metadata.pop("_embedded_extra_covers", None)
             return
-        norm_artist = nowplaying.utils.normalize(
-            self.metadata["artist"], sizecheck=0, nospaces=True
-        )
-        norm_album = nowplaying.utils.normalize(self.metadata["album"], sizecheck=0, nospaces=True)
-        normalid = f"{norm_artist}_{norm_album}"
-        identifier = f"{self.metadata['artist']}_{self.metadata['album']}"
+        normalid, identifier, cover_type = cachekey
+        # Namespace the URL by type too: normalid alone can be identical for an album
+        # and a track (a self-titled album with a title track), and url is the primary key.
+        urlbase = f"embedded://{cover_type}/{normalid}"
         storage = nowplaying.datacache.get_client().storage
         if self.metadata.get("coverimageraw"):
             logging.debug(
@@ -167,9 +199,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                 normalid,
             )
             await storage.store(
-                url=f"embedded://{normalid}/provided_0",
+                url=f"{urlbase}/provided_0",
                 identifier=normalid,
-                data_type="front_cover",
+                data_type=cover_type,
                 provider="embedded",
                 data_value=self.metadata["coverimageraw"],
                 ttl_seconds=30 * 24 * 3600,
@@ -181,9 +213,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                 converted = nowplaying.utils.image2png(raw_data)
                 if converted:
                     await storage.store(
-                        url=f"embedded://{normalid}/provided_{index}",
+                        url=f"{urlbase}/provided_{index}",
                         identifier=normalid,
-                        data_type="front_cover",
+                        data_type=cover_type,
                         provider="embedded",
                         data_value=converted,
                         ttl_seconds=30 * 24 * 3600,
@@ -191,7 +223,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                     )
         else:
             self.metadata.pop("_embedded_extra_covers", None)
-            result = await storage.retrieve_by_identifier(normalid, "front_cover", random=True)
+            result = await storage.retrieve_by_identifier(normalid, cover_type, random=True)
             if result:
                 logging.debug("Restoring coverimageraw from datacache for %s", identifier)
                 self.metadata["coverimageraw"] = result.data

--- a/nowplaying/metadata/processors.py
+++ b/nowplaying/metadata/processors.py
@@ -29,16 +29,49 @@ from nowplaying.types import TrackMetadata
 import nowplaying.datacache
 import nowplaying.datacache.colors
 
-# Cover art is cached per album so embedded and network art share a lookup key.
-# Tracks with no album tag fall back to an artist+title key under a separate
-# data_type: a self-titled album with a title track ("Weezer", "Bad") would
-# otherwise produce the same key as the album itself.
-ALBUM_COVER_TYPE = "front_cover"
-TRACK_COVER_TYPE = "track_cover"
+# All cover art is one data_type: a track's embedded art is still a front cover,
+# and data_type drives eviction, TTL, and color extraction (see IMAGE_DATA_TYPES
+# and COLOR_EXTRACT_TYPES in datacache), so splitting it would need registering
+# in each of those.  What varies is the *subject* the art is filed under, which
+# is the identifier's job — hence the prefix below rather than a second type.
+COVER_DATA_TYPE = "front_cover"
+_TRACK_COVER_PREFIX = "track_"
 
 NOTE_RE = re.compile("N(?i:ote):")
 YOUTUBE_COMMENT_MATCH_RE = re.compile(r"^https?://(?:www\.)?youtube\.com/watch\?v=")
 YOUTUBE_TITLE_MATCH_RE = re.compile(r"^[^\s]+_-_[^\s]+")
+
+
+def cover_cache_key(metadata: TrackMetadata) -> tuple[str, str] | None:
+    """Return (datacache identifier, human-readable label) for a track's front cover.
+
+    Prefers artist+album, normalizing each part before joining — mirrors
+    queue_front_cover() in artistextras/__init__.py so embedded art and network art
+    share one entry.  Tracks with no album tag (promos, white labels, untagged rips)
+    fall back to artist+title behind a prefix, so their embedded art is still cached
+    and still found on replay without colliding with a same-named album: "Weezer"
+    the album and "Weezer" the track normalize identically.
+
+    Shared with trackpoll's late cover lookup so both sides agree on the key.
+
+    Returns None when there is nothing usable to key on.
+    """
+    artist = metadata.get("artist")
+    norm_artist = nowplaying.utils.normalize(artist, sizecheck=0, nospaces=True)
+    if not norm_artist:
+        return None
+
+    if (album := metadata.get("album")) and (
+        norm_album := nowplaying.utils.normalize(album, sizecheck=0, nospaces=True)
+    ):
+        return f"{norm_artist}_{norm_album}", f"{artist}_{album}"
+
+    if (title := metadata.get("title")) and (
+        norm_title := nowplaying.utils.normalize(title, sizecheck=0, nospaces=True)
+    ):
+        return f"{_TRACK_COVER_PREFIX}{norm_artist}_{norm_title}", f"{artist}_{title}"
+
+    return None
 
 
 def split_youtube_title(title: str) -> tuple[str, str]:
@@ -127,10 +160,16 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         except Exception:  # pylint: disable=broad-except
             logging.exception("Ignoring sub-metaproc failure.")
 
-        await self._process_cover_images()
-
+        # Cover caching keys on title, so run it after the title fixups: otherwise an
+        # input plugin reporting "Artist - Title" keys under the raw string while a
+        # cleaner one keys under the stripped title, splitting one track across two
+        # entries.  _strip_identifiers() in _finalize_metadata() edits the title again
+        # later, so the key still is not the final title — but it cannot move past
+        # _process_plugins(), which expects cover art resolved before plugins run.
         self._fix_filename_stem()
         self._fix_artist_in_title()
+
+        await self._process_cover_images()
 
         await self._process_plugins(skipplugins)
 
@@ -152,45 +191,13 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
         self._finalize_metadata()
         return self.metadata
 
-    def _cover_cache_key(self) -> tuple[str, str, str] | None:
-        """Return (normalized key, human-readable identifier, data_type) for cover art.
-
-        Album art normalizes artist+album separately then joins — mirrors
-        queue_front_cover() in artistextras/__init__.py so the lookup key matches
-        what network-art plugins store.  Tracks with no album tag (promos, white
-        labels, untagged rips) fall back to artist+title so their embedded art is
-        still cached and still found on replay; that key lives under a separate
-        data_type to avoid colliding with a same-named album.
-
-        Returns None when there is nothing usable to key on.
-        """
-        artist = self.metadata.get("artist")
-        norm_artist = nowplaying.utils.normalize(artist, sizecheck=0, nospaces=True)
-        if not norm_artist:
-            return None
-
-        if (album := self.metadata.get("album")) and (
-            norm_album := nowplaying.utils.normalize(album, sizecheck=0, nospaces=True)
-        ):
-            return f"{norm_artist}_{norm_album}", f"{artist}_{album}", ALBUM_COVER_TYPE
-
-        if (title := self.metadata.get("title")) and (
-            norm_title := nowplaying.utils.normalize(title, sizecheck=0, nospaces=True)
-        ):
-            return f"{norm_artist}_{norm_title}", f"{artist}_{title}", TRACK_COVER_TYPE
-
-        return None
-
     async def _process_cover_images(self) -> None:
         """Store embedded cover art in datacache, or restore a cached image when none is
         embedded."""
-        if not (cachekey := self._cover_cache_key()):
+        if not (cachekey := cover_cache_key(self.metadata)):
             self.metadata.pop("_embedded_extra_covers", None)
             return
-        normalid, identifier, cover_type = cachekey
-        # Namespace the URL by type too: normalid alone can be identical for an album
-        # and a track (a self-titled album with a title track), and url is the primary key.
-        urlbase = f"embedded://{cover_type}/{normalid}"
+        normalid, identifier = cachekey
         storage = nowplaying.datacache.get_client().storage
         if self.metadata.get("coverimageraw"):
             logging.debug(
@@ -199,9 +206,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                 normalid,
             )
             await storage.store(
-                url=f"{urlbase}/provided_0",
+                url=f"embedded://{normalid}/provided_0",
                 identifier=normalid,
-                data_type=cover_type,
+                data_type=COVER_DATA_TYPE,
                 provider="embedded",
                 data_value=self.metadata["coverimageraw"],
                 ttl_seconds=30 * 24 * 3600,
@@ -213,9 +220,9 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                 converted = nowplaying.utils.image2png(raw_data)
                 if converted:
                     await storage.store(
-                        url=f"{urlbase}/provided_{index}",
+                        url=f"embedded://{normalid}/provided_{index}",
                         identifier=normalid,
-                        data_type=cover_type,
+                        data_type=COVER_DATA_TYPE,
                         provider="embedded",
                         data_value=converted,
                         ttl_seconds=30 * 24 * 3600,
@@ -223,7 +230,7 @@ class MetadataProcessors:  # pylint: disable=too-few-public-methods
                     )
         else:
             self.metadata.pop("_embedded_extra_covers", None)
-            result = await storage.retrieve_by_identifier(normalid, cover_type, random=True)
+            result = await storage.retrieve_by_identifier(normalid, COVER_DATA_TYPE, random=True)
             if result:
                 logging.debug("Restoring coverimageraw from datacache for %s", identifier)
                 self.metadata["coverimageraw"] = result.data

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -21,6 +21,7 @@ import nowplaying.guessgame
 import nowplaying.datacache
 import nowplaying.inputs
 import nowplaying.metadata
+import nowplaying.metadata.processors
 import nowplaying.notifications
 import nowplaying.pluginimporter
 import nowplaying.trackrequests
@@ -701,14 +702,20 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
 
         if not self.currentmeta.get("coverimageraw"):
             storage = nowplaying.datacache.get_client().storage
-            artist = self.currentmeta.get("artist")
-            album = self.currentmeta.get("album")
-            if artist and album:
-                norm_artist = nowplaying.utils.normalize(artist, sizecheck=0, nospaces=True)
-                norm_album = nowplaying.utils.normalize(album, sizecheck=0, nospaces=True)
+            # Shared with _process_cover_images() so both sides build the key the same
+            # way and album-less tracks get looked up here too.  They do not always
+            # agree on the *input*: that stores mid-pipeline, while currentmeta has
+            # been through _strip_identifiers().  So an album-less track whose title
+            # loses content to titlestripper() was stored under the unstripped title
+            # and will miss here.  Silent miss, never wrong art, and the album path is
+            # unaffected since it does not key on title.  Making it hit would mean
+            # carrying the computed identifier through as another temp key, or
+            # stripping before MusicBrainz sees the title -- neither is worth it for a
+            # fallback.
+            if cachekey := nowplaying.metadata.processors.cover_cache_key(self.currentmeta):
                 result = await storage.retrieve_by_identifier(
-                    f"{norm_artist}_{norm_album}",
-                    "front_cover",
+                    cachekey[0],
+                    nowplaying.metadata.processors.COVER_DATA_TYPE,
                     random=True,
                 )
                 if result:

--- a/tests/test_processors_unit.py
+++ b/tests/test_processors_unit.py
@@ -275,8 +275,8 @@ async def test_prioritizenetworkart_toggle(bootstrap, prioritize_network):
 
     fake_image = b"fake-embedded-cover-bytes"
     metadatain = {
-        "artist": "Test Artist",
-        "title": "Test Song",
+        "artist": "WNP Mock Artist",
+        "title": "WNP Mock Song",
         "coverimageraw": fake_image,
         "_embedded_extra_covers": [fake_image],
     }
@@ -303,7 +303,88 @@ async def test_prioritizenetworkart_toggle(bootstrap, prioritize_network):
     # In both cases the embedded art should be present: when toggle is off it
     # was never cleared; when toggle is on plugins found nothing so it was restored.
     assert metadataout.get("coverimageraw") == fake_image
-    # _embedded_extra_covers is only stripped by the stash block (prioritize_network=True)
-    # or by the datacache block which requires artist+album; no album here so False keeps it.
-    if prioritize_network:
-        assert "_embedded_extra_covers" not in metadataout
+    # Stripped either by the stash block (prioritize_network=True) or by the
+    # datacache block, which now handles album-less tracks via the artist+title key.
+    assert "_embedded_extra_covers" not in metadataout
+
+
+def _processors(config):
+    """build a MetadataProcessors with plugins/network work disabled"""
+    config.cparser.setValue("acoustidmb/enabled", False)
+    config.cparser.setValue("musicbrainz/enabled", False)
+    return nowplaying.metadata.MetadataProcessors(config=config)
+
+
+@pytest.mark.parametrize(
+    "metadata,expected_key,expected_type",
+    [
+        # album present: key on artist+album so embedded and network art collide on purpose
+        (
+            {"artist": "WNP Mock Artist", "album": "WNP Mock Album", "title": "WNP Mock Song"},
+            "wnpmockartist_wnpmockalbum",
+            nowplaying.metadata.processors.ALBUM_COVER_TYPE,
+        ),
+        # no album at all: fall back to artist+title
+        (
+            {"artist": "WNP Mock Artist", "title": "WNP Mock Song"},
+            "wnpmockartist_wnpmocksong",
+            nowplaying.metadata.processors.TRACK_COVER_TYPE,
+        ),
+        # empty album is treated as absent
+        (
+            {"artist": "WNP Mock Artist", "album": "", "title": "WNP Mock Song"},
+            "wnpmockartist_wnpmocksong",
+            nowplaying.metadata.processors.TRACK_COVER_TYPE,
+        ),
+        # an album that normalizes away also falls back rather than keying on "None"
+        (
+            {"artist": "WNP Mock Artist", "album": "'", "title": "WNP Mock Song"},
+            "wnpmockartist_wnpmocksong",
+            nowplaying.metadata.processors.TRACK_COVER_TYPE,
+        ),
+    ],
+)
+def test_cover_cache_key(bootstrap, metadata, expected_key, expected_type):
+    """cover art keys on artist+album, falling back to artist+title when album is missing"""
+    processors = _processors(bootstrap)
+    processors.metadata = metadata
+
+    normalid, _identifier, cover_type = processors._cover_cache_key()  # pylint: disable=protected-access
+
+    assert normalid == expected_key
+    assert cover_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"title": "WNP Mock Song"},  # no artist
+        {"artist": "WNP Mock Artist"},  # artist but nothing to pair it with
+        {"artist": "'", "title": "WNP Mock Song"},  # artist normalizes away
+        {},
+    ],
+)
+def test_cover_cache_key_unusable(bootstrap, metadata):
+    """metadata with nothing to key on yields no cache key rather than a bogus one"""
+    processors = _processors(bootstrap)
+    processors.metadata = metadata
+
+    assert processors._cover_cache_key() is None  # pylint: disable=protected-access
+
+
+def test_cover_cache_key_selftitled_album_does_not_collide(bootstrap):
+    """A self-titled album and a same-named track share a key but not a data_type.
+
+    "Weezer"/"Weezer" and Michael Jackson's "Bad"/"Bad" would otherwise let an
+    album-less track overwrite or read the album's cover art.
+    """
+    processors = _processors(bootstrap)
+
+    processors.metadata = {"artist": "Weezer", "album": "Weezer"}
+    album_key, _, album_type = processors._cover_cache_key()  # pylint: disable=protected-access
+
+    processors.metadata = {"artist": "Weezer", "title": "Weezer"}
+    track_key, _, track_type = processors._cover_cache_key()  # pylint: disable=protected-access
+
+    assert album_key == track_key
+    assert album_type != track_type

--- a/tests/test_processors_unit.py
+++ b/tests/test_processors_unit.py
@@ -308,51 +308,37 @@ async def test_prioritizenetworkart_toggle(bootstrap, prioritize_network):
     assert "_embedded_extra_covers" not in metadataout
 
 
-def _processors(config):
-    """build a MetadataProcessors with plugins/network work disabled"""
-    config.cparser.setValue("acoustidmb/enabled", False)
-    config.cparser.setValue("musicbrainz/enabled", False)
-    return nowplaying.metadata.MetadataProcessors(config=config)
-
-
 @pytest.mark.parametrize(
-    "metadata,expected_key,expected_type",
+    "metadata,expected_key",
     [
-        # album present: key on artist+album so embedded and network art collide on purpose
+        # album present: key on artist+album so embedded and network art share an entry
         (
             {"artist": "WNP Mock Artist", "album": "WNP Mock Album", "title": "WNP Mock Song"},
             "wnpmockartist_wnpmockalbum",
-            nowplaying.metadata.processors.ALBUM_COVER_TYPE,
         ),
-        # no album at all: fall back to artist+title
+        # no album at all: fall back to a prefixed artist+title key
         (
             {"artist": "WNP Mock Artist", "title": "WNP Mock Song"},
-            "wnpmockartist_wnpmocksong",
-            nowplaying.metadata.processors.TRACK_COVER_TYPE,
+            "track_wnpmockartist_wnpmocksong",
         ),
         # empty album is treated as absent
         (
             {"artist": "WNP Mock Artist", "album": "", "title": "WNP Mock Song"},
-            "wnpmockartist_wnpmocksong",
-            nowplaying.metadata.processors.TRACK_COVER_TYPE,
+            "track_wnpmockartist_wnpmocksong",
         ),
-        # an album that normalizes away also falls back rather than keying on "None"
+        # a whitespace-only album normalizes to empty, so fall back rather than
+        # keying on the literal string "None"
         (
-            {"artist": "WNP Mock Artist", "album": "'", "title": "WNP Mock Song"},
-            "wnpmockartist_wnpmocksong",
-            nowplaying.metadata.processors.TRACK_COVER_TYPE,
+            {"artist": "WNP Mock Artist", "album": "  ", "title": "WNP Mock Song"},
+            "track_wnpmockartist_wnpmocksong",
         ),
     ],
 )
-def test_cover_cache_key(bootstrap, metadata, expected_key, expected_type):
+def test_cover_cache_key(metadata, expected_key):
     """cover art keys on artist+album, falling back to artist+title when album is missing"""
-    processors = _processors(bootstrap)
-    processors.metadata = metadata
+    identifier, _label = nowplaying.metadata.processors.cover_cache_key(metadata)
 
-    normalid, _identifier, cover_type = processors._cover_cache_key()  # pylint: disable=protected-access
-
-    assert normalid == expected_key
-    assert cover_type == expected_type
+    assert identifier == expected_key
 
 
 @pytest.mark.parametrize(
@@ -360,31 +346,27 @@ def test_cover_cache_key(bootstrap, metadata, expected_key, expected_type):
     [
         {"title": "WNP Mock Song"},  # no artist
         {"artist": "WNP Mock Artist"},  # artist but nothing to pair it with
-        {"artist": "'", "title": "WNP Mock Song"},  # artist normalizes away
+        {"artist": "  ", "title": "WNP Mock Song"},  # artist normalizes to empty
         {},
     ],
 )
-def test_cover_cache_key_unusable(bootstrap, metadata):
+def test_cover_cache_key_unusable(metadata):
     """metadata with nothing to key on yields no cache key rather than a bogus one"""
-    processors = _processors(bootstrap)
-    processors.metadata = metadata
-
-    assert processors._cover_cache_key() is None  # pylint: disable=protected-access
+    assert nowplaying.metadata.processors.cover_cache_key(metadata) is None
 
 
-def test_cover_cache_key_selftitled_album_does_not_collide(bootstrap):
-    """A self-titled album and a same-named track share a key but not a data_type.
+def test_cover_cache_key_selftitled_album_does_not_collide():
+    """A self-titled album and a same-named track must not share a key.
 
-    "Weezer"/"Weezer" and Michael Jackson's "Bad"/"Bad" would otherwise let an
-    album-less track overwrite or read the album's cover art.
+    "Weezer"/"Weezer" and Michael Jackson's Bad/"Bad" normalize identically, so
+    without the track prefix an album-less track would read or overwrite the
+    album's cover art.
     """
-    processors = _processors(bootstrap)
+    album_key, _ = nowplaying.metadata.processors.cover_cache_key(
+        {"artist": "Weezer", "album": "Weezer"}
+    )
+    track_key, _ = nowplaying.metadata.processors.cover_cache_key(
+        {"artist": "Weezer", "title": "Weezer"}
+    )
 
-    processors.metadata = {"artist": "Weezer", "album": "Weezer"}
-    album_key, _, album_type = processors._cover_cache_key()  # pylint: disable=protected-access
-
-    processors.metadata = {"artist": "Weezer", "title": "Weezer"}
-    track_key, _, track_type = processors._cover_cache_key()  # pylint: disable=protected-access
-
-    assert album_key == track_key
-    assert album_type != track_type
+    assert album_key != track_key


### PR DESCRIPTION
_process_cover_images() returned early unless both artist and album were set, so a track with no album tag never cached its embedded art and never found it again on replay. Promos, white labels, and untagged rips are common in DJ libraries, and with multi-deck display coming, unaddressable art becomes a bigger problem.

Extract _cover_cache_key(), which keeps the artist+album key when an album is present (matching queue_front_cover() in artistextras so embedded and network art still share a lookup) and falls back to artist+title otherwise.

The fallback lives under its own data_type rather than sharing front_cover. A self-titled album with a title track -- Weezer/"Weezer", Michael Jackson's Bad/"Bad" -- normalizes to the same key both ways, so sharing the type would let an album-less track read or overwrite the album's cover. The url is namespaced by type for the same reason, since url is the primary key.

Also guard on the normalized values rather than the raw ones: normalize() returns None for input that reduces to nothing, which previously could build a key containing the literal string "None".

## Summary by Sourcery

Handle cover art caching for tracks without album tags and unify cache key generation across metadata processing and track polling.

Bug Fixes:
- Ensure embedded cover art for tracks missing album tags is cached and restored on replay instead of being ignored.

Enhancements:
- Introduce a shared cover cache key helper that normalizes artist/album or artist/title and prevents collisions between self-titled albums and same-named tracks.
- Centralize cover art data type configuration via a COVER_DATA_TYPE constant and reuse it in both storage and retrieval paths.
- Adjust metadata processing order so cover caching runs after title fixups to avoid splitting cache entries for the same track.

Tests:
- Expand processor tests to cover the new cover_cache_key behavior, including fallbacks, unusable metadata, and self-titled album collision avoidance, and update existing network-art prioritization tests to reflect the new cache handling.