### PR TITLE
feat: store external request id for song-request sources

### DIFF
--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -71,6 +71,7 @@ USERREQUEST_TEXT = [
     "normalizedtitle",
     "user_platform",
     "request_origin",
+    "external_id",
 ]
 
 USERREQUEST_BLOB = ["userimage"]
@@ -1004,6 +1005,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         user_input: str,
         request_origin: str = "wnp",
         user_platform: str | None = "twitch",
+        external_id: str | None = None,
     ) -> TrackRequestResult:
         """generic request"""
         logging.debug("%s generic requested %s", user, user_input)
@@ -1045,6 +1047,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             "userimage": setting.get("userimage"),
             "request_origin": request_origin,
             "user_platform": user_platform,
+            "external_id": external_id,
         }
 
         await self.add_to_db(data)
@@ -1102,6 +1105,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
         query: str | None = None,
         artist: str | None = None,
         title: str | None = None,
+        external_id: str | None = None,
         dedup_window: int = 30,
     ) -> TrackRequestResult:
         """create a request from an external source.
@@ -1123,6 +1127,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
                 "type": "Generic",
                 "request_origin": request_origin,
                 "user_platform": user_platform,
+                "external_id": external_id,
             }
             await self.add_to_db(data)
             return {
@@ -1141,7 +1146,12 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             return {"accepted": False, "reason": "empty request"}
 
         result = await self.user_track_request(
-            {}, requester, user_input, request_origin=request_origin, user_platform=user_platform
+            {},
+            requester,
+            user_input,
+            request_origin=request_origin,
+            user_platform=user_platform,
+            external_id=external_id,
         )
         result["accepted"] = True
         result["deduped"] = False

--- a/nowplaying/trackrequests.py
+++ b/nowplaying/trackrequests.py
@@ -1097,7 +1097,7 @@ class Requests:  # pylint: disable=too-many-instance-attributes, too-many-public
             return False
         return row is not None
 
-    async def enqueue_request(  # pylint: disable=too-many-arguments
+    async def enqueue_request(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         requester: str,
         request_origin: str,

--- a/nowplaying/types.py
+++ b/nowplaying/types.py
@@ -143,6 +143,7 @@ class UserTrackRequest(BaseTrackRequest, total=False):
     normalizedtitle: str
     user_platform: str | None
     request_origin: str | None
+    external_id: str | None
 
     # Blob fields
     userimage: bytes | None

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -70,6 +70,7 @@ class RequestsHandler:
             query=body.get("query"),
             artist=body.get("artist"),
             title=body.get("title"),
+            external_id=body.get("external_id"),
         )
         if not result.get("accepted"):
             return web.json_response(result, status=400)
@@ -90,6 +91,7 @@ class RequestsHandler:
                     "track_id": nowplaying.trackrequests.Requests.track_id(
                         row.get("artist"), row.get("title")
                     ),
+                    "external_id": row.get("external_id"),
                     "artist": row.get("artist"),
                     "title": row.get("title"),
                     "requester": row.get("username"),

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -79,7 +79,7 @@ async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: dis
 
 @pytest.mark.asyncio
 async def test_enqueue_request_external_id(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
-    """external_id (the source's own request id) is stored on both the structured and free-text paths"""
+    """external_id (the source's request id) is stored on both enqueue paths"""
     trackrequest = trackrequestbootstrap
     await trackrequest.enqueue_request(
         requester="viewer1",

--- a/tests/test_trackrequests.py
+++ b/tests/test_trackrequests.py
@@ -78,6 +78,30 @@ async def test_enqueue_request_structured(trackrequestbootstrap):  # pylint: dis
 
 
 @pytest.mark.asyncio
+async def test_enqueue_request_external_id(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
+    """external_id (the source's own request id) is stored on both the structured and free-text paths"""
+    trackrequest = trackrequestbootstrap
+    await trackrequest.enqueue_request(
+        requester="viewer1",
+        request_origin="lumia",
+        artist="Radiohead",
+        title="Creep",
+        external_id="lumia-structured-1",
+    )
+    await trackrequest.enqueue_request(
+        requester="viewer2",
+        request_origin="lumia",
+        query="Nirvana - Breed",
+        external_id="lumia-freetext-2",
+    )
+    stored = {
+        row.get("external_id") for row in [r async for r in trackrequest.get_all_generator()]
+    }
+    assert "lumia-structured-1" in stored
+    assert "lumia-freetext-2" in stored
+
+
+@pytest.mark.asyncio
 async def test_enqueue_request_dedup(trackrequestbootstrap):  # pylint: disable=redefined-outer-name
     """a second identical request from the same user within the window is deduped"""
     trackrequest = trackrequestbootstrap

--- a/tests/webserver/test_webserver_requests.py
+++ b/tests/webserver/test_webserver_requests.py
@@ -331,3 +331,39 @@ async def test_requests_delete_no_match_404(getwebserver):  # pylint: disable=re
             timeout=aiohttp.ClientTimeout(total=10),
         ) as req:
             assert req.status == 404
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_requests_external_id_roundtrip(getwebserver):  # pylint: disable=redefined-outer-name
+    """external_id posted by the source round-trips through GET so the queue mirror can match it"""
+    config, _ = getwebserver
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+    port = await _ready(config)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+
+        async with session.post(
+            f"http://localhost:{port}{REQUEST_URL}",
+            json={
+                "requester": "viewer1",
+                "artist": "Radiohead",
+                "title": "Creep",
+                "external_id": "lumia-xyz-123",
+            },
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as req:
+            assert req.status == 200
+
+        async with session.get(
+            f"http://localhost:{port}{REQUEST_URL}", timeout=aiohttp.ClientTimeout(total=10)
+        ) as req:
+            assert req.status == 200
+            items = (await req.json())["requests"]
+            match = next(item for item in items if item["title"] == "Creep")
+            assert match["external_id"] == "lumia-xyz-123"


### PR DESCRIPTION
Add a nullable external_id column to userrequest so a song-request source can hand back the id it assigned a request. It is stored on both enqueue_request paths -- structured artist/title and the chat-parser free-text path via user_track_request -- and returned by GET /v1/requests.

Without it the queue mirror reports WNP's own track_id, which never matches the id the source (Lumia) filed the request under, so the source prunes its own live entries on the next reconcile. Echoing the source's id back lets it match and keep them.

_migrate_db adds the column to existing databases; the response field is additive.

## Summary by Sourcery

Add support for propagating an external request identifier from request sources through storage and the requests API so queue mirrors can round-trip the source’s ID.

New Features:
- Store a nullable external_id field on user requests and expose it in the requests API responses.
- Accept an optional external_id when enqueuing requests via both structured and free-text request paths.

Tests:
- Add integration tests to verify external_id is accepted on POST /v1/requests and returned on subsequent GET.
- Add tests to ensure external_id is persisted for both structured and free-text enqueue_request flows.