### PR TITLE
feat: add /v1/events, a publish-only WebSocket stream

### DIFF
--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -27,6 +27,7 @@ from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
 from zeroconf import IPVersion
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
+from nowplaying.webserver.events_websocket import EventsWebSocketHandler
 from nowplaying.webserver.gifwords_websocket import GifwordsWebSocketHandler
 from nowplaying.webserver.guessgame_websocket import GuessgameWebSocketHandler
 from nowplaying.webserver.images_websocket import ImagesWebSocketHandler
@@ -73,6 +74,11 @@ REMOTEDB_KEY = web.AppKey("remotedb", nowplaying.db.MetadataDB)
 WS_KEY = web.AppKey("websockets", weakref.WeakSet)
 DC_STORAGE_KEY: web.AppKey[nowplaying.datacache.DataStorage] = web.AppKey("datacache_storage")
 WATCHER_KEY = web.AppKey("watcher", nowplaying.db.DBWatcher)
+REQUESTS_WATCHER_KEY = web.AppKey("requests_watcher", nowplaying.db.DBWatcher)
+# Broadcast target for /v1/events -- one asyncio.Queue per connection, not sockets
+# themselves. Deliberately not in on_shutdown, at the cost of up to a 30s shutdown
+# delay; see events_websocket.py for the full rationale.
+EVENTS_WS_KEY = web.AppKey("events_websockets", weakref.WeakSet)
 JINJA2_KEY = web.AppKey("jinja2_env", jinja2.Environment)
 METADATA_KEY = web.AppKey("metadata", nowplaying.metadata.MetadataProcessors)
 HTTP_SESSION_KEY = web.AppKey("http_session", aiohttp.ClientSession)
@@ -141,6 +147,16 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         )
 
         self.requests_handler = RequestsHandler(config_key=CONFIG_KEY)
+
+        self.events_ws_handler = EventsWebSocketHandler(
+            stopevent=self.stopevent,
+            config_key=CONFIG_KEY,
+            metadb_key=METADB_KEY,
+            watcher_key=WATCHER_KEY,
+            requests_watcher_key=REQUESTS_WATCHER_KEY,
+            events_ws_key=EVENTS_WS_KEY,
+            requests_handler=self.requests_handler,
+        )
 
         while not enabled and not nowplaying.utils.safe_stopevent_check(self.stopevent):
             try:
@@ -735,6 +751,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         threading.current_thread().name = "WebServer-runner"
         app = web.Application()
         app[WS_KEY] = weakref.WeakSet()
+        app[EVENTS_WS_KEY] = weakref.WeakSet()
         app.on_startup.append(self.on_startup)
         app.on_cleanup.append(self.on_cleanup)
         app.on_shutdown.append(self.on_shutdown)
@@ -779,6 +796,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                     "/wsguessgamestream", self.guessgame_ws_handler.websocket_guessgame_streamer
                 ),
                 web.get("/v1/images/ws", self.images_ws_handler.websocket_images_handler),
+                web.get("/v1/events", self.events_ws_handler.websocket_events_handler),
                 web.get(
                     "/whatsnowplaying-websocket.js", self.static_handler.whatsnowplaying_js_handler
                 ),
@@ -835,6 +853,12 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         self.tasks.add(guessgame_task)
         guessgame_task.add_done_callback(self.tasks.discard)
 
+        events_task = asyncio.create_task(
+            self.events_ws_handler.events_broadcast_task(self.runner.app)
+        )
+        self.tasks.add(events_task)
+        events_task.add_done_callback(self.tasks.discard)
+
         await self.site.start()
 
         # Register mDNS/Bonjour service after server starts
@@ -866,6 +890,10 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         app[DC_STORAGE_KEY] = nowplaying.datacache.get_client().storage
         app[WATCHER_KEY] = app[METADB_KEY].watcher()
         app[WATCHER_KEY].start()
+        # Requests() runs a sync DB migration; to_thread keeps it off the event loop.
+        requests_instance = await asyncio.to_thread(self.requests_handler.get_requests, app)
+        app[REQUESTS_WATCHER_KEY] = nowplaying.db.DBWatcher(requests_instance.databasefile)
+        app[REQUESTS_WATCHER_KEY].start()
         if os.environ.get("WNP_REMOTEDB_TEST_FILE"):
             remotedb: pathlib.Path | None = pathlib.Path(os.environ["WNP_REMOTEDB_TEST_FILE"])
         else:
@@ -906,6 +934,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         await app["statedb"].close()
         await app[HTTP_SESSION_KEY].close()
         app[WATCHER_KEY].stop()
+        app[REQUESTS_WATCHER_KEY].stop()
         await app[DC_STORAGE_KEY].close()
 
         # Cleanup runner last (site cleanup happens automatically)

--- a/nowplaying/webserver/events_websocket.py
+++ b/nowplaying/webserver/events_websocket.py
@@ -269,7 +269,12 @@ class EventsWebSocketHandler:
     async def events_broadcast_task(self, app: web.Application) -> None:
         """Background task: poll both DBWatchers, broadcast only on real change"""
         logging.info("Starting events broadcast task")
-        reqs = await asyncio.to_thread(self.requests_handler.get_requests, app)
+        # on_startup already built and cached this instance via asyncio.to_thread --
+        # that is the one call that pays for Requests()'s synchronous _migrate_db().
+        # runner.setup() awaits on_startup to completion before start_server ever
+        # creates this task, so this is always a cache hit: call directly rather than
+        # paying for another thread-pool hop that does nothing but a None check.
+        reqs = self.requests_handler.get_requests(app)
         last_meta_time = app[self.watcher_key].updatetime
         last_requests_time = app[self.requests_watcher_key].updatetime
         # Baseline only -- do not announce as "added" whatever already existed when

--- a/nowplaying/webserver/events_websocket.py
+++ b/nowplaying/webserver/events_websocket.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""/v1/events -- one-way WebSocket event stream (now-playing + request-queue deltas)
+
+Publish-only: the server pushes typed frames ({"type", "timestamp", "payload"}), clients
+never send commands over this socket.  Mutations stay on POST/DELETE /v1/requests, which
+already give a real synchronous response.
+"""
+
+import asyncio
+import contextlib
+import logging
+import re
+import time
+import uuid
+import weakref
+from typing import TYPE_CHECKING
+
+import aiohttp
+from aiohttp import web
+
+import nowplaying.db
+import nowplaying.utils
+import nowplaying.webserver.auth
+import nowplaying.webserver.shutdown
+from nowplaying.webserver.requests_handlers import RequestsHandler
+
+if TYPE_CHECKING:
+    import nowplaying.config
+    from nowplaying.types import TrackMetadata
+
+POLL_INTERVAL_SECONDS = 1.0
+
+# Frames are only enqueued on actual change (not per poll tick), so ordinary traffic
+# never gets close to this. It exists so a wedged consumer -- heartbeat is 30s, so a
+# truly dead peer is usually caught well before this -- applies backpressure by
+# dropping instead of growing without bound.
+MAX_QUEUE_SIZE = 1000
+
+# Matches the shape of a minted id (str(uuid.uuid4())[:8]) and any reasonable
+# caller-supplied slug; short and conservative on purpose -- this only ever ends
+# up in log lines and a JSON frame, not anywhere security-sensitive.
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+class EventsWebSocketHandler:
+    """Handler for the /v1/events publish-only WebSocket"""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        stopevent: asyncio.Event,
+        config_key: "web.AppKey[nowplaying.config.ConfigFile]",
+        metadb_key: "web.AppKey[nowplaying.db.MetadataDB]",
+        watcher_key: "web.AppKey[nowplaying.db.DBWatcher]",
+        requests_watcher_key: "web.AppKey[nowplaying.db.DBWatcher]",
+        events_ws_key: "web.AppKey[weakref.WeakSet[asyncio.Queue]]",
+        requests_handler: RequestsHandler,
+    ):
+        self.stopevent = stopevent
+        self.config_key = config_key
+        self.metadb_key = metadb_key
+        self.watcher_key = watcher_key
+        self.requests_watcher_key = requests_watcher_key
+        self.events_ws_key = events_ws_key
+        self.requests_handler = requests_handler
+
+    @staticmethod
+    def _session_id(request: web.Request) -> str:
+        """X-WNP-Client-Session lets a header-capable caller supply its own
+        correlation id (the standard X-Request-ID pattern); falls back to a
+        server-minted one when absent or malformed.  Never a query param -- there
+        is no preceding .htm render for this endpoint to relay one from, unlike
+        /wsstream et al., so a query value would be a bare, untrusted string.
+
+        The fallback is silent rather than a rejected connection: this is a
+        logging convenience, not something worth failing a connection over. And
+        it must not pass an unsanitized header straight into logging.info() --
+        that is a textbook log-injection vector (embed a newline, forge a fake
+        log line).
+        """
+        candidate = request.headers.get("X-WNP-Client-Session", "")
+        if _SESSION_ID_RE.match(candidate):
+            return candidate
+        return str(uuid.uuid4())[:8]
+
+    @staticmethod
+    def _envelope(event_type: str, payload: dict) -> dict:
+        return {"type": event_type, "timestamp": int(time.time() * 1000), "payload": payload}
+
+    @staticmethod
+    def _strip_track_blobs(metadata: "TrackMetadata") -> dict:
+        """currentmeta row -> wire shape: drop METADATABLOBLIST + dbid, keep coverurl.
+
+        dbid is synthesized separately from row["id"] in _postprocess_read_last_meta
+        (nowplaying/db.py) -- it is not in METADATABLOBLIST, so it needs its own
+        explicit strip, same as every other consumer of read_last_meta_async()
+        (_wss_do_update, websocket_lastjson_handler) already does.
+        """
+        stripped = dict(metadata)
+        for key in nowplaying.db.METADATABLOBLIST:
+            stripped.pop(key, None)
+        stripped.pop("dbid", None)
+        return stripped
+
+    @staticmethod
+    def diff_requests(previous: dict[int, dict], current: dict[int, dict]):
+        """Pure diff, no I/O: (added, changed, removed), each {reqid: serialized_row}.
+
+        removed carries the row's LAST-KNOWN value (from `previous`), not just the
+        bare id, so a consumer gets a full record on removal too -- free, since
+        `previous` already has it cached from the prior tick.
+
+        changed is a reqid present on both sides whose serialized payload differs --
+        an in-place UPDATE (respin being the one existing example: same reqid, new
+        artist/title). Reported as its own frame rather than removed-then-added so a
+        consumer never sees a transient empty slot for a row that never actually left
+        the queue.
+        """
+        added = {rid: row for rid, row in current.items() if rid not in previous}
+        changed = {
+            rid: row for rid, row in current.items() if rid in previous and previous[rid] != row
+        }
+        removed = {rid: row for rid, row in previous.items() if rid not in current}
+        return added, changed, removed
+
+    async def _send_snapshot(
+        self, websocket: web.WebSocketResponse, request: web.Request, session_id: str
+    ) -> None:
+        """connected signal, then a full track + request-queue snapshot, then a marker"""
+        await websocket.send_json(self._envelope("connected", {"session_id": session_id}))
+        metadata = await request.app[self.metadb_key].read_last_meta_async()
+        if metadata:
+            await websocket.send_json(
+                self._envelope("track-update", self._strip_track_blobs(metadata))
+            )
+        reqs = self.requests_handler.get_requests(request.app)
+        request_count = 0
+        async for row in reqs.get_all_generator():
+            payload = RequestsHandler.serialize_request_row(row)
+            await websocket.send_json(self._envelope("request-added", payload))
+            request_count += 1
+        # A burst of individually-framed request-added events has no inherent
+        # terminator, so a consumer can't tell "that's all of them" from "one
+        # more might still be coming" without a marker -- this is that marker.
+        # request_count lets it sanity-check its own tally, not just proceed.
+        await websocket.send_json(
+            self._envelope("snapshot-complete", {"request_count": request_count})
+        )
+
+    @staticmethod
+    async def _drain_queue(websocket: web.WebSocketResponse, queue: "asyncio.Queue[dict]") -> None:
+        """the only coroutine that writes to `websocket` once the connection is live"""
+        while True:
+            frame = await queue.get()
+            await websocket.send_json(frame)
+
+    async def _read_until_closed(self, websocket: web.WebSocketResponse) -> None:
+        """publish-only: read just to notice CLOSE/ERROR; any actual message is ignored.
+
+        This is also how a connection notices server shutdown: stopevent is checked
+        once per loop iteration, and each iteration blocks on receive() for up to 30s.
+        A connection can therefore take up to that long to exit once stopevent is set,
+        delaying runner.cleanup() by the same amount -- matches existing gifwords /
+        guessgame behavior, so it's house-consistent, but is a real trade-off against
+        forcibly closing every connection, not a free one.
+        """
+        while not nowplaying.webserver.shutdown.safe_stopevent_check_websocket(self.stopevent):
+            try:
+                msg = await asyncio.wait_for(websocket.receive(), timeout=30.0)
+            except TimeoutError:
+                continue
+            if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR):
+                return
+
+    async def websocket_events_handler(self, request: web.Request):
+        """GET /v1/events -- connect, get a snapshot, then receive live frames"""
+        config = request.app[self.config_key]
+        config.get()
+        # Header preferred, ?secret= as the legacy fallback -- same contract as
+        # every REST endpoint.  Not optional here the way it looked at first: the
+        # browser WebSocket() constructor has no mechanism to set custom headers
+        # at all (unlike fetch/XHR), so a header-only check would categorically
+        # lock out any browser-rendered consumer, not just make it inconvenient.
+        # Trade-off: the header exists specifically to keep the shared secret out
+        # of access/proxy/browser-history logs, so a browser consumer using this
+        # fallback puts it in the server's access log on every connect.
+        auth_result = nowplaying.webserver.auth.check_client_auth(
+            request,
+            config,
+            legacy_secret=request.query.get("secret", ""),
+            source="Events WebSocket connect",
+        )
+        if auth_result == nowplaying.webserver.auth.AUTH_MISSING:
+            return web.Response(status=401)
+        if auth_result == nowplaying.webserver.auth.AUTH_INVALID:
+            return web.Response(status=403)
+
+        websocket = web.WebSocketResponse(heartbeat=30.0)
+        await websocket.prepare(request)
+        session_id = self._session_id(request)
+        logging.info("Session %s: Events streamer connected from %s", session_id, request.remote)
+
+        # Joined before the snapshot below is captured, not after: a queue only ever
+        # gains frames via _broadcast's put_nowait, so joining early just means a
+        # broadcast that lands mid-snapshot is queued instead of lost -- at worst one
+        # duplicate frame right after the snapshot, never a client stuck showing stale
+        # data until the *next* change (which is what late-joining used to risk).
+        queue: "asyncio.Queue[dict]" = asyncio.Queue(maxsize=MAX_QUEUE_SIZE)
+        request.app[self.events_ws_key].add(queue)
+        reader_task: asyncio.Task | None = None
+        writer_task: asyncio.Task | None = None
+
+        try:
+            # _broadcast only ever touches `queue` (see below), never `websocket`
+            # directly, so _drain_queue is structurally the *only* writer to this
+            # socket for its whole life -- "one writer per socket" is enforced by
+            # construction, not by a comment asking callers to respect an ordering.
+            await self._send_snapshot(websocket, request, session_id)
+            reader_task = asyncio.create_task(self._read_until_closed(websocket))
+            writer_task = asyncio.create_task(self._drain_queue(websocket, queue))
+            # Exactly one of these ever finishes on its own: the reader when the
+            # peer disconnects, the writer only if send_json raises.
+            done, _pending = await asyncio.wait(
+                {reader_task, writer_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                if (error := task.exception()) is not None:
+                    raise error
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Session %s: events websocket error", session_id)
+        finally:
+            # Cancelling this coroutine itself (aiohttp does this during
+            # runner.cleanup()) raises CancelledError -- a BaseException -- straight
+            # out of the `await asyncio.wait(...)` above, skipping the `except
+            # Exception` block entirely and landing here with both tasks still
+            # live. Doing the cancel-and-gather here instead of only on the
+            # happy path means it runs on *every* exit, including that one.
+            # Cancelling an already-finished task is a no-op, so this is safe to
+            # do unconditionally rather than tracking which task was still running.
+            for task in (reader_task, writer_task):
+                if task is not None:
+                    task.cancel()
+            live_tasks = [task for task in (reader_task, writer_task) if task is not None]
+            if live_tasks:
+                await asyncio.gather(*live_tasks, return_exceptions=True)
+            request.app[self.events_ws_key].discard(queue)  # stop queuing before closing below
+            # An abrupt disconnect (WSMsgType.ERROR) can leave `closed` still False,
+            # so this send can raise ConnectionResetError -- swallow it rather than
+            # letting it escape from inside a finally and skip the disconnect log.
+            with contextlib.suppress(Exception):
+                if not websocket.closed:
+                    await websocket.send_json(self._envelope("connection-closing", {}))
+                    await websocket.close()
+            logging.info("Session %s: Events streamer disconnected", session_id)
+        return websocket
+
+    def _broadcast(self, app: web.Application, frame: dict) -> None:
+        # Enqueue only -- never touch a socket here. Each connection's own
+        # _drain_queue is the sole writer to it; this keeps that true unconditionally
+        # instead of depending on callers to sequence sends correctly.
+        for queue in list(app[self.events_ws_key]):
+            try:
+                queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                logging.warning(
+                    "Events queue full (%d), dropping a frame for a wedged connection",
+                    MAX_QUEUE_SIZE,
+                )
+
+    async def events_broadcast_task(self, app: web.Application) -> None:
+        """Background task: poll both DBWatchers, broadcast only on real change"""
+        logging.info("Starting events broadcast task")
+        reqs = await asyncio.to_thread(self.requests_handler.get_requests, app)
+        last_meta_time = app[self.watcher_key].updatetime
+        last_requests_time = app[self.requests_watcher_key].updatetime
+        # Baseline only -- do not announce as "added" whatever already existed when
+        # the task started; that is not new.
+        last_rows = {
+            row["reqid"]: RequestsHandler.serialize_request_row(row)
+            async for row in reqs.get_all_generator()
+        }
+
+        try:
+            while not nowplaying.utils.safe_stopevent_check(self.stopevent):
+                if app[self.watcher_key].updatetime > last_meta_time:
+                    last_meta_time = app[self.watcher_key].updatetime
+                    metadata = await app[self.metadb_key].read_last_meta_async()
+                    if metadata:
+                        self._broadcast(
+                            app,
+                            self._envelope("track-update", self._strip_track_blobs(metadata)),
+                        )
+
+                if app[self.requests_watcher_key].updatetime > last_requests_time:
+                    last_requests_time = app[self.requests_watcher_key].updatetime
+                    current_rows = {
+                        row["reqid"]: RequestsHandler.serialize_request_row(row)
+                        async for row in reqs.get_all_generator()
+                    }
+                    added, changed, removed = self.diff_requests(last_rows, current_rows)
+                    for payload in added.values():
+                        self._broadcast(app, self._envelope("request-added", payload))
+                    for payload in changed.values():
+                        self._broadcast(app, self._envelope("request-updated", payload))
+                    for payload in removed.values():
+                        self._broadcast(app, self._envelope("request-removed", payload))
+                    last_rows = current_rows
+
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            logging.info("Events broadcast task cancelled")
+            raise
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Events broadcast task error")

--- a/nowplaying/webserver/requests_handlers.py
+++ b/nowplaying/webserver/requests_handlers.py
@@ -20,16 +20,24 @@ class RequestsHandler:
         self.config_key = config_key
         self._requests_instance: "nowplaying.trackrequests.Requests | None" = None
 
-    def _requests(self, request: web.Request) -> "nowplaying.trackrequests.Requests":
-        # Requests() runs a synchronous _migrate_db() (sqlite connect + PRAGMA, possibly
-        # ALTER) in its constructor, so build it once and reuse it rather than paying that
-        # cost on the event loop on every API hit. request.app[config_key] is a single
-        # stable object and Requests reads config live via cparser, so caching is safe.
+    def get_requests(self, app: web.Application) -> "nowplaying.trackrequests.Requests":
+        """App-keyed accessor for the cached Requests() instance.
+
+        Requests() runs a synchronous _migrate_db() (sqlite connect + PRAGMA, possibly
+        ALTER) in its constructor, so build it once and reuse it rather than paying that
+        cost on the event loop on every API hit. app[config_key] is a single stable
+        object and Requests reads config live via cparser, so caching is safe.
+
+        Takes app rather than request so callers that only have the former -- the
+        events-websocket background broadcast task, in particular -- can reuse the
+        same cached instance instead of constructing a second one.
+        """
         if self._requests_instance is None:
-            self._requests_instance = nowplaying.trackrequests.Requests(
-                request.app[self.config_key]
-            )
+            self._requests_instance = nowplaying.trackrequests.Requests(app[self.config_key])
         return self._requests_instance
+
+    def _requests(self, request: web.Request) -> "nowplaying.trackrequests.Requests":
+        return self.get_requests(request.app)
 
     def _authorized(self, request: web.Request, provided_secret: str) -> bool:
         """reuse the webserver's shared secret (empty key disables auth)
@@ -76,6 +84,23 @@ class RequestsHandler:
             return web.json_response(result, status=400)
         return web.json_response(result)
 
+    @staticmethod
+    def serialize_request_row(row: "nowplaying.trackrequests.UserTrackRequest") -> dict:
+        """wire shape for one queue row — shared by GET /v1/requests and /v1/events"""
+        return {
+            "request_id": row.get("reqid"),
+            "track_id": nowplaying.trackrequests.Requests.track_id(
+                row.get("artist"), row.get("title")
+            ),
+            "external_id": row.get("external_id"),
+            "artist": row.get("artist"),
+            "title": row.get("title"),
+            "requester": row.get("username"),
+            "user_platform": row.get("user_platform"),
+            "request_origin": row.get("request_origin"),
+            "timestamp": row.get("timestamp"),
+        }
+
     async def get_requests_handler(self, request: web.Request) -> web.Response:
         """GET /v1/requests — the current queue snapshot for Lumia to mirror"""
         if not self._authorized(request, request.query.get("secret", "")):
@@ -83,23 +108,7 @@ class RequestsHandler:
         if not self._requests_enabled(request):
             return web.json_response({"requests": []})
         reqs = self._requests(request)
-        items = []
-        async for row in reqs.get_all_generator():
-            items.append(
-                {
-                    "request_id": row.get("reqid"),
-                    "track_id": nowplaying.trackrequests.Requests.track_id(
-                        row.get("artist"), row.get("title")
-                    ),
-                    "external_id": row.get("external_id"),
-                    "artist": row.get("artist"),
-                    "title": row.get("title"),
-                    "requester": row.get("username"),
-                    "user_platform": row.get("user_platform"),
-                    "request_origin": row.get("request_origin"),
-                    "timestamp": row.get("timestamp"),
-                }
-            )
+        items = [self.serialize_request_row(row) async for row in reqs.get_all_generator()]
         return web.json_response({"requests": items})
 
     async def delete_request_handler(self, request: web.Request) -> web.Response:

--- a/tests/webserver/test_webserver_consolidated.py
+++ b/tests/webserver/test_webserver_consolidated.py
@@ -10,7 +10,9 @@ import aiohttp
 import pytest
 import websockets
 
+import nowplaying.db
 import nowplaying.metadata.processors
+import nowplaying.trackrequests
 import nowplaying.webserver.auth
 from tests.utils_images import jpeg_bytes
 from tests.webserver.conftest import wait_for_webserver_content_update, wait_for_webserver_ready
@@ -507,6 +509,346 @@ async def test_cover_by_cachekey_unknown_key_is_404(getwebserver):
         ) as req,
     ):
         assert req.status == 404
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_connect_sends_connected_frame_first(getwebserver):
+    """the very first frame is a server-minted, per-connection-unique session id
+
+    Never a query param -- there is no preceding .htm render for /v1/events to
+    relay one from, unlike /wsstream et al., so the id has to be minted here.
+    """
+    config, _metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws1:
+        first1 = json.loads(await asyncio.wait_for(ws1.recv(), timeout=10))
+        async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws2:
+            first2 = json.loads(await asyncio.wait_for(ws2.recv(), timeout=10))
+
+    assert first1["type"] == "connected"
+    assert first2["type"] == "connected"
+    session_id1 = first1["payload"]["session_id"]
+    session_id2 = first2["payload"]["session_id"]
+    assert session_id1
+    assert session_id2
+    assert session_id1 != session_id2
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_connect_honors_client_session_header(getwebserver):
+    """a well-formed X-WNP-Client-Session is echoed back verbatim"""
+    config, _metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    async with websockets.connect(
+        f"ws://localhost:{port}/v1/events",
+        additional_headers={"X-WNP-Client-Session": "my-lumia-session-42"},
+    ) as ws:
+        first = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+
+    assert first == {
+        "type": "connected",
+        "timestamp": first["timestamp"],
+        "payload": {"session_id": "my-lumia-session-42"},
+    }
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_connect_sends_snapshot(getwebserver):
+    """after connected: current track, one request-added per row, then snapshot-complete
+
+    snapshot-complete is the deterministic alternative to a client-side debounce
+    timer for "is the initial request-added burst finished yet".
+    """
+    config, metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+
+    await metadb.write_to_metadb(
+        metadata={
+            "artist": "WNP Mock Artist",
+            "title": "WNP Mock Song",
+            "coverimageraw": jpeg_bytes(),
+        }
+    )
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}/v1/requests", timeout=aiohttp.ClientTimeout(total=5)
+        ) as req:
+            assert req.status == 200
+        async with session.post(
+            f"http://localhost:{port}/v1/requests",
+            json={"requester": "viewer1", "artist": "Radiohead", "title": "Creep"},
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as req:
+            assert req.status == 200
+
+    async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws:
+        connected = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+        track_update = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+        request_added = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+        snapshot_complete = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+
+    assert connected["type"] == "connected"
+    assert track_update["type"] == "track-update"
+    assert track_update["payload"]["artist"] == "WNP Mock Artist"
+    for key in nowplaying.db.METADATABLOBLIST:
+        assert key not in track_update["payload"]
+    assert "dbid" not in track_update["payload"]
+    assert request_added["type"] == "request-added"
+    assert request_added["payload"]["artist"] == "Radiohead"
+    assert request_added["payload"]["title"] == "Creep"
+    assert snapshot_complete["type"] == "snapshot-complete"
+    assert snapshot_complete["payload"]["request_count"] == 1
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_broadcasts_track_update_on_change(getwebserver):
+    """a live write_to_metadb after connecting produces a fresh track-update frame"""
+    config, metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws:
+        await asyncio.wait_for(ws.recv(), timeout=10)  # connected
+        # No snapshot frame necessarily follows: getwebserver's metadb and request
+        # queue both start empty, so there is nothing to send until something
+        # actually changes -- scan by type/content rather than assume a fixed count.
+
+        await metadb.write_to_metadb(metadata={"artist": "Depeche Mode", "title": "Strangelove"})
+
+        frame = None
+        for _ in range(5):
+            frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            if (
+                frame["type"] == "track-update"
+                and frame["payload"].get("artist") == "Depeche Mode"
+            ):
+                break
+        assert frame is not None
+        assert frame["type"] == "track-update"
+        assert frame["payload"]["artist"] == "Depeche Mode"
+        assert frame["payload"]["title"] == "Strangelove"
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_broadcasts_request_added_and_removed(getwebserver):
+    """POST /v1/requests -> request-added; DELETE that id -> request-removed with the full row"""
+    config, _metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}/v1/requests", timeout=aiohttp.ClientTimeout(total=5)
+        ) as req:
+            assert req.status == 200
+
+        async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws:
+            await asyncio.wait_for(ws.recv(), timeout=10)  # connected
+            # Queue is empty after the clear above, so the snapshot phase is just
+            # "connected" then "snapshot-complete" (request_count=0) -- no need to
+            # drain it explicitly, the scan-by-type loop below skips past it.
+
+            async with session.post(
+                f"http://localhost:{port}/v1/requests",
+                json={"requester": "viewer1", "artist": "Pet Shop Boys", "title": "Heart"},
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as req:
+                assert req.status == 200
+
+            added = None
+            for _ in range(5):
+                frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+                if frame["type"] == "request-added":
+                    added = frame
+                    break
+            assert added is not None
+            assert added["payload"]["artist"] == "Pet Shop Boys"
+            reqid = added["payload"]["request_id"]
+
+            async with session.delete(
+                f"http://localhost:{port}/v1/requests/{reqid}",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as req:
+                assert req.status == 200
+
+            removed = None
+            for _ in range(5):
+                frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+                if frame["type"] == "request-removed":
+                    removed = frame
+                    break
+            assert removed is not None
+            assert removed["payload"]["request_id"] == reqid
+            assert removed["payload"]["artist"] == "Pet Shop Boys"
+            assert removed["payload"]["title"] == "Heart"
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_broadcasts_request_updated_on_respin(getwebserver):
+    """An in-place UPDATE to an existing reqid (what respin does) -> request-updated,
+    never a request-removed/request-added pair -- a consumer should never see a
+    transient empty slot for a row that never actually left the queue."""
+    config, _metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    config.cparser.setValue("settings/requests", True)
+    config.cparser.sync()
+
+    async with aiohttp.ClientSession() as session:
+        async with session.delete(
+            f"http://localhost:{port}/v1/requests", timeout=aiohttp.ClientTimeout(total=5)
+        ) as req:
+            assert req.status == 200
+
+        async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws:
+            await asyncio.wait_for(ws.recv(), timeout=10)  # connected
+
+            async with session.post(
+                f"http://localhost:{port}/v1/requests",
+                json={"requester": "viewer1", "artist": "Pet Shop Boys", "title": "Heart"},
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as req:
+                assert req.status == 200
+
+            added = None
+            for _ in range(5):
+                frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+                if frame["type"] == "request-added":
+                    added = frame
+                    break
+            assert added is not None
+            reqid = added["payload"]["request_id"]
+
+            # Respin's own UPDATE (trackrequests.py: user_roulette_request -> add_to_db
+            # with reqid set) rewrites artist/title/etc. in place on the same row rather
+            # than deleting and re-inserting. Drive that exact code path directly --
+            # there is no REST endpoint for it, respin is only reachable from the
+            # roulette poller -- against the same request.db the webserver subprocess
+            # is watching, so this is a real UPDATE, not a simulated one.
+            reqs = nowplaying.trackrequests.Requests(config)
+            await reqs.add_to_db(
+                {
+                    "reqid": reqid,
+                    "username": "viewer1",
+                    "playlist": "",
+                    "type": "Roulette",
+                    "displayname": "",
+                    "artist": "Pet Shop Boys",
+                    "title": "West End Girls",
+                }
+            )
+
+            updated = None
+            saw_added_or_removed = False
+            for _ in range(5):
+                frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+                if frame["type"] == "request-updated":
+                    updated = frame
+                    break
+                if frame["type"] in ("request-added", "request-removed"):
+                    saw_added_or_removed = True
+            assert not saw_added_or_removed
+            assert updated is not None
+            assert updated["payload"]["request_id"] == reqid
+            assert updated["payload"]["artist"] == "Pet Shop Boys"
+            assert updated["payload"]["title"] == "West End Girls"
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "secret_config,client_header,query_secret,expected_status",
+    [
+        (None, None, None, 200),
+        ("test_secret", "test_secret", None, 200),
+        ("test_secret", "wrong_secret", None, 403),
+        ("test_secret", None, None, 401),
+        # Header-preferred, ?secret= as the legacy fallback -- same contract as
+        # every REST endpoint.  Not optional: the browser WebSocket() constructor
+        # cannot set custom headers at all, so this is the only path a
+        # browser-rendered consumer of this stream would ever have.
+        ("test_secret", None, "test_secret", 200),
+        ("test_secret", None, "wrong_secret", 403),
+    ],
+)
+async def test_events_auth(
+    getwebserver, secret_config, client_header, query_secret, expected_status
+):
+    """header preferred, ?secret= query param as the browser-compatible fallback"""
+    config, _metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    if secret_config:
+        config.cparser.setValue("remote/remote_key", secret_config)
+    config.cparser.sync()
+
+    headers = {}
+    if client_header:
+        headers[nowplaying.webserver.auth.CLIENT_AUTH_HEADER] = client_header
+    url = f"ws://localhost:{port}/v1/events"
+    if query_secret:
+        url += f"?secret={query_secret}"
+
+    if expected_status == 200:
+        async with websockets.connect(url, additional_headers=headers) as ws:
+            frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            assert frame["type"] == "connected"
+    else:
+        with pytest.raises(websockets.exceptions.InvalidStatus) as excinfo:
+            async with websockets.connect(url, additional_headers=headers):
+                pass
+        assert excinfo.value.response.status_code == expected_status
+
+
+@pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")
+@pytest.mark.asyncio
+async def test_events_ignores_client_messages(getwebserver):
+    """publish-only: sending text from the client doesn't close the connection or do anything"""
+    config, metadb = getwebserver
+    port = config.cparser.value("weboutput/httpport", type=int)
+    if not await wait_for_webserver_ready(port, timeout=10.0):
+        raise RuntimeError(f"Webserver on port {port} failed to respond within 10 seconds")
+
+    async with websockets.connect(f"ws://localhost:{port}/v1/events") as ws:
+        await asyncio.wait_for(ws.recv(), timeout=10)  # connected
+
+        await ws.send("some arbitrary client text, not a command")
+
+        await metadb.write_to_metadb(metadata={"artist": "Yazoo", "title": "Situation"})
+
+        frame = None
+        for _ in range(5):
+            frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            if frame["type"] == "track-update" and frame["payload"].get("artist") == "Yazoo":
+                break
+        assert frame is not None
+        assert ws.close_code is None  # still open
 
 
 @pytest.mark.xfail(sys.platform == "darwin", reason="timeouts on macos CI")

--- a/tests/webserver/test_webserver_events_websocket.py
+++ b/tests/webserver/test_webserver_events_websocket.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""test the pure-function pieces of /v1/events: diffing, blob-stripping, session ids
+
+Deliberately no asyncio/DB/webserver here -- these are plain functions and the
+whole point of factoring them out that way is that they're testable without any
+of that.  End-to-end behavior (snapshot on connect, live broadcasts, auth) is
+covered in tests/webserver/test_webserver_consolidated.py against a real server.
+"""
+
+from unittest.mock import MagicMock
+
+import nowplaying.db  # pylint: disable=import-error
+import nowplaying.webserver.events_websocket  # pylint: disable=import-error
+
+Handler = nowplaying.webserver.events_websocket.EventsWebSocketHandler
+
+
+def test_diff_requests_empty_to_empty():
+    """no rows on either side -- nothing to report"""
+    added, changed, removed = Handler.diff_requests({}, {})
+    assert added == {}
+    assert changed == {}
+    assert removed == {}
+
+
+def test_diff_requests_one_added():
+    """a reqid present in current but not previous is added"""
+    row = {"reqid": 1, "artist": "WNP Mock Artist", "title": "WNP Mock Song"}
+    added, changed, removed = Handler.diff_requests({}, {1: row})
+    assert added == {1: row}
+    assert changed == {}
+    assert removed == {}
+
+
+def test_diff_requests_one_removed_carries_last_known_payload():
+    """removed must carry the row's LAST-KNOWN value, not just a bare id"""
+    row = {"reqid": 1, "artist": "WNP Mock Artist", "title": "WNP Mock Song"}
+    added, changed, removed = Handler.diff_requests({1: row}, {})
+    assert added == {}
+    assert changed == {}
+    assert removed == {1: row}
+
+
+def test_diff_requests_simultaneous_add_and_remove():
+    """one row appearing and another vanishing in the same tick don't cross-contaminate"""
+    gone = {"reqid": 1, "artist": "Gone Artist", "title": "Gone Song"}
+    new = {"reqid": 2, "artist": "New Artist", "title": "New Song"}
+    added, changed, removed = Handler.diff_requests({1: gone}, {2: new})
+    assert added == {2: new}
+    assert changed == {}
+    assert removed == {1: gone}
+
+
+def test_diff_requests_identical_input_is_a_noop():
+    """the same row set on both sides produces no events"""
+    row = {"reqid": 1, "artist": "WNP Mock Artist", "title": "WNP Mock Song"}
+    added, changed, removed = Handler.diff_requests({1: row}, {1: row})
+    assert added == {}
+    assert changed == {}
+    assert removed == {}
+
+
+def test_diff_requests_reqid_present_both_sides_with_different_payload_is_changed():
+    """respin (same reqid, new artist/title) must surface as changed, not added+removed"""
+    before = {"reqid": 1, "artist": "WNP Mock Artist", "title": "WNP Mock Song"}
+    after = {"reqid": 1, "artist": "WNP Mock Artist 2", "title": "WNP Mock Song 2"}
+    added, changed, removed = Handler.diff_requests({1: before}, {1: after})
+    assert added == {}
+    assert changed == {1: after}
+    assert removed == {}
+
+
+def test_diff_requests_added_changed_and_removed_together_dont_cross_contaminate():
+    """one row added, one changed in place, one removed, all in the same tick"""
+    stable = {"reqid": 1, "artist": "WNP Mock Artist", "title": "WNP Mock Song"}
+    respun_before = {"reqid": 2, "artist": "WNP Mock Artist 2", "title": "WNP Mock Song 2"}
+    respun_after = {"reqid": 2, "artist": "WNP Mock Artist 3", "title": "WNP Mock Song 3"}
+    gone = {"reqid": 3, "artist": "Gone Artist", "title": "Gone Song"}
+    new = {"reqid": 4, "artist": "New Artist", "title": "New Song"}
+
+    previous = {1: stable, 2: respun_before, 3: gone}
+    current = {1: stable, 2: respun_after, 4: new}
+
+    added, changed, removed = Handler.diff_requests(previous, current)
+    assert added == {4: new}
+    assert changed == {2: respun_after}
+    assert removed == {3: gone}
+
+
+def test_strip_track_blobs_drops_blobs_and_dbid_keeps_everything_else():
+    """the track-update wire shape: no METADATABLOBLIST keys, no dbid, rest intact"""
+    metadata = dict.fromkeys(nowplaying.db.METADATABLOBLIST, b"binary data")
+    metadata["dbid"] = 42
+    metadata["coverurl"] = "cover/some-cachekey"
+    metadata["artist"] = "WNP Mock Artist"
+    metadata["title"] = "WNP Mock Song"
+
+    stripped = Handler._strip_track_blobs(metadata)  # pylint: disable=protected-access
+
+    for key in nowplaying.db.METADATABLOBLIST:
+        assert key not in stripped
+    assert "dbid" not in stripped
+    assert stripped["coverurl"] == "cover/some-cachekey"
+    assert stripped["artist"] == "WNP Mock Artist"
+    assert stripped["title"] == "WNP Mock Song"
+
+
+def _request_with_header(value):
+    request = MagicMock()
+    request.headers = {"X-WNP-Client-Session": value} if value is not None else {}
+    return request
+
+
+def test_session_id_accepts_well_formed_header():
+    """a caller-supplied X-WNP-Client-Session is used verbatim when it's safe"""
+    request = _request_with_header("my-id_123")
+    assert Handler._session_id(request) == "my-id_123"  # pylint: disable=protected-access
+
+
+def test_session_id_mints_when_header_absent():
+    """no header at all -- fall back to a minted id, matching str(uuid.uuid4())[:8]"""
+    request = _request_with_header(None)
+    session_id = Handler._session_id(request)  # pylint: disable=protected-access
+    assert len(session_id) == 8
+
+
+def test_session_id_mints_when_header_empty():
+    """an empty header is treated the same as an absent one"""
+    request = _request_with_header("")
+    session_id = Handler._session_id(request)  # pylint: disable=protected-access
+    assert len(session_id) == 8
+
+
+def test_session_id_rejects_newline_rather_than_logging_it_verbatim():
+    """log-injection guard: a header can't smuggle a fake log line through"""
+    request = _request_with_header("legit\nWARNING fake log line")
+    session_id = Handler._session_id(request)  # pylint: disable=protected-access
+    assert "\n" not in session_id
+    assert len(session_id) == 8
+
+
+def test_session_id_rejects_oversized_value():
+    """the allow-list caps length at 64 chars"""
+    request = _request_with_header("x" * 65)
+    session_id = Handler._session_id(request)  # pylint: disable=protected-access
+    assert len(session_id) == 8


### PR DESCRIPTION
Replaces the Lumia plugin's 10-second polling of GET /v1/requests with a one-way WebSocket stream: the server pushes typed frames, clients never send commands over it. Mutations stay on POST/DELETE /v1/requests, which already give a real synchronous response -- same split as Twitch's own EventSub-over-WebSocket (subscribe/act via REST, EventSub itself push-only).

Frames:
* connected / snapshot-complete / connection-closing -- signals
* track-update -- now-playing changes (blob fields stripped)
* request-added / request-updated / request-removed -- queue deltas, diffed against the last-known row set once per second. request-updated covers in-place mutations (respin being the one live example) so a consumer never sees a transient empty slot for a row that never left the queue.

Design notes:
* Session id is minted server-side (str(uuid.uuid4())[:8]) and handed back as the first frame, with an optional X-WNP-Client-Session header override (sanitized against an allow-list) for callers that want to correlate their own logs against WNP's.
* Auth checks the header first, falling back to ?secret= -- the browser WebSocket() constructor has no way to set custom headers at all, so a header-only check would lock out any browser-rendered consumer.
* Each connection gets its own asyncio.Queue, joined before its snapshot is captured rather than after, so a broadcast landing mid-snapshot is queued instead of silently dropped. A single per-connection writer task drains it and is the only coroutine that ever touches that connection's socket; _broadcast only ever enqueues. Both the writer and the paired reader task (which just watches for CLOSE/ERROR) are cancelled and awaited from a finally block, so cleanup runs on every exit path including the handler's own coroutine being cancelled during runner.cleanup(), not just the happy path.
* RequestsHandler grew an app-keyed get_requests() so the background broadcast task can reuse the same cached Requests() instance that request handlers use, plus a shared serialize_request_row() so both GET /v1/requests and this stream produce identical row shapes.

Full unit coverage for the pure-function pieces (diffing, blob-stripping, session-id sanitization) plus integration tests against a real subprocess webserver: connect/snapshot ordering, live track and request broadcasts, respin producing request-updated rather than a remove/add pair, and auth across both the header and query-param paths.

## Summary by Sourcery

Introduce a publish-only /v1/events WebSocket that streams now-playing and request-queue changes, backed by a DB watcher–driven broadcast task and shared serialization with the existing requests API.

New Features:
- Add /v1/events WebSocket endpoint that sends a session-id frame on connect, an initial snapshot, and subsequent track and request queue update events.
- Support client-provided session identifiers via X-WNP-Client-Session, with safe validation and logging correlation.
- Provide unified serialization for request queue rows so GET /v1/requests and /v1/events expose the same wire format.

Enhancements:
- Reuse a single cached Requests instance across both HTTP handlers and the events broadcaster, and add a DB watcher for the requests database for efficient change detection.

Tests:
- Add unit tests for events WebSocket pure functions including request diffing, blob stripping, and session-id sanitization.
- Add integration tests covering events stream connection behavior, snapshot ordering, live track and request broadcasts, respin handling, authentication via header and query parameter, and ignoring client messages.