### PR TITLE
Cap image counts in tests, drop the dead Windows CI script

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -122,7 +122,6 @@ jobs:
           python-version: '3.12'
       - name: install dependencies
         run: |
-          python fix_win_ver.py
           python -m pip install --upgrade pip
           pip install -e ".[test,osspecials,dev]"
       - name: special dependencies

--- a/tests/utils_artistextras.py
+++ b/tests/utils_artistextras.py
@@ -13,6 +13,14 @@ import aiosqlite
 import orjson
 import pytest
 
+import nowplaying.datacache.utils
+
+# Per-artist image cap for tests.  The shipped defaults (6 each, 50 fanart) exist
+# for a DJ who wants variety across a set; a test only needs enough to exercise
+# the multi-image paths, and the real numbers queue dozens of pending rows per
+# artist into the datacache that CI carries between runs.
+TEST_IMAGE_CAP = 2
+
 # Shared pytest.mark.skipif decorators for API key requirements
 skip_no_discogs_key = pytest.mark.skipif(
     not os.environ.get("DISCOGS_API_KEY"), reason="Discogs API key not available"
@@ -76,6 +84,9 @@ async def datacache_image_available(client, identifier: str, data_type: str) -> 
 
 def configureplugins(config):
     """Configure plugins for testing"""
+    for imagetype in nowplaying.datacache.utils.CAPPED_IMAGE_TYPES:
+        config.cparser.setValue(f"artistextras/{imagetype}", TEST_IMAGE_CAP)
+
     plugins = ["wikimedia"]
     if os.environ.get("DISCOGS_API_KEY"):
         plugins.append("discogs")


### PR DESCRIPTION
Nothing on the test side set the artistextras counts, so they fell through to the shipped 6/50 and one artist queued twenty-odd fanart URLs. Two is enough -- the helpers assert an image is available, not how many. Set in configureplugins() rather than the bootstrap fixture, which test_shipped_defaults_apply needs untouched.

The Windows job also ran fix_win_ver.py, deleted years ago. PowerShell does not abort a step on a failing native command, so pip install masked it.

## Summary by Sourcery

Keep test image queues small and remove the obsolete Windows CI setup command.

Bug Fixes:
- Limit artistextras image counts in tests to prevent excessive fanart URLs and datacache entries during CI runs.
- Remove the obsolete Windows version-fix script from the Windows test workflow so dependency installation is no longer preceded by a dead command.

CI:
- Simplify the Windows CI dependency-installation step by dropping the deleted fix_win_ver.py invocation.

Tests:
- Configure test artistextras image caps without altering shipped default settings, preserving coverage of multi-image paths.