### PR TITLE
ci: capture per-test timings and raise the job timeout

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   testing-macos:
     runs-on: macos-latest
-    timeout-minutes: 50
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -78,7 +78,7 @@ jobs:
             popd
           fi
           source /tmp/venv/bin/activate
-          pytest --durations=10 -s tests
+          pytest --durations=0 --junit-xml=junit-macos.xml -s tests
           ls -al .coverage*
           coverage xml
       - name: artifact mac test
@@ -92,12 +92,13 @@ jobs:
             .coverage.*
             .coverage*
             coverage.xml
+            junit-macos.xml
       #       htmlcov
 
 
   testing-win:
     runs-on: windows-2025
-    timeout-minutes: 50
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
@@ -151,7 +152,7 @@ jobs:
             export FPCALC
             popd
           fi
-          pytest --durations=10 -s tests
+          pytest --durations=0 --junit-xml=junit-windows.xml -s tests
           coverage xml
       - name: artifact windows test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -164,10 +165,11 @@ jobs:
             .coverage.*
             htmlcov
             coverage.xml
+            junit-windows.xml
 
   testing-linux:
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:
@@ -255,7 +257,7 @@ jobs:
             popd
           fi
           source /tmp/venv/bin/activate
-          pytest --durations=10 -s
+          pytest --durations=0 --junit-xml=junit-linux-${{ matrix.python }}.xml -s
           coverage xml
       - name: artifact linux test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -268,6 +270,7 @@ jobs:
             .coverage.*
             htmlcov
             coverage.xml
+            junit-linux-${{ matrix.python }}.xml
 
   merge:
     if: always()

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -328,6 +328,7 @@ jobs:
         if: always()
         with:
           name: full-coverage
+          include-hidden-files: true
           path: |
             .coverage
             htmlcov

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -78,7 +78,7 @@ jobs:
             popd
           fi
           source /tmp/venv/bin/activate
-          pytest --durations=0 --junit-xml=junit-macos.xml -s tests
+          pytest --durations=40 --junit-xml=junit-macos.xml -s tests
           ls -al .coverage*
           coverage xml
       - name: artifact mac test
@@ -152,7 +152,7 @@ jobs:
             export FPCALC
             popd
           fi
-          pytest --durations=0 --junit-xml=junit-windows.xml -s tests
+          pytest --durations=40 --junit-xml=junit-windows.xml -s tests
           coverage xml
       - name: artifact windows test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -257,7 +257,7 @@ jobs:
             popd
           fi
           source /tmp/venv/bin/activate
-          pytest --durations=0 --junit-xml=junit-linux-${{ matrix.python }}.xml -s
+          pytest --durations=40 --junit-xml=junit-linux-${{ matrix.python }}.xml -s
           coverage xml
       - name: artifact linux test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7


### PR DESCRIPTION
Three related changes to make test cost visible and stop the wall clock from destroying the evidence.

--junit-xml records a time per test in a machine-readable file, one per job, added to the existing artifact uploads.  Those already carry if: always(), so a failing run still yields its numbers -- the case most worth having.  It is pytest core, so no new dependency.  Until now --durations=10 showed only the ten slowest in the log, and working out where time actually went meant reconstructing it from log timestamps, which resolves no finer than per-file.

--durations=0 complements that rather than duplicating it: JUnit reports one total per test, so a test whose cost is almost entirely autouse fixture setup looks the same as one doing real work.  The split is what distinguishes them; on fast files that setup measured ~80% of runtime with the bodies near zero.  Costs about 2.2 lines per test, phases under 5ms being hidden.  pyproject stays at --durations=10 so local runs remain readable.

The timeout goes to 60 because today's run on main had almost no margin: testing-win used 49.7 of its 50 minutes and testing-macos 48.1.  Windows passed, so the wall never got blamed, but it was 20 seconds from cancellation -- and since actions/cache is post-if: success(), a cancelled job skips the cache save and leaves the next run cold, slow enough to hit the wall again.  Linux is at 33.6, so this is headroom for the two slow platforms, not a general loosening.

## Summary by Sourcery

Improve CI test observability and reliability by publishing detailed timing reports and extending platform job timeouts.

New Features:
- Capture per-test timing data in JUnit XML files and publish it with each platform's test artifacts.

Enhancements:
- Increase test duration reporting to include the slowest 40 tests while retaining readable local pytest defaults.
- Increase CI test job timeouts to provide additional headroom for slower Windows and macOS runs.

CI:
- Publish JUnit timing artifacts for macOS, Windows, and each Linux Python matrix job.
- Preserve hidden coverage files when downloading the full coverage artifact.