### PR TITLE
Fix artist extras image caps reading a config key nothing sets

### DIFF
--- a/nowplaying/imagecache.py
+++ b/nowplaying/imagecache.py
@@ -330,13 +330,13 @@ class ImageCache:
             return
 
         if "logo" in imagetype:
-            maxart: int = config.cparser.value("identifierextras/logos", defaultValue=3, type=int)
+            maxart: int = config.cparser.value("artistextras/logos", defaultValue=3, type=int)
         elif "banner" in imagetype:
-            maxart = config.cparser.value("identifierextras/banners", defaultValue=3, type=int)
+            maxart = config.cparser.value("artistextras/banners", defaultValue=3, type=int)
         elif "thumb" in imagetype:
-            maxart = config.cparser.value("identifierextras/thumbnails", defaultValue=3, type=int)
+            maxart = config.cparser.value("artistextras/thumbnails", defaultValue=3, type=int)
         else:
-            maxart = config.cparser.value("identifierextras/fanart", defaultValue=20, type=int)
+            maxart = config.cparser.value("artistextras/fanart", defaultValue=20, type=int)
 
         logging.debug(
             "Putting %s unfiltered for %s/%s",


### PR DESCRIPTION
fill_queue() read identifierextras/{logos,banners,thumbnails,fanart} to decide how many images to keep, but nothing has ever written that prefix.  Every read therefore missed and fell back to its hardcoded defaultValue, so the counts in the Artist Extras settings page have been ignored since March 2024.

375f91d4 (#1027) renamed artist -> identifier throughout imagecache.py and the sweep caught these four config-key strings.  config.py still writes artistextras/*, which is what the settings UI reads and writes, so the two ends have disagreed ever since.

Note this changes effective behaviour rather than just wiring: users were silently getting the fallbacks (20 fanart, 3 each of logos/banners/thumbnails) and will now get what they configured -- 10 fanart and 2 of each by default, so fewer images unless they raise it.

No test covered the caps, which is why this went unnoticed for two years.

## Summary by Sourcery

Bug Fixes:
- Fix artist extras image caps to read the configuration values used by the settings UI.