### PR TITLE
denon: multi-device StagelinQ rework (5.2 port)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -47,7 +47,7 @@ updates required.
 * **[Virtual DJ](input/virtualdj.md)** — history and playlist database with background refresh,
   artist search
 * **[Denon DJ](input/denon.md)** (StagelinQ protocol) — direct network connection to supported
-  hardware
+  hardware, including multi-player setups (e.g. two SC6000s), with or without a Denon mixer
 * **[djay Pro](input/djaypro.md)** — track detection and metadata
 * **[DJUCED](input/djuced.md)** — database integration, smart playlists, artist search
 * **[JRiver Media Center](input/jriver.md)** — via network API

--- a/docs/input/denon.md
+++ b/docs/input/denon.md
@@ -6,9 +6,12 @@ Connects directly to Denon DJ equipment over your network to get real-time track
 
 ## Supported Equipment
 
-- Denon DJ Prime series mixers (Prime 2, Prime 4, Prime Go/Go+)
-- Denon DJ standalone players (SC5000, SC6000)
+- Denon DJ standalone all-in-ones (Prime 2, Prime 4, Prime Go/Go+, SC Live 2/4, Mixstream Pro series)
+- Denon DJ standalone players (SC5000/SC5000M, SC6000/SC6000M)
 - Other StagelinQ-compatible Denon DJ equipment
+
+Denon DJ mixers (X1800/X1850 Prime) do not need to be configured: they push fader and crossfader
+information to the connected players automatically, and **What's Now Playing** reads it from there.
 
 ## Instructions
 
@@ -26,10 +29,39 @@ Connects directly to Denon DJ equipment over your network to get real-time track
 2. **Deck Skip** - Check decks to ignore during track detection
 3. Click Save
 
+## Multiple Players
+
+**What's Now Playing** connects to every Denon DJ player and all-in-one it finds on the network
+at the same time, so setups such as two SC6000s with a mixer work out of the box.
+
+With more than one player, deck numbers are assigned by the player number set on each unit
+(Engine OS preferences, shown on the jog display), then by layer:
+
+| Player | Layer | Deck number |
+|--------|-------|-------------|
+| 1      | A     | 1           |
+| 1      | B     | 2           |
+| 2      | A     | 3           |
+| 2      | B     | 4           |
+
+A single all-in-one keeps its usual deck 1-4 numbering. The **Deck Skip** checkboxes refer to
+these numbers, so with two players, "Deck 3" means player 2's layer A. If a player leaves the
+network, the remaining decks are renumbered, so double-check deck skip settings if you change
+your setup mid-show.
+
+> NOTE: Give each unit a **distinct player number**. If two players are both left at the
+> default of 1, deck numbering falls back to an arbitrary order and a warning is logged.
+
 ## How It Works
 
-**What's Now Playing** monitors all decks and selects the track your audience is actually hearing based on fader
-positions, crossfader state, and play status.
+**What's Now Playing** monitors all decks and selects the track your audience is actually
+hearing based on fader positions, crossfader state, and play status.
+
+- **All-in-one units** report their own fader and crossfader positions.
+- **Players with a Denon DJ mixer** (X1800/X1850) receive per-deck volume from the mixer;
+  no direct mixer connection is needed.
+- **Players with a third-party or analog mixer** provide no volume information, so every
+  playing deck is treated as audible and selection falls back to play status and mix mode.
 
 ## Troubleshooting
 
@@ -45,6 +77,8 @@ positions, crossfader state, and play status.
 - Check deck skip settings
 - Verify fader positions (very low faders are ignored)
 - Try switching between "newest" and "oldest" mix modes
+- With an analog or third-party mixer, fader positions are unavailable: stop or pause decks
+  that should not be reported
 
 ### Connection Issues
 

--- a/nowplaying/denon/connection.py
+++ b/nowplaying/denon/connection.py
@@ -326,6 +326,7 @@ class ConnectionManager:
             if writer:
                 with contextlib.suppress(Exception):
                     writer.close()
+                    await writer.wait_closed()
 
     async def send_announcements(self) -> None:
         """Continuously announce ourselves to devices"""

--- a/nowplaying/denon/connection.py
+++ b/nowplaying/denon/connection.py
@@ -11,6 +11,9 @@ import contextlib
 import logging
 import socket
 from collections.abc import Callable
+from dataclasses import dataclass
+
+import netifaces
 
 import nowplaying.version  # pylint: disable=no-member,import-error,no-name-in-module
 
@@ -19,10 +22,22 @@ from .types import (
     DISCOVERY_PORT,
     MSG_REFERENCE,
     MSG_SERVICE_ANNOUNCEMENT,
+    MSG_SERVICES_REQUEST,
     DenonDevice,
     DenonService,
     DenonState,
 )
+
+
+@dataclass
+class DeviceConnection:
+    """Live connections and tasks for one StagelinQ device"""
+
+    device: DenonDevice
+    main_writer: asyncio.StreamWriter
+    ref_task: asyncio.Task
+    state_writer: asyncio.StreamWriter | None = None
+    monitor_task: asyncio.Task | None = None
 
 
 class ConnectionManager:
@@ -30,9 +45,9 @@ class ConnectionManager:
 
     def __init__(self, token: bytes):
         self.token = token
-        self.device: DenonDevice | None = None
-        self.state_service: DenonService | None = None
-        self.connections: list[asyncio.StreamWriter] = []
+        # live device connections keyed by discovery token
+        self.active: dict[bytes, DeviceConnection] = {}
+        # global tasks: self-announcement and the discovery loop
         self.tasks: list[asyncio.Task] = []
 
     async def discover_devices(self, timeout: float) -> list[DenonDevice]:
@@ -59,8 +74,16 @@ class ConnectionManager:
                         and device.token not in found_tokens
                         and device.token != self.manager.token
                     ):
-                        devices.append(device)
                         found_tokens.add(device.token)
+                        if device.is_connectable():
+                            devices.append(device)
+                        else:
+                            logging.debug(
+                                "Skipping non-connectable StagelinQ device: %s (%s) at %s",
+                                device.name,
+                                device.software_name,
+                                addr[0],
+                            )
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     logging.debug("Failed to parse discovery message from %s: %s", addr, err)
 
@@ -96,13 +119,10 @@ class ConnectionManager:
         """Connect to device and get available services"""
         reader, writer = await asyncio.open_connection(device.ipaddr, device.port)
 
+        # Start reference message task to keep the connection alive
+        ref_task = asyncio.create_task(self._send_reference_messages(writer, device.token))
+
         try:
-            self.connections.append(writer)
-
-            # Start reference message task
-            ref_task = asyncio.create_task(self._send_reference_messages(writer, device.token))
-            self.tasks.append(ref_task)
-
             # Send services request
             services_msg = StagelinqProtocol.create_services_request(self.token)
             writer.write(services_msg)
@@ -136,25 +156,79 @@ class ConnectionManager:
                         if service:
                             services.append(service)
 
+                    elif msg_id == MSG_SERVICES_REQUEST:
+                        # Devices are peers: they ask what services we offer.
+                        # Consume the device's token and keep reading; we
+                        # offer no services of our own.
+                        await reader.readexactly(16)
+
                     elif msg_id == MSG_REFERENCE:
                         # End of service list
                         await reader.readexactly(40)  # Skip reference message data
                         break
 
+                    else:
+                        # Unknown message: length is unknowable, so the rest
+                        # of the stream cannot be parsed safely
+                        logging.warning(
+                            "Unknown StagelinQ message id 0x%08x from %s; "
+                            "stopping service read with %d service(s)",
+                            msg_id,
+                            device.ipaddr,
+                            len(services),
+                        )
+                        break
+
                 except asyncio.IncompleteReadError:
                     break
 
+            # Hand the live connection and its keepalive to the manager;
+            # callers that decide not to use this device must call
+            # disconnect_device() to release them
+            self.active[device.token] = DeviceConnection(
+                device=device, main_writer=writer, ref_task=ref_task
+            )
             return services
 
-        except Exception:
-            # Ensure writer is closed on any failure
+        except BaseException:  # pylint: disable=broad-exception-caught
+            # Ensure keepalive is stopped and writer is closed on any
+            # failure. BaseException so that cancellation (stop() during an
+            # input-plugin switch cancelling an in-flight setup task) cannot
+            # orphan the keepalive and socket, which are not yet registered
+            # in self.active at this point. Close the socket synchronously
+            # first: close() cannot be interrupted by a further cancel.
+            writer.close()
+            ref_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ref_task
             with contextlib.suppress(Exception):
-                writer.close()
                 await writer.wait_closed()
-            # Remove from connections list if it was added
-            if writer in self.connections:
-                self.connections.remove(writer)
             raise
+
+    async def disconnect_device(self, token: bytes) -> None:
+        """Close all connections and stop all tasks for one device"""
+        conn = self.active.pop(token, None)
+        if not conn:
+            return
+
+        # Close sockets synchronously first: the conn is already popped from
+        # self.active, so a cancellation between the awaits below must not be
+        # able to skip these
+        for writer in (conn.state_writer, conn.main_writer):
+            if writer:
+                with contextlib.suppress(Exception):
+                    writer.close()
+
+        for task in (conn.monitor_task, conn.ref_task):
+            if task and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        for writer in (conn.state_writer, conn.main_writer):
+            if writer:
+                with contextlib.suppress(Exception):
+                    await writer.wait_closed()
 
     async def monitor_state_changes(  # pylint: disable=too-many-locals
         self,
@@ -163,9 +237,11 @@ class ConnectionManager:
         state_callback: Callable[[DenonState], None],
     ) -> None:
         """Monitor track state changes from StateMap service"""
+        writer = None
         try:
             reader, writer = await asyncio.open_connection(device.ipaddr, service.port)
-            self.connections.append(writer)
+            if conn := self.active.get(device.token):
+                conn.state_writer = writer
 
             # Send service announcement
             local_port = writer.get_extra_info("sockname")[1]
@@ -189,11 +265,27 @@ class ConnectionManager:
                         f"/Engine/Deck{deck}/Track/Genre",
                         f"/Engine/Deck{deck}/Track/SongLoaded",
                         f"/Mixer/CH{deck}faderPosition",
+                        # Effective per-deck audibility: Denon mixers and
+                        # all-in-one controllers push fader x crossfader into
+                        # the deck's own StateMap; standalone players never
+                        # emit /Mixer/ states at all
+                        f"/Engine/Deck{deck}/ExternalMixerVolume",
+                        f"/Engine/Deck{deck}/DeckIsMaster",
                     ]
                 )
 
             # Also subscribe to crossfader position
             state_paths.append("/Mixer/CrossfaderPosition")
+
+            # Device-level states: DJ-assigned player number (deck identity
+            # across multiple players), deck count, and sync-master status
+            state_paths.extend(
+                [
+                    "/Client/Preferences/Player",
+                    "/Engine/DeckCount",
+                    "/Engine/Sync/Network/MasterStatus",
+                ]
+            )
 
             for state_path in state_paths:
                 sub_msg = StagelinqProtocol.create_state_subscription(state_path)
@@ -210,7 +302,16 @@ class ConnectionManager:
 
                     if state := StagelinqProtocol.parse_state_emit_message(payload):
                         state_callback(state)
-                        logging.debug("State update: %s = %s", state.name, state.value)
+                        # Include the device address: multiple players often
+                        # share a name (e.g. two "sc6000m") and all use the
+                        # same per-device Deck1/Deck2 state paths
+                        logging.debug(
+                            "State update [%s@%s]: %s = %s",
+                            device.name,
+                            device.ipaddr,
+                            state.name,
+                            state.value,
+                        )
 
                 except asyncio.IncompleteReadError:
                     break
@@ -218,6 +319,13 @@ class ConnectionManager:
         except Exception as err:  # pylint: disable=broad-exception-caught
             logging.debug("Track monitoring error: %s", err)
             raise
+        finally:
+            # The monitor ending means this connection is finished; close
+            # the writer directly in case the device was disconnected
+            # before it could be registered in self.active
+            if writer:
+                with contextlib.suppress(Exception):
+                    writer.close()
 
     async def send_announcements(self) -> None:
         """Continuously announce ourselves to devices"""
@@ -230,6 +338,21 @@ class ConnectionManager:
         except Exception as err:  # pylint: disable=broad-exception-caught
             logging.debug("Announcement error: %s", err)
 
+    @staticmethod
+    def _get_broadcast_addresses() -> list[str]:
+        """Get broadcast addresses for all IPv4 interfaces plus the global broadcast"""
+        addresses = {"255.255.255.255"}
+        try:
+            # pylint: disable=no-member
+            for interface in netifaces.interfaces():
+                for addr_info in netifaces.ifaddresses(interface).get(netifaces.AF_INET, []):
+                    broadcast = addr_info.get("broadcast")
+                    if broadcast and not addr_info.get("addr", "").startswith("127."):
+                        addresses.add(broadcast)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Failed to enumerate interface broadcast addresses")
+        return sorted(addresses)
+
     async def _announce_self(self) -> None:
         """Send UDP announcement to let devices know about us"""
         try:
@@ -240,10 +363,14 @@ class ConnectionManager:
                 nowplaying.version.__VERSION__,  # pylint:disable=no-member
             )
 
-            # Send to broadcast address
+            # The global broadcast address only goes out the default-route
+            # interface, so also send to each interface's subnet broadcast
+            # to reach devices on non-default networks
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            sock.sendto(message, ("255.255.255.255", DISCOVERY_PORT))
+            for address in self._get_broadcast_addresses():
+                with contextlib.suppress(OSError):
+                    sock.sendto(message, (address, DISCOVERY_PORT))
             sock.close()
 
         except Exception as err:  # pylint: disable=broad-exception-caught
@@ -268,21 +395,13 @@ class ConnectionManager:
 
     async def cleanup(self) -> None:
         """Stop all tasks and close all connections"""
-        # Cancel all tasks
+        # Disconnect every device (monitors, keepalives, sockets)
+        for token in list(self.active):
+            await self.disconnect_device(token)
+
+        # Cancel global tasks (announcements, discovery loop)
         for task in self.tasks:
             task.cancel()
-
-        # Close all connections
-        for writer in self.connections:
-            with contextlib.suppress(Exception):
-                writer.close()
-                await writer.wait_closed()
-
-        # Wait for tasks to complete
         if self.tasks:
             await asyncio.gather(*self.tasks, return_exceptions=True)
-
         self.tasks.clear()
-        self.connections.clear()
-        self.device = None
-        self.state_service = None

--- a/nowplaying/denon/metadata.py
+++ b/nowplaying/denon/metadata.py
@@ -2,34 +2,78 @@
 """
 StagelinQ Metadata Processor
 
-This module handles track selection logic, fader calculations, and metadata extraction.
-It contains all the business logic for determining which track is "now playing"
-based on mixer state and configuration.
+This module handles track selection logic, audibility calculations, and metadata
+extraction across all connected StagelinQ devices. It contains the business logic
+for determining which track is "now playing" based on per-device deck state,
+mixer signals, and configuration.
 """
 
+import logging
 import time
 from typing import Any
 
 from nowplaying.types import TrackMetadata
 
-from .types import DenonState
+from .types import DenonDevice, DenonState
 
 # Minimum effective volume considered "audible" (0.0-1.0 scale)
 AUDIBLE_VOLUME_THRESHOLD = 0.1
 
+# Decks assumed for devices whose model and DeckCount state are both unknown
+DEFAULT_DECK_COUNT = 4
+
+# Player numbers are 1-4; unknown players sort after all known ones
+UNKNOWN_PLAYER_SORT_KEY = 99
+
 
 class MetadataProcessor:
-    """Processes StagelinQ state data to determine currently playing track"""
+    """Determines the currently playing track from all connected devices' StateMaps"""
 
     def __init__(self, config):
         self.config = config
-        self.current_metadata: dict[str, dict[str, Any]] = {}
-        self._deck_play_times: dict[int, float] = {}
+        # per-device state stores, keyed by the device's discovery token
+        self._devices: dict[bytes, dict[str, Any]] = {}
+        self._device_info: dict[bytes, DenonDevice] = {}
+        # devices whose ExternalMixerVolume is being driven by a Denon
+        # mixer or controller (a nonzero value has been observed)
+        self._emv_active: set[bytes] = set()
+        self._deck_play_times: dict[tuple[bytes, int], float] = {}
         self._mixmode = "newest"
+        # player numbers already warned about as duplicated, to keep the
+        # per-poll enumeration from spamming the warning
+        self._warned_dup_players: set[int] = set()
 
-    def update_state(self, state: DenonState) -> None:
-        """Update internal state with new StagelinQ data"""
-        self.current_metadata[state.name] = state.value
+    def register_device(self, device: DenonDevice) -> None:
+        """Start tracking states for a connected device"""
+        self._devices.setdefault(device.token, {})
+        self._device_info[device.token] = device
+
+    def unregister_device(self, token: bytes) -> None:
+        """Stop tracking a disconnected device"""
+        self._devices.pop(token, None)
+        self._device_info.pop(token, None)
+        self._emv_active.discard(token)
+        for key in [key for key in self._deck_play_times if key[0] == token]:
+            del self._deck_play_times[key]
+
+    def update_state(self, token: bytes, state: DenonState) -> None:
+        """Update a device's state store with new StagelinQ data"""
+        states = self._devices.setdefault(token, {})
+        states[state.name] = state.value
+
+        # A mixerless player never updates ExternalMixerVolume (and may
+        # report an initial 0), so the value is only trustworthy once a
+        # Denon mixer/controller has demonstrably driven it nonzero
+        if (
+            token not in self._emv_active
+            and "/ExternalMixerVolume" in state.name
+            and self._extract_numeric_value(state.value) > 0.0
+        ):
+            self._emv_active.add(token)
+            logging.info(
+                "Denon mixer/controller is driving %s; using ExternalMixerVolume for audibility",
+                self._device_name(token),
+            )
 
     def set_mixmode(self, mixmode: str) -> str:
         """Set the mix mode"""
@@ -43,9 +87,6 @@ class MetadataProcessor:
 
     def get_playing_track(self) -> TrackMetadata | None:
         """Get the currently playing track metadata"""
-        if not self.current_metadata:
-            return None
-
         playing_decks = self._get_audible_playing_decks()
         if not playing_decks:
             return None
@@ -53,82 +94,219 @@ class MetadataProcessor:
         selected_deck = self._select_deck_by_mix_mode(playing_decks)
         return self._build_track_metadata(selected_deck)
 
+    def get_all_decks(self) -> list[dict]:
+        """Snapshot of every loaded deck across all devices, regardless of play state.
+
+        Groundwork for multi-deck displays: each entry carries the logical
+        deck number, display label, track fields, play state, and audibility.
+        deckskip is deliberately not applied - that is a now-playing
+        selection concern; display consumers decide their own filtering.
+        """
+        decks = []
+        for logical_deck, token, deck_idx in self._enumerate_logical_decks():
+            if deck_info := self._deck_snapshot(logical_deck, token, deck_idx):
+                decks.append(deck_info)
+        return decks
+
+    def _deck_snapshot(self, logical_deck: int, token: bytes, deck_idx: int) -> dict | None:
+        """Build one deck's display snapshot, or None if nothing is loaded"""
+        states = self._devices.get(token, {})
+        prefix = f"/Engine/Deck{deck_idx}"
+        artist = self._state_field(states, f"{prefix}/Track/ArtistName", "string")
+        title = self._state_field(states, f"{prefix}/Track/SongName", "string")
+        loaded_state = states.get(f"{prefix}/Track/SongLoaded")
+        if not (artist or title or (isinstance(loaded_state, dict) and loaded_state.get("state"))):
+            return None
+
+        play_state = states.get(f"{prefix}/Play")
+        deck_info = {
+            "deck": logical_deck,
+            "label": self._deck_label(
+                {"token": token, "deck_idx": deck_idx, "deck": logical_deck}
+            ),
+            "artist": artist or "",
+            "title": title or "",
+            "playing": bool(isinstance(play_state, dict) and play_state.get("state") is True),
+            "effective_volume": self._effective_volume(token, deck_idx),
+        }
+        if album := self._state_field(states, f"{prefix}/Track/AlbumName", "string"):
+            deck_info["album"] = album
+        if bpm := self._state_field(states, f"{prefix}/Track/BPM", "data"):
+            deck_info["bpm"] = str(bpm)
+        if genre := self._state_field(states, f"{prefix}/Track/Genre", "string"):
+            deck_info["genre"] = genre
+        return deck_info
+
     def _get_deck_skip_list(self) -> list[str]:
-        """Get the list of decks to skip"""
+        """Get the list of logical deck numbers to skip"""
         deckskip = self.config.cparser.value("denon/deckskip")
         if deckskip and not isinstance(deckskip, list):
             deckskip = list(deckskip)
         return deckskip or []
 
+    def _device_name(self, token: bytes) -> str:
+        """Human-readable device name for logging, falling back to the token"""
+        if info := self._device_info.get(token):
+            return info.name
+        return token.hex()[:8]
+
+    def _player_number(self, token: bytes) -> int | None:
+        """DJ-assigned player number (1-4) from /Client/Preferences/Player"""
+        value = self._devices.get(token, {}).get("/Client/Preferences/Player")
+        if isinstance(value, dict) and (number := value.get("string")):
+            try:
+                return int(number)
+            except (ValueError, TypeError):
+                return None
+        return None
+
+    def _deck_count(self, token: bytes) -> int:
+        """Decks on a device: DeckCount state, then model table, then default"""
+        value = self._devices.get(token, {}).get("/Engine/DeckCount")
+        if isinstance(value, dict):
+            if count := int(self._extract_numeric_value(value)):
+                return count
+        info = self._device_info.get(token)
+        if info and info.model and info.model.deck_count:
+            return info.model.deck_count
+        return DEFAULT_DECK_COUNT
+
+    def _enumerate_logical_decks(self) -> list[tuple[int, bytes, int]]:
+        """Enumerate (logical deck number, token, device deck index) across devices.
+
+        Devices sort by DJ-assigned player number (unknown numbers last,
+        stable by token); each device then contributes its decks in order.
+        A single 4-deck controller maps to logical decks 1-4 exactly as a
+        single-device setup always has; two dual-layer players map to
+        player 1 layers A/B -> decks 1/2 and player 2 layers A/B -> 3/4.
+        """
+        self._warn_duplicate_player_numbers()
+        ordered = sorted(
+            self._devices,
+            key=lambda tok: (self._player_number(tok) or UNKNOWN_PLAYER_SORT_KEY, tok),
+        )
+        logical = []
+        deck_number = 1
+        for token in ordered:
+            for deck_idx in range(1, self._deck_count(token) + 1):
+                logical.append((deck_number, token, deck_idx))
+                deck_number += 1
+        return logical
+
+    def _warn_duplicate_player_numbers(self) -> None:
+        """Warn (once per composition) when devices share a player number.
+
+        Deck numbering and deck labels are keyed by the DJ-assigned player
+        number; two units left at the factory default of 1 get an arbitrary
+        (token-based) ordering and indistinguishable labels.
+        """
+        assigned: dict[int, int] = {}
+        for token in self._devices:
+            if (number := self._player_number(token)) is not None:
+                assigned[number] = assigned.get(number, 0) + 1
+        duplicated = {number for number, count in assigned.items() if count > 1}
+
+        if new_dups := duplicated - self._warned_dup_players:
+            logging.warning(
+                "Multiple Denon players report the same player number %s; "
+                "deck numbering will use an arbitrary order and deck labels "
+                "will repeat - assign a distinct player number to each unit",
+                sorted(new_dups),
+            )
+        self._warned_dup_players = duplicated
+
     def _get_audible_playing_decks(self) -> list[dict]:
-        """Find all currently playing and audible decks"""
+        """Find all currently playing and audible decks across all devices"""
         deckskip = self._get_deck_skip_list()
         playing_decks = []
-        crossfader_pos = self._get_crossfader_position()
 
-        for deck_num in range(1, 5):
-            if str(deck_num) in deckskip:
+        for logical_deck, token, deck_idx in self._enumerate_logical_decks():
+            if str(logical_deck) in deckskip:
                 continue
 
-            if deck_info := self._analyze_deck(deck_num, crossfader_pos):
+            if deck_info := self._analyze_deck(logical_deck, token, deck_idx):
                 playing_decks.append(deck_info)
-            elif deck_num in self._deck_play_times:
-                # Deck stopped playing, remove from tracking
-                del self._deck_play_times[deck_num]
+            elif self._deck_play_times.pop((token, deck_idx), None):
+                logging.debug(
+                    "Deck %d on %s no longer playing/audible",
+                    logical_deck,
+                    self._device_name(token),
+                )
 
         return playing_decks
 
-    def _analyze_deck(self, deck_num: int, crossfader_pos: float) -> dict | None:
-        """Analyze a single deck to see if it's playing and audible"""
-        state_keys = self._get_deck_state_keys(deck_num)
+    def _analyze_deck(self, logical_deck: int, token: bytes, deck_idx: int) -> dict | None:
+        """Analyze a single device deck to see if it's playing and audible"""
+        states = self._devices.get(token, {})
+        artist_data = states.get(f"/Engine/Deck{deck_idx}/Track/ArtistName")
+        title_data = states.get(f"/Engine/Deck{deck_idx}/Track/SongName")
+        play_state = states.get(f"/Engine/Deck{deck_idx}/Play")
 
-        # Check if required metadata exists
-        if any(key not in self.current_metadata for key in state_keys[:3]):
+        if artist_data is None or title_data is None or play_state is None:
             return None
 
-        play_state = self.current_metadata.get(state_keys[2], {})
         if not (isinstance(play_state, dict) and play_state.get("state") is True):
             return None
-
-        # Get track metadata
-        artist_data = self.current_metadata.get(state_keys[0], {})
-        title_data = self.current_metadata.get(state_keys[1], {})
-        fader_data = self.current_metadata.get(state_keys[3], {})
 
         if not (isinstance(artist_data, dict) and isinstance(title_data, dict)):
             return None
 
-        # Calculate effective volume
-        fader_pos = self._extract_numeric_value(fader_data)
-        effective_volume = self._calculate_effective_volume(deck_num, fader_pos, crossfader_pos)
-
+        effective_volume = self._effective_volume(token, deck_idx)
         if effective_volume <= AUDIBLE_VOLUME_THRESHOLD:  # Not audible enough
             return None
 
         # Track is playing and audible
-        if deck_num not in self._deck_play_times:
-            self._deck_play_times[deck_num] = time.time()
+        play_key = (token, deck_idx)
+        if play_key not in self._deck_play_times:
+            self._deck_play_times[play_key] = time.time()
+            logging.debug(
+                "Deck %d on %s started playing: %s - %s (volume %.2f)",
+                logical_deck,
+                self._device_name(token),
+                artist_data.get("string", ""),
+                title_data.get("string", ""),
+                effective_volume,
+            )
 
         return {
-            "deck": deck_num,
+            "deck": logical_deck,
+            "token": token,
+            "deck_idx": deck_idx,
             "artist": artist_data.get("string", ""),
             "title": title_data.get("string", ""),
-            "start_time": self._deck_play_times[deck_num],
+            "start_time": self._deck_play_times[play_key],
             "effective_volume": effective_volume,
         }
 
-    @staticmethod
-    def _get_deck_state_keys(deck_num: int) -> list[str]:
-        """Get the state keys for a specific deck"""
-        return [
-            f"/Engine/Deck{deck_num}/Track/ArtistName",
-            f"/Engine/Deck{deck_num}/Track/SongName",
-            f"/Engine/Deck{deck_num}/Play",
-            f"/Mixer/CH{deck_num}faderPosition",
-        ]
+    def _effective_volume(self, token: bytes, deck_idx: int) -> float:
+        """Per-deck audibility ladder.
+
+        1. Raw mixer states (all-in-one controllers emit fader and
+           crossfader in their own StateMap): combine them as before.
+        2. ExternalMixerVolume, once a Denon mixer/controller has been
+           observed driving it: the mixer computes fader x crossfader
+           and pushes the result into the player's StateMap.
+        3. No mixer signal at all (analog mixer, or nothing moved yet):
+           assume the deck is audible.
+        """
+        states = self._devices.get(token, {})
+
+        fader_data = states.get(f"/Mixer/CH{deck_idx}faderPosition")
+        if fader_data is not None:
+            fader_pos = self._extract_numeric_value(fader_data)
+            crossfader_pos = self._extract_numeric_value(
+                states.get("/Mixer/CrossfaderPosition", {}), default=0.5
+            )
+            return self._calculate_effective_volume(deck_idx, fader_pos, crossfader_pos)
+
+        emv_data = states.get(f"/Engine/Deck{deck_idx}/ExternalMixerVolume")
+        if token in self._emv_active and emv_data is not None:
+            return self._extract_numeric_value(emv_data)
+
+        return 1.0
 
     def _select_deck_by_mix_mode(self, playing_decks: list[dict]) -> dict:
-        """Select which deck to use based on mix mode and volume, with deterministic tie-breaking"""
+        """Select which deck to use based on mix mode and volume, with deterministic tie-break"""
         if len(playing_decks) == 1:
             return playing_decks[0]
 
@@ -153,42 +331,42 @@ class MetadataProcessor:
         metadata: TrackMetadata = {
             "artist": selected_deck["artist"],
             "title": selected_deck["title"],
+            "deck": self._deck_label(selected_deck),
         }
 
-        deck_num = selected_deck["deck"]
-        self._add_optional_metadata(metadata, deck_num)
+        states = self._devices.get(selected_deck["token"], {})
+        deck_idx = selected_deck["deck_idx"]
+        if album := self._state_field(states, f"/Engine/Deck{deck_idx}/Track/AlbumName", "string"):
+            metadata["album"] = album
+        if bpm := self._state_field(states, f"/Engine/Deck{deck_idx}/Track/BPM", "data"):
+            metadata["bpm"] = str(bpm)
+        if genre := self._state_field(states, f"/Engine/Deck{deck_idx}/Track/Genre", "string"):
+            metadata["genre"] = genre
         return metadata
 
-    def _add_optional_metadata(self, metadata: dict, deck_num: int) -> None:
-        """Add optional metadata fields if available"""
-        optional_fields = [
-            (f"/Engine/Deck{deck_num}/Track/AlbumName", "album", "string"),
-            (f"/Engine/Deck{deck_num}/Track/BPM", "bpm", "data"),
-            (f"/Engine/Deck{deck_num}/Track/Genre", "genre", "string"),
-        ]
-
-        for key, field_name, data_key in optional_fields:
-            if key in self.current_metadata:
-                data = self.current_metadata[key]
-                if isinstance(data, dict) and data.get(data_key):
-                    value = data.get(data_key, "")
-                    if field_name == "bpm":
-                        value = str(value)
-                    metadata[field_name] = value
-
-    def _get_crossfader_position(self) -> float:
-        """Get crossfader position (0.0 = full left, 0.5 = center, 1.0 = full right)"""
-        crossfader_data = self.current_metadata.get("/Mixer/CrossfaderPosition", {})
-        return self._extract_numeric_value(crossfader_data, default=0.5)  # Default to center
+    def _deck_label(self, selected_deck: dict) -> str:
+        """Human deck label: player number + layer letter when known, e.g. '2B'"""
+        if player := self._player_number(selected_deck["token"]):
+            layer = chr(ord("A") + selected_deck["deck_idx"] - 1)
+            return f"{player}{layer}"
+        return str(selected_deck["deck"])
 
     @staticmethod
-    def _extract_numeric_value(data: dict, default: float = 0.0) -> float:
+    def _state_field(states: dict[str, Any], key: str, field: str) -> Any:
+        """Read one field out of a state value dict, or None"""
+        data = states.get(key)
+        if isinstance(data, dict):
+            return data.get(field) or None
+        return None
+
+    @staticmethod
+    def _extract_numeric_value(data: Any, default: float = 0.0) -> float:
         """Extract numeric value from StagelinQ data dict"""
         if not isinstance(data, dict):
             return default
 
         # Try different possible numeric field names
-        for field in ["data", "value", "number", "float"]:
+        for field in ["data", "value", "number", "float", "string"]:
             if field in data:
                 try:
                     return float(data[field])

--- a/nowplaying/denon/metadata.py
+++ b/nowplaying/denon/metadata.py
@@ -353,7 +353,12 @@ class MetadataProcessor:
 
     @staticmethod
     def _state_field(states: dict[str, Any], key: str, field: str) -> Any:
-        """Read one field out of a state value dict, or None"""
+        """Read one field out of a state value dict, or None.
+
+        Falsy values deliberately collapse to None: in StagelinQ, an empty
+        string means "no track loaded" and a BPM of 0 means "not analyzed",
+        so they are treated as absent rather than published as data.
+        """
         data = states.get(key)
         if isinstance(data, dict):
             return data.get(field) or None

--- a/nowplaying/denon/metadata.py
+++ b/nowplaying/denon/metadata.py
@@ -56,6 +56,20 @@ class MetadataProcessor:
         for key in [key for key in self._deck_play_times if key[0] == token]:
             del self._deck_play_times[key]
 
+    def clear_devices(self) -> None:
+        """Drop all device state, e.g. on plugin stop.
+
+        The monitor-done callback deliberately skips unregistration for
+        cancelled tasks (shutdown is not a connection loss), so a stopped
+        plugin must clear explicitly or a later restart of the same
+        instance would compute now-playing from stale devices.
+        """
+        self._devices.clear()
+        self._device_info.clear()
+        self._emv_active.clear()
+        self._deck_play_times.clear()
+        self._warned_dup_players.clear()
+
     def update_state(self, token: bytes, state: DenonState) -> None:
         """Update a device's state store with new StagelinQ data"""
         states = self._devices.setdefault(token, {})

--- a/nowplaying/denon/plugin.py
+++ b/nowplaying/denon/plugin.py
@@ -9,15 +9,17 @@ the protocol handler, connection manager, and metadata processor.
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
+import nowplaying.upgrades
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
 
 from .connection import ConnectionManager
 from .metadata import MetadataProcessor
 from .protocol import StagelinqProtocol
-from .types import DenonDevice, DenonService, DenonState
+from .types import DenonDevice, DenonState
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
@@ -25,6 +27,9 @@ if TYPE_CHECKING:
 
     import nowplaying.config
     import nowplaying.uihelp
+
+# Seconds before retrying a device that failed to connect or had no StateMap
+FAILURE_BACKOFF_SECONDS = 30.0
 
 
 class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
@@ -44,9 +49,13 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self.metadata_processor = MetadataProcessor(config)
 
         # Plugin state
-        self.current_device: DenonDevice | None = None
-        self.current_service: DenonService | None = None
         self._discovery_timeout = 5.0
+        # tokens with a connection attempt currently in flight
+        self._attempting: set[bytes] = set()
+        # monotonic deadline before which a failed device is not retried
+        self._backoff_until: dict[bytes, float] = {}
+        # references to in-flight setup/cleanup tasks; pruned on reconcile
+        self._setup_tasks: set[asyncio.Task] = set()
 
     def install(self) -> bool:
         """Auto-install detection - StagelinQ devices are network-based"""
@@ -56,8 +65,21 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def get_source_agent_data(self) -> dict:
         """Return source agent data including device software version from StagelinQ discovery."""
         data = super().get_source_agent_data()
-        if self.current_device and self.current_device.software_version:
-            data["source_agent_version"] = self.current_device.software_version
+        # Devices can run mixed firmware; report the lowest version present
+        # so the choice is deterministic rather than connection-order luck
+        versions = [
+            conn.device.software_version
+            for conn in self.connection_manager.active.values()
+            if conn.device.software_version
+        ]
+        if versions:
+            try:
+                lowest = min(versions, key=nowplaying.upgrades.Version)
+            except ValueError:
+                # Firmware strings are not guaranteed to parse as semver;
+                # fall back to lexicographic, still deterministic
+                lowest = min(versions)
+            data["source_agent_version"] = lowest
         return data
 
     def defaults(self, qsettings: "QSettings | None"):
@@ -166,8 +188,8 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             logging.error("Failed to start Denon plugin: %s", err)
 
     async def _find_and_connect(self):
-        """Find devices and connect to the first available one"""
-        try:  # pylint: disable=too-many-nested-blocks
+        """Continuously discover devices and connect to any new ones"""
+        try:
             while True:
                 try:
                     self._discovery_timeout = self.config.cparser.value(
@@ -178,45 +200,67 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                     devices = await self.connection_manager.discover_devices(
                         self._discovery_timeout
                     )
-
-                    if devices:
-                        logging.info("Found %d Denon device(s)", len(devices))
-
-                        # Give devices time to receive multiple announcements before connecting
-                        # The devices need to know who we are first
-                        logging.debug("Waiting for devices to receive our announcements...")
-                        await asyncio.sleep(3.0)  # Wait longer for devices to trust us
-
-                        # Try each device until we find one with StateMap
-                        for device in devices:
-                            logging.debug(
-                                "Trying device: %s (%s)", device.name, device.software_name
-                            )
-                            success = await self._connect_and_monitor_device(device)
-                            if success:
-                                # Successfully connected, exit the retry loop
-                                return
-
-                    # No devices found or connection failed, wait before trying again
-                    logging.debug("No devices found, retrying in 10 seconds...")
+                    logging.debug(
+                        "Discovery pass found %d connectable device(s); %d connected",
+                        len(devices),
+                        len(self.connection_manager.active),
+                    )
+                    self._reconcile_devices(devices)
                     await asyncio.sleep(10.0)
 
-                except Exception as err:  # pylint: disable=broad-exception-caught
-                    logging.error("Error in device discovery: %s", err)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logging.exception("Error in device discovery")
                     await asyncio.sleep(10.0)
         except asyncio.CancelledError:
             logging.debug("Device discovery cancelled")
             raise
 
+    def _reconcile_devices(self, devices: list[DenonDevice]) -> None:
+        """Spawn connection attempts for newly discovered devices"""
+        self._setup_tasks = {task for task in self._setup_tasks if not task.done()}
+        now = time.monotonic()
+
+        for device in devices:
+            if device.token in self.connection_manager.active:
+                continue
+            if device.token in self._attempting:
+                continue
+            if now < self._backoff_until.get(device.token, 0.0):
+                continue
+
+            logging.info(
+                "Discovered Denon device: %s (%s) at %s",
+                device.name,
+                device.software_name,
+                device.ipaddr,
+            )
+            self._attempting.add(device.token)
+            self._setup_tasks.add(asyncio.create_task(self._setup_device(device)))
+
+    async def _setup_device(self, device: DenonDevice) -> None:
+        """Run one connection attempt, applying backoff on failure"""
+        try:
+            if not await self._connect_and_monitor_device(device):
+                self._backoff_until[device.token] = time.monotonic() + FAILURE_BACKOFF_SECONDS
+                logging.info("Will retry %s in %.0f seconds", device.name, FAILURE_BACKOFF_SECONDS)
+            else:
+                self._backoff_until.pop(device.token, None)
+        finally:
+            self._attempting.discard(device.token)
+
     async def _connect_and_monitor_device(self, device: DenonDevice) -> bool:
         """Connect to a device and start monitoring. Returns True on success."""
         try:
+            # Devices only trust peers whose announcements they have seen;
+            # we broadcast every second from startup and discovery itself
+            # takes several seconds, so a short settle is enough
+            await asyncio.sleep(1.0)
             logging.info("Connecting to Denon device: %s at %s", device.name, device.ipaddr)
 
             # Get available services
             services = await self.connection_manager.connect_to_device(device)
 
-            logging.debug("Device offers %d services:", len(services))
+            logging.debug("Device %s offers %d services:", device.name, len(services))
             for service in services:
                 logging.debug("  - %s on port %d", service.name, service.port)
 
@@ -226,51 +270,71 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             )
             if not state_service:
                 logging.warning(
-                    "StateMap service not available on device (found %d other services)",
+                    "StateMap service not available on %s (found %d other services)",
+                    device.name,
                     len(services),
                 )
-                # Connection manager will handle cleanup
+                # Release the connection and its keepalive task; otherwise
+                # every failed attempt leaks a socket and a 250ms timer
+                await self.connection_manager.disconnect_device(device.token)
                 return False
 
             # Successfully connected
-            self.current_device = device
-            self.current_service = state_service
+            self.metadata_processor.register_device(device)
 
-            # Start monitoring track states
+            # Start monitoring track states, tagging updates with the
+            # emitting device so multi-device state stays separated
             monitor_task = asyncio.create_task(
                 self.connection_manager.monitor_state_changes(
-                    device, state_service, self._on_state_update
+                    device,
+                    state_service,
+                    lambda state: self._on_state_update(device.token, state),
                 )
             )
-            monitor_task.add_done_callback(self._on_monitor_task_done)
-            self.connection_manager.tasks.append(monitor_task)
+            monitor_task.add_done_callback(lambda task: self._on_monitor_task_done(task, device))
+            if conn := self.connection_manager.active.get(device.token):
+                conn.monitor_task = monitor_task
 
             logging.info("Successfully connected to %s", device.name)
             return True
 
         except Exception as err:  # pylint: disable=broad-exception-caught
-            logging.debug("Failed to connect to device %s: %s", device.name, err)
+            logging.warning("Failed to connect to device %s: %s", device.name, err)
+            await self.connection_manager.disconnect_device(device.token)
             return False
 
-    def _on_state_update(self, state: DenonState) -> None:
+    def _on_state_update(self, token: bytes, state: DenonState) -> None:
         """Handle state updates from the connection manager"""
-        self.metadata_processor.update_state(state)
+        self.metadata_processor.update_state(token, state)
 
-    def _on_monitor_task_done(self, task):
-        """Called when monitoring task finishes (due to connection loss)"""
-        if not task.cancelled():
-            # Task finished due to error, not cancellation
-            logging.info("Connection lost, will attempt to reconnect")
-            self.current_device = None
-            self.current_service = None
+    def _on_monitor_task_done(self, task, device: DenonDevice):
+        """Called when a device's monitoring task finishes (connection loss)"""
+        if task.cancelled():
+            return
 
-            # Start reconnection task
-            reconnect_task = asyncio.create_task(self._find_and_connect())
-            self.connection_manager.tasks.append(reconnect_task)
+        # Retrieve the exception so asyncio does not later emit a spurious
+        # "Task exception was never retrieved" traceback into user logs
+        if exc := task.exception():
+            logging.debug("Monitor for %s ended with: %s", device.name, exc)
+
+        logging.info("Connection lost to %s; will reconnect on next discovery", device.name)
+        self.metadata_processor.unregister_device(device.token)
+
+        # Close out the device's remaining connection state; the ongoing
+        # discovery loop reconnects it once it reannounces. Keep a task
+        # reference so it is neither garbage-collected nor orphaned.
+        cleanup_task = asyncio.create_task(self.connection_manager.disconnect_device(device.token))
+        self._setup_tasks.add(cleanup_task)
 
     async def stop(self):
         """Stop the plugin and cleanup"""
         logging.info("Stopping Denon StagelinQ plugin")
+        for task in self._setup_tasks:
+            task.cancel()
+        if self._setup_tasks:
+            await asyncio.gather(*self._setup_tasks, return_exceptions=True)
+        self._setup_tasks.clear()
+        self._attempting.clear()
         await self.connection_manager.cleanup()
 
     async def getrandomtrack(self, playlist: str) -> str | None:

--- a/nowplaying/denon/plugin.py
+++ b/nowplaying/denon/plugin.py
@@ -336,6 +336,7 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self._setup_tasks.clear()
         self._attempting.clear()
         await self.connection_manager.cleanup()
+        self.metadata_processor.clear_devices()
 
     async def getrandomtrack(self, playlist: str) -> str | None:
         """Get random track from playlist - not supported by StagelinQ"""

--- a/nowplaying/denon/types.py
+++ b/nowplaying/denon/types.py
@@ -19,6 +19,49 @@ MSG_SERVICE_ANNOUNCEMENT = 0x00000000
 MSG_REFERENCE = 0x00000001
 MSG_SERVICES_REQUEST = 0x00000002
 
+# Device roles derived from discovery software names
+ROLE_PLAYER = "player"
+ROLE_CONTROLLER = "controller"  # all-in-one: engine decks + mixer in one StateMap
+ROLE_MIXER = "mixer"
+ROLE_OTHER = "other"
+
+
+@dataclass(frozen=True)
+class DenonModel:
+    """Known hardware model information keyed by discovery software name"""
+
+    model: str
+    role: str
+    deck_count: int
+
+
+# Software name codes observed in StagelinQ discovery announcements,
+# from the Engine OS firmware assignment files and the StageLinq
+# reference implementations
+DEVICE_MODELS: dict[str, DenonModel] = {
+    "JP07": DenonModel("SC5000", ROLE_PLAYER, 2),
+    "JP08": DenonModel("SC5000M", ROLE_PLAYER, 2),
+    "JP13": DenonModel("SC6000", ROLE_PLAYER, 2),
+    "JP14": DenonModel("SC6000M", ROLE_PLAYER, 2),
+    "JC11": DenonModel("PRIME 4", ROLE_CONTROLLER, 4),
+    "JC16": DenonModel("PRIME 2", ROLE_CONTROLLER, 2),
+    "JP11": DenonModel("PRIME GO", ROLE_CONTROLLER, 2),
+    "JP20": DenonModel("SC LIVE 2", ROLE_CONTROLLER, 2),
+    "JP21": DenonModel("SC LIVE 4", ROLE_CONTROLLER, 4),
+    "NH08": DenonModel("MIXSTREAM PRO", ROLE_CONTROLLER, 2),
+    "NH09": DenonModel("MIXSTREAM PRO+", ROLE_CONTROLLER, 2),
+    "NH10": DenonModel("MIXSTREAM PRO GO", ROLE_CONTROLLER, 2),
+    "JM08": DenonModel("DN-X1800 Prime", ROLE_MIXER, 0),
+    "JM10": DenonModel("DN-X1850 Prime", ROLE_MIXER, 0),
+    "JC20": DenonModel("LC6000", ROLE_OTHER, 0),
+}
+
+# Non-hardware StagelinQ announcers that never offer usable services
+# (Engine OS runs several of these alongside the actual player software;
+# SoundSwitchEmbedded and friends are covered by the SoundSwitch prefix)
+IGNORED_SOFTWARE_NAMES = {"OfflineAnalyzer"}
+IGNORED_SOFTWARE_PREFIXES = ("SoundSwitch", "Resolume", "SSS")
+
 # State message magic bytes
 STATE_SUBSCRIBE_MAGIC = b"\x00\x00\x07\xd2"
 STATE_EMIT_MAGIC = b"\x00\x00\x00\x00"
@@ -34,6 +77,26 @@ class DenonDevice:
     software_name: str
     software_version: str
     token: bytes
+
+    @property
+    def model(self) -> DenonModel | None:
+        """Known hardware model for this device's software name, if any"""
+        return DEVICE_MODELS.get(self.software_name)
+
+    def is_connectable(self) -> bool:
+        """True if this device is worth a StateMap connection.
+
+        Players and controllers carry track state. Mixers refuse inbound
+        connections and instead push fader data into the players' own
+        StateMaps (ExternalMixerVolume), so they are never connected.
+        Known non-hardware announcers are skipped; unknown software names
+        are assumed to be future hardware and tried.
+        """
+        if model := DEVICE_MODELS.get(self.software_name):
+            return model.role in {ROLE_PLAYER, ROLE_CONTROLLER}
+        if self.software_name in IGNORED_SOFTWARE_NAMES:
+            return False
+        return not self.software_name.startswith(IGNORED_SOFTWARE_PREFIXES)
 
 
 @dataclass

--- a/tests/test_denon.py
+++ b/tests/test_denon.py
@@ -2,11 +2,26 @@
 """Tests for Denon DJ StagelinQ input plugin"""
 # pylint: disable=protected-access,redefined-outer-name
 
+import asyncio
+import struct
+import time
+
 import pytest
 
 import nowplaying.inputs.denon
 from nowplaying.denon import StagelinqError
+from nowplaying.denon.connection import ConnectionManager, DeviceConnection
 from nowplaying.denon.protocol import StagelinqProtocol
+from nowplaying.denon.types import MSG_SERVICES_REQUEST, DenonDevice, DenonService, DenonState
+
+DEVICE_TOKEN_1 = b"\x01" * 16
+DEVICE_TOKEN_2 = b"\x02" * 16
+
+
+def _feed_states(processor, token: bytes, states: dict) -> None:
+    """Feed synthetic StateMap values into the metadata processor"""
+    for name, value in states.items():
+        processor.update_state(token, DenonState(name=name, value=value))
 
 
 @pytest.fixture
@@ -117,17 +132,36 @@ async def test_extract_numeric_value(denon_plugin):
 
 
 @pytest.mark.asyncio
-async def test_get_crossfader_position(denon_plugin):
-    """Test crossfader position retrieval"""
-    # Test with no crossfader data (should default to center)
-    denon_plugin.metadata_processor.current_metadata = {}
-    result = denon_plugin.metadata_processor._get_crossfader_position()
-    assert result == 0.5
+async def test_effective_volume_ladder(denon_plugin):
+    """Test the audibility ladder: mixer states, then EMV, then default-audible"""
+    processor = denon_plugin.metadata_processor
+    token = DEVICE_TOKEN_1
 
-    # Test with crossfader data
-    denon_plugin.metadata_processor.current_metadata = {"/Mixer/CrossfaderPosition": {"data": 0.8}}
-    result = denon_plugin.metadata_processor._get_crossfader_position()
-    assert result == 0.8
+    # No mixer signal at all: assume audible (analog mixer case)
+    assert processor._effective_volume(token, 1) == 1.0
+
+    # ExternalMixerVolume present but never nonzero (mixerless player
+    # reporting an initial 0): still assumed audible
+    _feed_states(processor, token, {"/Engine/Deck1/ExternalMixerVolume": {"data": 0.0}})
+    assert processor._effective_volume(token, 1) == 1.0
+
+    # A nonzero EMV proves a Denon mixer/controller is driving it;
+    # from then on the value is authoritative, including zero
+    _feed_states(processor, token, {"/Engine/Deck1/ExternalMixerVolume": {"data": 0.7}})
+    assert processor._effective_volume(token, 1) == 0.7
+    _feed_states(processor, token, {"/Engine/Deck1/ExternalMixerVolume": {"data": 0.0}})
+    assert processor._effective_volume(token, 1) == 0.0
+
+    # Raw mixer states (all-in-one controllers) take precedence over EMV
+    _feed_states(
+        processor,
+        token,
+        {
+            "/Mixer/CH1faderPosition": {"data": 0.5},
+            "/Mixer/CrossfaderPosition": {"data": 0.5},
+        },
+    )
+    assert processor._effective_volume(token, 1) == 0.5
 
 
 @pytest.mark.asyncio
@@ -209,13 +243,17 @@ async def test_calculate_effective_volume_crossfader_transition(denon_plugin):
 async def test_getplayingtrack_single_audible_deck(denon_plugin):
     """Test track selection with single audible deck"""
     # Set up metadata for one playing, audible track
-    denon_plugin.metadata_processor.current_metadata = {
-        "/Engine/Deck1/Play": {"state": True},
-        "/Engine/Deck1/Track/ArtistName": {"string": "Test Artist"},
-        "/Engine/Deck1/Track/SongName": {"string": "Test Song"},
-        "/Mixer/CH1faderPosition": {"data": 0.8},
-        "/Mixer/CrossfaderPosition": {"data": 0.5},
-    }
+    _feed_states(
+        denon_plugin.metadata_processor,
+        DEVICE_TOKEN_1,
+        {
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Test Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Test Song"},
+            "/Mixer/CH1faderPosition": {"data": 0.8},
+            "/Mixer/CrossfaderPosition": {"data": 0.5},
+        },
+    )
 
     result = await denon_plugin.getplayingtrack()
     assert result is not None
@@ -227,13 +265,17 @@ async def test_getplayingtrack_single_audible_deck(denon_plugin):
 async def test_getplayingtrack_inaudible_deck(denon_plugin):
     """Test that tracks with low effective volume are filtered out"""
     # Set up metadata for playing track but with fader down
-    denon_plugin.metadata_processor.current_metadata = {
-        "/Engine/Deck1/Play": {"state": True},
-        "/Engine/Deck1/Track/ArtistName": {"string": "Test Artist"},
-        "/Engine/Deck1/Track/SongName": {"string": "Test Song"},
-        "/Mixer/CH1faderPosition": {"data": 0.05},  # Very low fader
-        "/Mixer/CrossfaderPosition": {"data": 0.5},
-    }
+    _feed_states(
+        denon_plugin.metadata_processor,
+        DEVICE_TOKEN_1,
+        {
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Test Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Test Song"},
+            "/Mixer/CH1faderPosition": {"data": 0.05},  # Very low fader
+            "/Mixer/CrossfaderPosition": {"data": 0.5},
+        },
+    )
 
     result = await denon_plugin.getplayingtrack()
     assert result is None  # Should be filtered out due to low volume
@@ -243,19 +285,23 @@ async def test_getplayingtrack_inaudible_deck(denon_plugin):
 async def test_getplayingtrack_multiple_decks_volume_priority(denon_plugin):
     """Test track selection prioritizes louder tracks"""
     # Set up two playing tracks with different volumes
-    denon_plugin.metadata_processor.current_metadata = {
-        # Deck 1 - quieter
-        "/Engine/Deck1/Play": {"state": True},
-        "/Engine/Deck1/Track/ArtistName": {"string": "Quiet Artist"},
-        "/Engine/Deck1/Track/SongName": {"string": "Quiet Song"},
-        "/Mixer/CH1faderPosition": {"data": 0.3},
-        # Deck 2 - louder
-        "/Engine/Deck2/Play": {"state": True},
-        "/Engine/Deck2/Track/ArtistName": {"string": "Loud Artist"},
-        "/Engine/Deck2/Track/SongName": {"string": "Loud Song"},
-        "/Mixer/CH2faderPosition": {"data": 0.9},
-        "/Mixer/CrossfaderPosition": {"data": 0.5},  # Both sides audible
-    }
+    _feed_states(
+        denon_plugin.metadata_processor,
+        DEVICE_TOKEN_1,
+        {
+            # Deck 1 - quieter
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Quiet Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Quiet Song"},
+            "/Mixer/CH1faderPosition": {"data": 0.3},
+            # Deck 2 - louder
+            "/Engine/Deck2/Play": {"state": True},
+            "/Engine/Deck2/Track/ArtistName": {"string": "Loud Artist"},
+            "/Engine/Deck2/Track/SongName": {"string": "Loud Song"},
+            "/Mixer/CH2faderPosition": {"data": 0.9},
+            "/Mixer/CrossfaderPosition": {"data": 0.5},  # Both sides audible
+        },
+    )
 
     # Should select the louder track regardless of timing
     result = await denon_plugin.getplayingtrack()
@@ -270,19 +316,23 @@ async def test_getplayingtrack_deck_skip_functionality(denon_plugin):
     # Configure deck skip
     denon_plugin.config.cparser.setValue("denon/deckskip", ["1"])
 
-    denon_plugin.metadata_processor.current_metadata = {
-        # Deck 1 - should be skipped
-        "/Engine/Deck1/Play": {"state": True},
-        "/Engine/Deck1/Track/ArtistName": {"string": "Skipped Artist"},
-        "/Engine/Deck1/Track/SongName": {"string": "Skipped Song"},
-        "/Mixer/CH1faderPosition": {"data": 0.9},
-        # Deck 2 - should be selected
-        "/Engine/Deck2/Play": {"state": True},
-        "/Engine/Deck2/Track/ArtistName": {"string": "Selected Artist"},
-        "/Engine/Deck2/Track/SongName": {"string": "Selected Song"},
-        "/Mixer/CH2faderPosition": {"data": 0.7},
-        "/Mixer/CrossfaderPosition": {"data": 0.5},
-    }
+    _feed_states(
+        denon_plugin.metadata_processor,
+        DEVICE_TOKEN_1,
+        {
+            # Deck 1 - should be skipped
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Skipped Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Skipped Song"},
+            "/Mixer/CH1faderPosition": {"data": 0.9},
+            # Deck 2 - should be selected
+            "/Engine/Deck2/Play": {"state": True},
+            "/Engine/Deck2/Track/ArtistName": {"string": "Selected Artist"},
+            "/Engine/Deck2/Track/SongName": {"string": "Selected Song"},
+            "/Mixer/CH2faderPosition": {"data": 0.7},
+            "/Mixer/CrossfaderPosition": {"data": 0.5},
+        },
+    )
 
     result = await denon_plugin.getplayingtrack()
     assert result is not None
@@ -293,24 +343,164 @@ async def test_getplayingtrack_deck_skip_functionality(denon_plugin):
 @pytest.mark.asyncio
 async def test_getplayingtrack_crossfader_filtering(denon_plugin):
     """Test crossfader position affects track selection"""
-    denon_plugin.metadata_processor.current_metadata = {
-        # Left deck (should be audible when crossfader left)
-        "/Engine/Deck1/Play": {"state": True},
-        "/Engine/Deck1/Track/ArtistName": {"string": "Left Artist"},
-        "/Engine/Deck1/Track/SongName": {"string": "Left Song"},
-        "/Mixer/CH1faderPosition": {"data": 0.8},
-        # Right deck (should be inaudible when crossfader left)
-        "/Engine/Deck2/Play": {"state": True},
-        "/Engine/Deck2/Track/ArtistName": {"string": "Right Artist"},
-        "/Engine/Deck2/Track/SongName": {"string": "Right Song"},
-        "/Mixer/CH2faderPosition": {"data": 0.8},
-        "/Mixer/CrossfaderPosition": {"data": 0.0},  # Full left
-    }
+    _feed_states(
+        denon_plugin.metadata_processor,
+        DEVICE_TOKEN_1,
+        {
+            # Left deck (should be audible when crossfader left)
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Left Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Left Song"},
+            "/Mixer/CH1faderPosition": {"data": 0.8},
+            # Right deck (should be inaudible when crossfader left)
+            "/Engine/Deck2/Play": {"state": True},
+            "/Engine/Deck2/Track/ArtistName": {"string": "Right Artist"},
+            "/Engine/Deck2/Track/SongName": {"string": "Right Song"},
+            "/Mixer/CH2faderPosition": {"data": 0.8},
+            "/Mixer/CrossfaderPosition": {"data": 0.0},  # Full left
+        },
+    )
 
     result = await denon_plugin.getplayingtrack()
     assert result is not None
     assert result["artist"] == "Left Artist"
     assert result["title"] == "Left Song"
+
+
+@pytest.mark.asyncio
+async def test_two_players_logical_deck_numbering(denon_plugin):
+    """Test logical decks span devices ordered by DJ-assigned player number"""
+    processor = denon_plugin.metadata_processor
+    # Two SC6000Ms with an analog mixer: no mixer states at all.
+    # Register in reverse order to prove sorting is by player number.
+    for token, player, artist in [
+        (DEVICE_TOKEN_2, "2", "Second Artist"),
+        (DEVICE_TOKEN_1, "1", "First Artist"),
+    ]:
+        processor.register_device(_make_test_device(token))
+        _feed_states(
+            processor,
+            token,
+            {
+                "/Client/Preferences/Player": {"string": player},
+                "/Engine/Deck1/Play": {"state": True},
+                "/Engine/Deck1/Track/ArtistName": {"string": artist},
+                "/Engine/Deck1/Track/SongName": {"string": f"Song {player}"},
+            },
+        )
+
+    decks = processor._get_audible_playing_decks()
+    # JP14 = SC6000M = 2 decks per device: player 1 owns logical 1-2,
+    # player 2 owns logical 3-4; layer A of each is playing
+    assert [(deck["deck"], deck["artist"]) for deck in decks] == [
+        (1, "First Artist"),
+        (3, "Second Artist"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_two_players_deckskip_spans_devices(denon_plugin):
+    """Test deckskip logical numbers address decks on any device"""
+    processor = denon_plugin.metadata_processor
+    denon_plugin.config.cparser.setValue("denon/deckskip", ["1"])
+
+    for token, player, artist in [
+        (DEVICE_TOKEN_1, "1", "First Artist"),
+        (DEVICE_TOKEN_2, "2", "Second Artist"),
+    ]:
+        processor.register_device(_make_test_device(token))
+        _feed_states(
+            processor,
+            token,
+            {
+                "/Client/Preferences/Player": {"string": player},
+                "/Engine/Deck1/Play": {"state": True},
+                "/Engine/Deck1/Track/ArtistName": {"string": artist},
+                "/Engine/Deck1/Track/SongName": {"string": f"Song {player}"},
+            },
+        )
+
+    decks = processor._get_audible_playing_decks()
+    assert [(deck["deck"], deck["artist"]) for deck in decks] == [(3, "Second Artist")]
+
+
+@pytest.mark.asyncio
+async def test_deck_label_player_and_layer(denon_plugin):
+    """Test deck labels combine player number and layer letter"""
+    processor = denon_plugin.metadata_processor
+    _feed_states(processor, DEVICE_TOKEN_1, {"/Client/Preferences/Player": {"string": "2"}})
+
+    label = processor._deck_label({"token": DEVICE_TOKEN_1, "deck_idx": 2, "deck": 4})
+    assert label == "2B"
+
+    # Without a player number, fall back to the logical deck number
+    label = processor._deck_label({"token": DEVICE_TOKEN_2, "deck_idx": 1, "deck": 1})
+    assert label == "1"
+
+
+@pytest.mark.asyncio
+async def test_get_all_decks_includes_paused(denon_plugin):
+    """Test the multi-deck snapshot shows loaded decks regardless of play state"""
+    processor = denon_plugin.metadata_processor
+    for token, player in [(DEVICE_TOKEN_1, "1"), (DEVICE_TOKEN_2, "2")]:
+        processor.register_device(_make_test_device(token))
+        _feed_states(processor, token, {"/Client/Preferences/Player": {"string": player}})
+
+    # Player 1 layer A: playing
+    _feed_states(
+        processor,
+        DEVICE_TOKEN_1,
+        {
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Playing Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Playing Song"},
+            "/Engine/Deck1/Track/BPM": {"data": 128},
+        },
+    )
+    # Player 2 layer B: loaded but paused
+    _feed_states(
+        processor,
+        DEVICE_TOKEN_2,
+        {
+            "/Engine/Deck2/Play": {"state": False},
+            "/Engine/Deck2/Track/SongLoaded": {"state": True},
+            "/Engine/Deck2/Track/ArtistName": {"string": "Cued Artist"},
+            "/Engine/Deck2/Track/SongName": {"string": "Cued Song"},
+        },
+    )
+
+    decks = processor.get_all_decks()
+    assert [(deck["deck"], deck["label"], deck["artist"], deck["playing"]) for deck in decks] == [
+        (1, "1A", "Playing Artist", True),
+        (4, "2B", "Cued Artist", False),
+    ]
+    assert decks[0]["bpm"] == "128"
+
+    # The playing-track selection still only sees the audible playing deck
+    track = processor.get_playing_track()
+    assert track is not None
+    assert track["artist"] == "Playing Artist"
+
+
+@pytest.mark.asyncio
+async def test_unregister_device_clears_state(denon_plugin):
+    """Test device unregistration removes its decks from consideration"""
+    processor = denon_plugin.metadata_processor
+    processor.register_device(_make_test_device(DEVICE_TOKEN_1))
+    _feed_states(
+        processor,
+        DEVICE_TOKEN_1,
+        {
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Test Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Test Song"},
+        },
+    )
+    assert processor.get_playing_track() is not None
+
+    processor.unregister_device(DEVICE_TOKEN_1)
+    assert processor.get_playing_track() is None
+    assert not processor._deck_play_times
 
 
 def test_pack_utf16_string():
@@ -432,3 +622,333 @@ async def test_load_save_deckskip_settings(denon_plugin):
     assert not widget2.denon_deck2_skip_checkbox.isChecked()
     assert widget2.denon_deck3_skip_checkbox.isChecked()
     assert not widget2.denon_deck4_skip_checkbox.isChecked()
+
+
+class FakeStreamWriter:
+    """Minimal StreamWriter stand-in for connection tests"""
+
+    def __init__(self):
+        self.written = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        """collect written bytes"""
+        self.written += data
+
+    async def drain(self) -> None:
+        """no-op"""
+
+    def close(self) -> None:
+        """mark closed"""
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        """no-op"""
+
+    @staticmethod
+    def get_extra_info(_name: str) -> tuple[str, int]:
+        """fake socket address info"""
+        return ("127.0.0.1", 12345)
+
+
+def _make_test_device(token: bytes, software_name: str = "JP14") -> DenonDevice:
+    """Build a DenonDevice for connection tests"""
+    return DenonDevice(
+        ipaddr="127.0.0.1",
+        port=50010,
+        name="sc6000m",
+        software_name=software_name,
+        software_version="3.4.0",
+        token=token,
+    )
+
+
+def _patch_open_connection(monkeypatch, reader, writer):
+    """Patch asyncio.open_connection to return the given fake streams"""
+
+    async def fake_open_connection(_host, _port):
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_connection", fake_open_connection)
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_handles_device_services_request(monkeypatch):
+    """Test service reading survives the device sending its own ServicesRequest first"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    reader = asyncio.StreamReader()
+    # Device asks what services we offer before announcing its own
+    reader.feed_data(struct.pack(">I", MSG_SERVICES_REQUEST) + device_token)
+    reader.feed_data(StagelinqProtocol.create_service_announcement(device_token, "StateMap", 42))
+    reader.feed_data(StagelinqProtocol.create_reference_message(device_token, our_token))
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    services = await manager.connect_to_device(device)
+
+    assert [(service.name, service.port) for service in services] == [("StateMap", 42)]
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_unknown_message_stops_cleanly(monkeypatch):
+    """Test an unknown message id stops parsing without discarding found services"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(StagelinqProtocol.create_service_announcement(device_token, "StateMap", 42))
+    # Unknown message id: cannot be skipped safely, must stop parsing
+    reader.feed_data(struct.pack(">I", 0xDEADBEEF))
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    services = await manager.connect_to_device(device)
+
+    assert [(service.name, service.port) for service in services] == [("StateMap", 42)]
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_device_releases_connection(monkeypatch):
+    """Test disconnect_device cancels the keepalive task and closes the writer"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(StagelinqProtocol.create_reference_message(device_token, our_token))
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    await manager.connect_to_device(device)
+    assert manager.active[device_token].main_writer is writer
+    ref_task = manager.active[device_token].ref_task
+
+    await manager.disconnect_device(device_token)
+
+    assert writer.closed
+    assert not manager.active
+    assert ref_task.done()
+
+    # Disconnecting an unknown device is a no-op
+    await manager.disconnect_device(device_token)
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_failure_stops_keepalive(monkeypatch):
+    """Test handshake failure cancels the keepalive task and closes the writer"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    class FailingWriter(FakeStreamWriter):
+        """Writer whose drain fails, aborting the handshake"""
+
+        async def drain(self) -> None:
+            raise OSError("handshake failure")
+
+    reader = asyncio.StreamReader()
+    writer = FailingWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    pre_tasks = set(asyncio.all_tasks())
+
+    with pytest.raises(OSError):
+        await manager.connect_to_device(device)
+
+    assert writer.closed
+    assert not manager.active
+    # The keepalive task must be fully finished before the exception
+    # propagates, not left pending in the event loop; compare against a
+    # pre-call snapshot so unrelated runner tasks cannot flake this
+    leftover = [task for task in asyncio.all_tasks() - pre_tasks if not task.done()]
+    assert not leftover
+
+
+@pytest.mark.asyncio
+async def test_source_agent_version_semantic_lowest(denon_plugin):
+    """Test mixed-firmware rigs report the semantically lowest version"""
+    manager = denon_plugin.connection_manager
+    for token, version in [(DEVICE_TOKEN_1, "5.0.10"), (DEVICE_TOKEN_2, "5.0.4")]:
+        device = DenonDevice(
+            ipaddr="127.0.0.1",
+            port=50010,
+            name="sc6000m",
+            software_name="JP14",
+            software_version=version,
+            token=token,
+        )
+        manager.active[token] = DeviceConnection(
+            device=device,
+            main_writer=FakeStreamWriter(),
+            ref_task=asyncio.create_task(asyncio.sleep(0)),
+        )
+
+    data = denon_plugin.get_source_agent_data()
+    # Lexicographic sort would pick "5.0.10"; semantic ordering picks "5.0.4"
+    assert data["source_agent_version"] == "5.0.4"
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_connect_to_device_cancellation_stops_keepalive(monkeypatch):
+    """Test cancelling an in-flight connect releases the keepalive and socket"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+
+    # Reader never receives data: connect blocks in readexactly
+    reader = asyncio.StreamReader()
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    pre_tasks = set(asyncio.all_tasks())
+
+    connect_task = asyncio.create_task(manager.connect_to_device(device))
+    await asyncio.sleep(0)  # let it reach the read loop
+    connect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+
+    assert writer.closed
+    assert not manager.active
+    leftover = [task for task in asyncio.all_tasks() - pre_tasks if not task.done()]
+    assert not leftover
+
+
+@pytest.mark.asyncio
+async def test_duplicate_player_numbers_warn_once(denon_plugin, caplog):
+    """Test duplicate player numbers warn once and keep a stable ordering"""
+    processor = denon_plugin.metadata_processor
+    for token in (DEVICE_TOKEN_1, DEVICE_TOKEN_2):
+        processor.register_device(_make_test_device(token))
+        _feed_states(
+            processor,
+            token,
+            {
+                "/Client/Preferences/Player": {"string": "1"},
+                "/Engine/Deck1/Play": {"state": True},
+                "/Engine/Deck1/Track/ArtistName": {"string": "Artist"},
+                "/Engine/Deck1/Track/SongName": {"string": "Song"},
+            },
+        )
+
+    with caplog.at_level("WARNING"):
+        first = processor._enumerate_logical_decks()
+        second = processor._enumerate_logical_decks()
+
+    warnings = [rec for rec in caplog.records if "same player number" in rec.message]
+    assert len(warnings) == 1
+    # Ordering is arbitrary but stable across enumerations
+    assert first == second
+    assert [deck for deck, _, _ in first] == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_devices_guards(denon_plugin, monkeypatch):
+    """Test reconciliation skips connected, in-flight, and backed-off devices"""
+    attempted = []
+
+    async def fake_setup(device):
+        attempted.append(device.token)
+        denon_plugin._attempting.discard(device.token)
+
+    monkeypatch.setattr(denon_plugin, "_setup_device", fake_setup)
+    device1 = _make_test_device(DEVICE_TOKEN_1)
+    device2 = _make_test_device(DEVICE_TOKEN_2)
+
+    # Duplicate announcements in one pass produce a single attempt
+    denon_plugin._reconcile_devices([device1, device1])
+    await asyncio.gather(*denon_plugin._setup_tasks)
+    assert attempted == [DEVICE_TOKEN_1]
+
+    # An in-flight attempt is not duplicated
+    denon_plugin._attempting.add(DEVICE_TOKEN_1)
+    denon_plugin._reconcile_devices([device1])
+    await asyncio.gather(*denon_plugin._setup_tasks)
+    assert attempted == [DEVICE_TOKEN_1]
+    denon_plugin._attempting.discard(DEVICE_TOKEN_1)
+
+    # A backed-off device is skipped; others still connect
+    denon_plugin._backoff_until[DEVICE_TOKEN_1] = time.monotonic() + 60.0
+    denon_plugin._reconcile_devices([device1, device2])
+    await asyncio.gather(*denon_plugin._setup_tasks)
+    assert attempted == [DEVICE_TOKEN_1, DEVICE_TOKEN_2]
+
+    # Once the backoff expires, the device is retried
+    denon_plugin._backoff_until[DEVICE_TOKEN_1] = time.monotonic() - 1.0
+    denon_plugin._reconcile_devices([device1])
+    await asyncio.gather(*denon_plugin._setup_tasks)
+    assert attempted == [DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_1]
+
+
+@pytest.mark.asyncio
+async def test_monitor_subscribes_expected_states(monkeypatch):
+    """Test StateMap subscriptions include audibility and device-identity states"""
+    our_token = StagelinqProtocol.generate_token()
+    device_token = StagelinqProtocol.generate_token()
+    manager = ConnectionManager(our_token)
+    device = _make_test_device(device_token)
+    service = DenonService(name="StateMap", port=50011)
+
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    writer = FakeStreamWriter()
+    _patch_open_connection(monkeypatch, reader, writer)
+
+    await manager.monitor_state_changes(device, service, lambda state: None)
+
+    for state_path in [
+        "/Engine/Deck1/Track/ArtistName",
+        "/Engine/Deck4/ExternalMixerVolume",
+        "/Engine/Deck1/DeckIsMaster",
+        "/Client/Preferences/Player",
+        "/Engine/DeckCount",
+        "/Engine/Sync/Network/MasterStatus",
+        "/Mixer/CrossfaderPosition",
+    ]:
+        assert state_path.encode("utf-16be") in writer.written
+
+    await manager.cleanup()
+
+
+@pytest.mark.parametrize(
+    "software_name,expected",
+    [
+        ("JP14", True),  # SC6000M - player
+        ("JP07", True),  # SC5000 - player
+        ("JC11", True),  # PRIME 4 - controller
+        ("NH08", True),  # MIXSTREAM PRO - controller
+        ("JM08", False),  # DN-X1800 Prime - mixer, refuses inbound connections
+        ("JM10", False),  # DN-X1850 Prime - mixer
+        ("JC20", False),  # LC6000 - accessory, no engine
+        ("OfflineAnalyzer", False),
+        ("SoundSwitchEmbedded", False),
+        ("SSS0", False),  # SoundSwitch desktop
+        ("Resolume Arena", False),
+        ("XX99", True),  # unknown software name - assume future hardware
+    ],
+)
+def test_device_is_connectable(software_name, expected):
+    """Test discovery classification: only players/controllers get connections"""
+    token = StagelinqProtocol.generate_token()
+    device = _make_test_device(token, software_name=software_name)
+    assert device.is_connectable() is expected
+
+
+def test_get_broadcast_addresses():
+    """Test broadcast address enumeration always includes the global broadcast"""
+    addresses = ConnectionManager._get_broadcast_addresses()
+    assert "255.255.255.255" in addresses
+    for address in addresses:
+        assert not address.startswith("127.")

--- a/tests/test_denon.py
+++ b/tests/test_denon.py
@@ -483,6 +483,29 @@ async def test_get_all_decks_includes_paused(denon_plugin):
 
 
 @pytest.mark.asyncio
+async def test_stop_clears_metadata_state(denon_plugin):
+    """Test plugin stop drops device state so a restart cannot see stale decks"""
+    processor = denon_plugin.metadata_processor
+    processor.register_device(_make_test_device(DEVICE_TOKEN_1))
+    _feed_states(
+        processor,
+        DEVICE_TOKEN_1,
+        {
+            "/Engine/Deck1/Play": {"state": True},
+            "/Engine/Deck1/Track/ArtistName": {"string": "Stale Artist"},
+            "/Engine/Deck1/Track/SongName": {"string": "Stale Song"},
+        },
+    )
+    assert processor.get_playing_track() is not None
+
+    await denon_plugin.stop()
+
+    assert processor.get_playing_track() is None
+    assert not processor._devices
+    assert not processor._deck_play_times
+
+
+@pytest.mark.asyncio
 async def test_unregister_device_clears_state(denon_plugin):
     """Test device unregistration removes its decks from consideration"""
     processor = denon_plugin.metadata_processor


### PR DESCRIPTION
Protocol/connection fixes (field-verified against SC6000M fw 5.0.4):

* Handle peer ServicesRequest on the main connection; the old read loop misparsed it and discarded all service announcements ("0 services" bug). Unknown message ids log loudly and stop parsing.
* Release connections and keepalive tasks on failed attempts; await keepalive cancellation on handshake failure.
* Broadcast announcements to every interface's subnet broadcast, not just the default-route interface.

Multi-device support:

* Classify discovery by software-name model table (players and controllers connect; mixers never do - they push per-deck audibility into the players' own StateMaps; non-hardware announcers are skipped).
* Per-device connections (DeviceConnection keyed by discovery token); discovery is a continuous reconciliation loop with an in-flight guard, 30s failure backoff, and task pruning.
* Device-keyed metadata store; logical decks assigned by DJ player number then layer (two dual-layer players -> decks 1-4); deckskip applies to logical numbers; deck labels like "2B".
* Audibility ladder: raw /Mixer/ states (all-in-ones) ->
  ExternalMixerVolume once observed nonzero (mixerless players report a permanent 0 that must not mute everything; confirmed in field logs) -> assume audible (analog mixers).
* get_all_decks() snapshot of every loaded deck across devices as groundwork for multi-deck displays.
* Field-debuggable logging: discovery pass summaries, connect failures with backoff notice, EMV activation, deck start/stop transitions, device-tagged state updates.
* Docs: multi-player deck numbering, mixer behavior, analog-mixer troubleshooting.

Review hardening:

* Cancellation-safe teardown: connect_to_device cleanup catches BaseException and closes sockets synchronously first (stop() runs on every input-plugin switch and could orphan the keepalive); disconnect_device gets the same ordering.
* Monitor task exceptions are retrieved on connection loss so asyncio does not emit spurious tracebacks into user logs.
* Warn once when multiple players report the same DJ-assigned player number (deck ordering degrades to arbitrary, labels repeat).
* Semantic (not lexicographic) firmware version comparison for mixed-firmware rigs via nowplaying.upgrades.Version, with a deterministic fallback for unparseable strings.

## Summary by Sourcery

Add multi-device StagelinQ support with per-device metadata processing, more robust connection management, and improved audibility handling for Denon DJ setups, along with updated documentation and tests.

New Features:
- Support multiple Denon players and all-in-one units simultaneously with logical deck numbering based on DJ-assigned player numbers and per-device deck counts.
- Provide a multi-deck snapshot API that returns all loaded decks across devices, including paused but cued tracks, for richer displays.

Bug Fixes:
- Ensure StagelinQ service discovery correctly handles peer ServicesRequest messages and stops safely on unknown message IDs without losing previously discovered services.
- Fix keepalive and socket cleanup on failed or cancelled connection attempts so no background tasks or connections are orphaned.
- Resolve the "0 services" discovery issue and ensure broadcast announcements reach devices on all relevant subnets, not just the default-route interface.

Enhancements:
- Refactor metadata processing to be device-aware, including audibility computation via mixer states or ExternalMixerVolume and more informative deck labels.
- Introduce connection classification based on device software name so only players/controllers are connected, skipping mixers and non-hardware announcers.
- Improve logging around discovery, connection failures, audibility activation, deck transitions, and duplicate player-number configurations for easier field debugging.
- Use semantic firmware version comparison when reporting source agent version in mixed-firmware rigs, with deterministic fallback for unparseable versions.
- Make teardown and monitor handling more resilient by coordinating task cancellation, exception retrieval, and per-device cleanup in the connection manager and plugin.

Documentation:
- Update Denon input documentation to describe supported hardware, multi-player deck numbering, mixer behavior, and guidance for analog/third-party mixer setups.
- Highlight that multi-player setups (e.g., two SC6000 units) are supported and clarify how deck skip interacts with logical deck numbering.

Tests:
- Extend Denon tests to cover the audibility ladder, multi-device logical deck numbering and deck labels, multi-deck snapshots, device registration and removal, discovery reconciliation and backoff, broadcast enumeration, and connection-manager behavior under various success and failure scenarios.
- Add tests validating device role classification by software name, semantic source-agent version selection across devices, and expected StateMap subscriptions for audibility and device identity.