### PR TITLE
Move the HTTP clients from httpx to httpx2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,35 @@ playing" information from various DJ software.
   in the appropriate `_defaults_*()` method in `nowplaying/config.py`.** Do not
   rely solely on `defaultValue=` at the call site — defaults() is the single
   source of truth for fresh installs and reset-to-defaults.
+- **NEVER touch the user config from `nowplaying/__main__.py`, or from anything that
+  runs before `nowplaying.upgrade.upgrade()` finishes.** `UpgradeConfig.upgrade()` does
+  not go through `ConfigFile` at all. It reads the settings file directly by path
+  (`rawconfig = QSettings(str(sourcepath), self.qsettingsformat)`) and treats those
+  on-disk bytes as the authoritative record of what the user had before this version —
+  `_oldkey_to_newkey(rawconfig, config, mapping)` and every `_upgrade_to_*()` that needs
+  a prior value reads from `rawconfig` and writes through `config`. On macOS that raw
+  read deliberately bypasses the cfprefsd-cached handle. It also decides whether this is
+  a fresh install purely from `if not sourcepath.exists(): return`.
+
+  So one premature write does two kinds of damage: it can create the file and make an
+  existing user look brand new, which silently skips the entire `_upgrade_to_*()` chain,
+  `backup_config()`, and the `NowPlaying` -> `WhatsNowPlaying` key copy; and it can alter
+  the bytes the migration reads as "before", so key renames migrate the wrong values.
+  Both fail without an error. Config writes belong in `nowplaying/config.py` or in the
+  upgrade code — `ConfigFile` is constructed after `upgrade()` has run, which is exactly
+  what makes writing from it safe.
+
+  Reads are not obviously safe either, so do not reach for one as a workaround: the
+  migration's view is the file on disk while a `QSettings` handle goes through the
+  platform preference cache, and those two can disagree. If something genuinely needs
+  state before `upgrade()`, cache it outside the settings entirely —
+  `nowplaying/tlstrust.py` keeps its probe verdict in a JSON file next to the logs for
+  exactly this reason, and validates every field on the way back in because that file
+  is user-visible.
+- **Do not write to `QSettings.SystemScope`.** On macOS it resolves to
+  `/Library/Preferences/...`, where `isWritable()` is `False` and a write returns
+  `Status.AccessError` without creating a file; the value can still read back through
+  the platform preference cache, so a write appears to work when nothing persisted.
 - Plugins are dynamically loaded and follow a common interface pattern
 - The application uses multiprocessing for background tasks
 - Vendor dependencies are managed in `nowplaying/vendor/` to avoid conflicts

--- a/WhatsNowPlaying.spec
+++ b/WhatsNowPlaying.spec
@@ -10,7 +10,7 @@ import os
 import platform
 import sys
 
-from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
 
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -145,6 +145,11 @@ def windows_version_file():
 
 block_cipher = None
 
+# Packages that read their own version out of importlib.metadata at import
+# time, so they die if their .dist-info is stripped below.  httpx2's
+# __version__.py is literally version("httpx2") at module scope.
+KEEP_METADATA = ('httpx2',)
+
 # Versioned contents directory so each build's _internal-X.Y.Z/ is unique.
 # The installer renames the old binary aside and moves the new bundle in;
 # because the new binary looks for a different _internal-{new_ver}/ there is
@@ -172,7 +177,8 @@ for execname, execpy in executables.items():
                        # missing from the frozen app.
                        collect_data_files('wnp_templates') +
                        _nltk_datas('punkt') +
-                       _nltk_datas('punkt_tab'),
+                       _nltk_datas('punkt_tab') +
+                       [d for pkg in KEEP_METADATA for d in copy_metadata(pkg)],
                  hiddenimports=ALL_PLUGIN_MODULES + [
                      # tufup 0.10.0 imports setuptools.config.expand
                      # behind a try/except that hides it from
@@ -193,7 +199,10 @@ for execname, execpy in executables.items():
                  cipher=block_cipher,
                  noarchive=False)
 
-    a.datas = [x for x in a.datas if '.dist-info' not in x[0]]
+    _keep = tuple(f'{pkg}-' for pkg in KEEP_METADATA)
+    a.datas = [
+        x for x in a.datas if '.dist-info' not in x[0] or x[0].startswith(_keep)
+    ]
 
     # Splash screen disabled for folder mode
     # if sys.platform != 'darwin':

--- a/conftest.py
+++ b/conftest.py
@@ -54,7 +54,7 @@ def enforce_single_pytest_instance():
 # don't overwhelm test output.  (bootstrap.setuplogging() does the same for
 # the running app but is not called during tests.)
 logging.getLogger("hpack").setLevel(logging.WARNING)
-logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpx2").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 # DO NOT CHANGE THIS TO BE com.github.whatsnowplaying

--- a/conftest.py
+++ b/conftest.py
@@ -55,7 +55,8 @@ def enforce_single_pytest_instance():
 # the running app but is not called during tests.)
 logging.getLogger("hpack").setLevel(logging.WARNING)
 logging.getLogger("httpx2").setLevel(logging.WARNING)
-logging.getLogger("httpcore").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)  # respx still pulls httpx
+logging.getLogger("httpcore2").setLevel(logging.WARNING)
 
 # DO NOT CHANGE THIS TO BE com.github.whatsnowplaying
 # otherwise your actual bits will disappear!

--- a/docs/features.md
+++ b/docs/features.md
@@ -287,6 +287,9 @@ requires no account to start, and is built into WNP with no configuration needed
 * Export and import configuration as JSON for moving between systems
 * Home directory paths are automatically remapped on import
 * Stale legacy configuration keys are automatically cleaned up on upgrade
+* Falls back to bundled certificate authorities when the computer's own can no
+  longer verify the music services, so older machines keep fetching artwork and
+  biographies instead of silently coming up empty
 
 ## References
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -42,6 +42,20 @@
   Use Light or Dark to override Auto if your OS theme reporting is unreliable
   (e.g. macOS with wallpaper tinting enabled).
 
+* **Certificate Trust** - Controls which certificate authorities are used to
+  verify the sites **What's Now Playing** connects to. A computer that has not
+  been updated in several years may no longer recognise the authorities that
+  MusicBrainz, Discogs, and the other services use, which shows up as missing
+  artwork and biographies rather than as an obvious error.
+
+  * **Automatic** (default) — checks once whether this computer's certificates
+    still work and quietly switches to the bundled set if they do not.
+  * **Operating system** — always use this computer's certificates. Required if
+    your network inspects traffic with a certificate your workplace installed.
+  * **Bundled with What's Now Playing** — always use the bundled certificates.
+
+  Changes take effect the next time **What's Now Playing** starts.
+
 * **Configuration Backup** - Export and import your complete
   configuration to make version upgrades easier.
 

--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -38,6 +38,9 @@ def run_bootstrap(bundledir: str | None = None) -> pathlib.Path:  # pragma: no c
     logpath = nowplaying.bootstrap.setuplogging(rotate=True)
     plat = platform.platform()
     logging.info("starting up v%s on %s", nowplaying.__version__, plat)
+    # upgrade() checks whatsnowplaying.com for a new version, the first TLS this
+    # process makes, so the trust store has to be settled before it.
+    nowplaying.bootstrap.apply_ca_trust()
     nowplaying.upgrade.upgrade(bundledir=bundledir)
     logging.debug("ending upgrade")
 

--- a/nowplaying/artistextras/lastfm.py
+++ b/nowplaying/artistextras/lastfm.py
@@ -12,6 +12,7 @@ import orjson
 import nowplaying.artistextras
 import nowplaying.config
 import nowplaying.datacache
+import nowplaying.tlstrust
 import nowplaying.utils
 from nowplaying.types import TrackMetadata
 
@@ -42,7 +43,10 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
             await dc_client.initialize()
             if dc_client.in_cooldown("lastfm"):
                 return None
-            async with httpx2.AsyncClient(timeout=self.calculate_delay()) as session:
+            async with httpx2.AsyncClient(
+                timeout=self.calculate_delay(),
+                verify=nowplaying.tlstrust.create_ssl_context(),
+            ) as session:
                 response = await session.get(url)
             if response.status_code == 429:
                 try:

--- a/nowplaying/artistextras/lastfm.py
+++ b/nowplaying/artistextras/lastfm.py
@@ -6,7 +6,7 @@ import re
 import urllib.parse
 from typing import TYPE_CHECKING, Any
 
-import httpx
+import httpx2
 import orjson
 
 import nowplaying.artistextras
@@ -42,7 +42,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
             await dc_client.initialize()
             if dc_client.in_cooldown("lastfm"):
                 return None
-            async with httpx.AsyncClient(timeout=self.calculate_delay()) as session:
+            async with httpx2.AsyncClient(timeout=self.calculate_delay()) as session:
                 response = await session.get(url)
             if response.status_code == 429:
                 try:
@@ -63,7 +63,7 @@ class Plugin(nowplaying.artistextras.ArtistExtrasPlugin):
                 logging.debug("Last.fm API error: %s", data.get("message"))
                 return None
             return data
-        except httpx.TimeoutException:
+        except httpx2.TimeoutException:
             logging.error("Last.fm fetch timeout: %s", safe_url)
             return None
         except Exception:  # pragma: no cover pylint: disable=broad-except

--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -10,6 +10,34 @@ import time
 from PySide6.QtCore import QCoreApplication, QStandardPaths  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QErrorMessage  # pylint: disable=no-name-in-module
 
+import nowplaying.tlstrust
+
+
+def catrust_state_path() -> pathlib.Path:
+    """Where the CA trust decision is cached.
+
+    The cache location rather than Documents: this is a probe result, losing it
+    to an OS cache purge just costs one re-probe, and Documents is synced
+    between a user's machines -- a verdict reached on a stale old laptop has no
+    business landing on a healthy desktop.
+    """
+    return (
+        pathlib.Path(QStandardPaths.standardLocations(QStandardPaths.CacheLocation)[0])
+        / nowplaying.tlstrust.STATE_FILE
+    )
+
+
+def apply_ca_trust() -> None:
+    """Point this process at the trust store the last probe settled on.
+
+    upgrade() checks whatsnowplaying.com for a new version, which is the first
+    TLS this process makes.  That happens before ConfigFile exists and before
+    UpgradeConfig has run, and nothing may open QSettings that early, so the
+    decision is cached in a plain file instead of a setting.
+    """
+    effective, _, _ = nowplaying.tlstrust.load_state(catrust_state_path())
+    nowplaying.tlstrust.apply_mode(effective)
+
 
 def verify_python_version():
     """make sure the correct version of python is being used"""

--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -124,6 +124,6 @@ def setuplogging(
     logging.captureWarnings(True)
     # These libraries emit very noisy DEBUG-level tracing
     logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("httpcore2").setLevel(logging.WARNING)
     logging.getLogger("hpack").setLevel(logging.WARNING)
     return logpath

--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -95,7 +95,7 @@ def setuplogging(
     )
     logging.captureWarnings(True)
     # These libraries emit very noisy DEBUG-level tracing
-    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpx2").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("hpack").setLevel(logging.WARNING)
     return logpath

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -8,7 +8,6 @@ import logging
 import os
 import pathlib
 import re
-import ssl
 import sys
 import time
 from types import ModuleType
@@ -27,6 +26,7 @@ import nowplaying.inputs
 import nowplaying.notifications
 import nowplaying.pluginimporter
 import nowplaying.recognition
+import nowplaying.tlstrust
 import nowplaying.utils.config_json
 
 # IMPORTANT: Import compatibility shim FIRST to handle old AuthScope enums in Qt config
@@ -69,11 +69,6 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         logging.info("Logpath: %s", self.logpath)
         logging.info("Templates: %s", self.templatedir)
         logging.info("Bundle: %s", ConfigFile.BUNDLEDIR)
-        logging.debug("SSL_CERT_FILE=%s", os.environ.get("SSL_CERT_FILE"))
-        logging.debug("SSL CA FILE=%s", ssl.get_default_verify_paths().cafile)
-        logging.debug(
-            "SSL using system trust store=%s", ssl.SSLContext.__module__ == "truststore._api"
-        )
 
         self.qsettingsformat: QSettings.Format = QSettings.NativeFormat
         if sys.platform == "win32":
@@ -229,6 +224,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         """default values for general settings"""
         settings.setValue("settings/delay", "1.0")
         settings.setValue("settings/initialized", False)
+        settings.setValue(nowplaying.tlstrust.MODE_KEY, nowplaying.tlstrust.MODE_AUTO)
         settings.setValue("settings/loglevel", self.loglevel)
         settings.setValue("settings/notif", self.notif)
         settings.setValue("settings/requests", False)

--- a/nowplaying/datacache/__init__.py
+++ b/nowplaying/datacache/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
-from httpx import Headers as CacheHeaders  # re-exported so callers don't import httpx directly
+from httpx2 import Headers as CacheHeaders  # re-exported so callers don't import httpx2 directly
 
 import orjson
 
@@ -37,7 +37,7 @@ __all__ = [
     "reset_client",  # Reset DataCacheClient singleton (test fixtures)
     "reset_shared_storage",  # Reset singleton after DB move/delete
     "get_shared_storage",  # Access the storage singleton directly
-    "CacheHeaders",  # httpx.Headers re-export — use for get_or_fetch() headers param
+    "CacheHeaders",  # httpx2.Headers re-export — use for get_or_fetch() headers param
 ]
 
 

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -17,10 +17,10 @@ from typing import Any
 
 import ssl
 
-import httpx
+import httpx2
 import orjson
 import truststore
-from httpx import Headers as CacheHeaders
+from httpx2 import Headers as CacheHeaders
 
 import nowplaying.exceptions
 import nowplaying.version  # pylint: disable=no-name-in-module,import-error
@@ -92,7 +92,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
         self.rate_limiters = RateLimiterManager()
         self.bandwidth = BandwidthLimiter()
         self._initialized = False
-        self._session: httpx.AsyncClient | None = None
+        self._session: httpx2.AsyncClient | None = None
         self._init_lock = asyncio.Lock()
         self._retry_after_until: dict[str, float] = {}
         self._callbacks: dict[str, Callable] = {}
@@ -107,7 +107,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
             await self.storage.initialize()
             await self.queue.initialize()
             ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            self._session = httpx.AsyncClient(
+            self._session = httpx2.AsyncClient(
                 http2=True,
                 verify=ssl_ctx,
                 follow_redirects=True,
@@ -254,7 +254,9 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
         """
         self._retry_after_until.pop(provider, None)
 
-    async def _stream_body(self, response: httpx.Response, wait: bool = True) -> tuple[bytes, str]:
+    async def _stream_body(
+        self, response: httpx2.Response, wait: bool = True
+    ) -> tuple[bytes, str]:
         """Stream response body, returning (data, sha256_hex).
 
         Chunks are metered against the bandwidth budget as they arrive.  wait=False
@@ -270,7 +272,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
 
     async def _handle_429(  # pylint: disable=too-many-arguments
         self,
-        response: httpx.Response,
+        response: httpx2.Response,
         provider: str,
         attempt: int,
         retries: int,
@@ -312,7 +314,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
         for attempt in range(retries + 1):
             try:
                 async with self._session.stream(  # type: ignore[union-attr]
-                    "GET", url, timeout=httpx.Timeout(timeout), headers=headers
+                    "GET", url, timeout=httpx2.Timeout(timeout), headers=headers
                 ) as response:
                     if response.status_code == 200:
                         data, checksum = await self._stream_body(response, wait=throttle)
@@ -335,7 +337,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
                         "HTTP %d fetching %s", response.status_code, self._redact_url(url)
                     )
                     last_result = FetchResult(status=response.status_code, terminal=False)
-            except httpx.TimeoutException:
+            except httpx2.TimeoutException:
                 logging.warning(
                     "Timeout fetching URL (attempt %d/%d): %s",
                     attempt + 1,
@@ -590,10 +592,10 @@ def reset_client() -> None:
     """Reset the global client singleton.
 
     Forces the next get_client() call to create a fresh DataCacheClient,
-    binding its httpx session to the current event loop.  Call this from
+    binding its httpx2 session to the current event loop.  Call this from
     test fixtures after the event loop or database path may have changed.
 
-    Nulls out the httpx session before dropping the instance so that
+    Nulls out the httpx2 session before dropping the instance so that
     Windows's ProactorEventLoop does not emit ResourceWarning about
     unclosed transports — the connections are abandoned rather than
     cleanly closed, which is acceptable in test fixtures that run

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -15,14 +15,12 @@ from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
 
-import ssl
-
 import httpx2
 import orjson
-import truststore
 from httpx2 import Headers as CacheHeaders
 
 import nowplaying.exceptions
+import nowplaying.tlstrust
 import nowplaying.version  # pylint: disable=no-name-in-module,import-error
 
 from .pending import RequestQueue
@@ -106,7 +104,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
                 return
             await self.storage.initialize()
             await self.queue.initialize()
-            ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx = nowplaying.tlstrust.create_ssl_context()
             self._session = httpx2.AsyncClient(
                 http2=True,
                 verify=ssl_ctx,

--- a/nowplaying/discogsclient.py
+++ b/nowplaying/discogsclient.py
@@ -9,11 +9,11 @@ with just the functionality needed by the nowplaying application.
 
 import contextlib
 import logging
-import ssl
 from typing import Any
 
 import aiohttp
 
+import nowplaying.tlstrust
 import nowplaying.utils
 
 
@@ -132,8 +132,7 @@ class AsyncDiscogsClient:
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.session: aiohttp.ClientSession | None = None
 
-        # Create SSL context with proper certificate verification
-        self.ssl_context = ssl.create_default_context()
+        self.ssl_context = nowplaying.tlstrust.create_ssl_context()
 
     async def __aenter__(self):
         headers = {"User-Agent": self.user_agent}

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -22,6 +22,7 @@ from wnpmb.normalization import normalize
 import nowplaying.bootstrap
 import nowplaying.datacache
 import nowplaying.config
+import nowplaying.tlstrust
 import nowplaying.utils.metadata
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,7 @@ class MusicBrainzHelper:
         self.mb_client = MusicBrainzClient(
             timeout=5.0,
             retry_settings=RetrySettings(max_retries=2, wait=0.5, timeout_retries=1),
+            ca_bundle=nowplaying.tlstrust.ca_bundle(),
         )
 
     async def _mb_op_with_retry(self, operation, error_msg: str, default: Any) -> Any:

--- a/nowplaying/processes/template_sync.py
+++ b/nowplaying/processes/template_sync.py
@@ -23,14 +23,13 @@ import hashlib
 import json
 import logging
 import pathlib
-import ssl
 from typing import TYPE_CHECKING
 
 import httpx2
-import truststore
 import wnp_templates._version
 
 import nowplaying.datacache
+import nowplaying.tlstrust
 import nowplaying.upgrades
 import nowplaying.template_colors
 import nowplaying.utils.charts_api
@@ -147,7 +146,7 @@ async def sync_from_charts(  # pylint: disable=too-many-locals
 
 
 async def _fetch_manifest(url: str, api_key: str) -> dict | None:
-    ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ssl_ctx = nowplaying.tlstrust.create_ssl_context()
     try:
         async with httpx2.AsyncClient(verify=ssl_ctx, follow_redirects=True) as session:
             headers = {"X-WNP-Charts-Key": api_key} if api_key else None
@@ -254,7 +253,7 @@ async def sync_base_templates(config: "nowplaying.config.ConfigFile") -> None:
 
     allow_downloads = _server_is_newer(manifest_data.get("wnp_templates_version", ""))
 
-    ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ssl_ctx = nowplaying.tlstrust.create_ssl_context()
     async with httpx2.AsyncClient(
         verify=ssl_ctx, follow_redirects=True, timeout=httpx2.Timeout(_DOWNLOAD_TIMEOUT)
     ) as client:

--- a/nowplaying/processes/template_sync.py
+++ b/nowplaying/processes/template_sync.py
@@ -26,7 +26,7 @@ import pathlib
 import ssl
 from typing import TYPE_CHECKING
 
-import httpx
+import httpx2
 import truststore
 import wnp_templates._version
 
@@ -149,12 +149,12 @@ async def sync_from_charts(  # pylint: disable=too-many-locals
 async def _fetch_manifest(url: str, api_key: str) -> dict | None:
     ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     try:
-        async with httpx.AsyncClient(verify=ssl_ctx, follow_redirects=True) as session:
+        async with httpx2.AsyncClient(verify=ssl_ctx, follow_redirects=True) as session:
             headers = {"X-WNP-Charts-Key": api_key} if api_key else None
             resp = await session.get(
                 url,
                 headers=headers,
-                timeout=httpx.Timeout(_SYNC_TIMEOUT),
+                timeout=httpx2.Timeout(_SYNC_TIMEOUT),
             )
             if resp.status_code == 401:
                 logging.warning("Template sync: API key rejected by charts server")
@@ -165,7 +165,7 @@ async def _fetch_manifest(url: str, api_key: str) -> dict | None:
                 )
                 return None
             return resp.json()
-    except httpx.HTTPError:
+    except httpx2.HTTPError:
         logging.warning("Template sync: could not reach charts server", exc_info=True)
         return None
     except Exception:  # pylint: disable=broad-exception-caught
@@ -255,8 +255,8 @@ async def sync_base_templates(config: "nowplaying.config.ConfigFile") -> None:
     allow_downloads = _server_is_newer(manifest_data.get("wnp_templates_version", ""))
 
     ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    async with httpx.AsyncClient(
-        verify=ssl_ctx, follow_redirects=True, timeout=httpx.Timeout(_DOWNLOAD_TIMEOUT)
+    async with httpx2.AsyncClient(
+        verify=ssl_ctx, follow_redirects=True, timeout=httpx2.Timeout(_DOWNLOAD_TIMEOUT)
     ) as client:
         await _sync_base_htms(
             config,
@@ -318,7 +318,7 @@ def _sha256(path: pathlib.Path) -> str:
 
 async def _sync_base_htms(  # pylint: disable=too-many-branches,too-many-locals
     config: "nowplaying.config.ConfigFile",
-    client: httpx.AsyncClient,
+    client: httpx2.AsyncClient,
     templates: dict[str, dict],
     synced_dir: pathlib.Path,
     allow_downloads: bool = True,

--- a/nowplaying/resources/ui/general.ui
+++ b/nowplaying/resources/ui/general.ui
@@ -170,6 +170,69 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="catrust_label">
+     <property name="text">
+      <string>**Certificate Trust**</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::MarkdownText</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="catrust_layout">
+     <item>
+      <widget class="QLabel" name="catrust_combo_label">
+       <property name="text">
+        <string>Certificate authorities</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="catrust_combobox">
+       <item>
+        <property name="text">
+         <string>Automatic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Operating system</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Bundled with What's Now Playing</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="catrust_help_label">
+     <property name="text">
+      <string>Automatic switches to the bundled certificates when this computer's own are too old to verify the sites What's Now Playing connects to. Takes effect after a restart.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer>
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -42,6 +42,7 @@ import nowplaying.hostmeta
 import nowplaying.musicbrainz.plugin
 import nowplaying.settings.categories
 import nowplaying.settings.tabs
+import nowplaying.tlstrust
 import nowplaying.utils.qt
 from nowplaying.exceptions import PluginVerifyError
 
@@ -506,6 +507,14 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         tray_idx = TRAY_ICON_THEMES.index(tray_theme) if tray_theme in TRAY_ICON_THEMES else 0
         self.widgets["general"].tray_icon_combobox.setCurrentIndex(tray_idx)
 
+        catrust = self.config.cparser.value(
+            nowplaying.tlstrust.MODE_KEY, defaultValue=nowplaying.tlstrust.MODE_AUTO
+        )
+        catrust_idx = (
+            nowplaying.tlstrust.MODES.index(catrust) if catrust in nowplaying.tlstrust.MODES else 0
+        )
+        self.widgets["general"].catrust_combobox.setCurrentIndex(catrust_idx)
+
     def _upd_win_updates(self):
         """update the updates & backup settings page to match config"""
         self.widgets["updates"].prerelease_checkbox.setChecked(
@@ -758,6 +767,11 @@ class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods, too-many-
         )
         tray_theme = TRAY_ICON_THEMES[self.widgets["general"].tray_icon_combobox.currentIndex()]
         self.config.cparser.setValue("tray/icontheme", tray_theme)
+
+        catrust = nowplaying.tlstrust.MODES[
+            self.widgets["general"].catrust_combobox.currentIndex()
+        ]
+        self.config.cparser.setValue(nowplaying.tlstrust.MODE_KEY, catrust)
 
     def _upd_conf_updates(self):
         """save the updates & backup settings page to config

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -4,6 +4,7 @@
 import logging
 import socket
 import sqlite3
+import time
 
 from PySide6.QtCore import (  # pylint: disable=no-name-in-module
     QFileSystemWatcher,
@@ -28,6 +29,7 @@ import nowplaying.upgrades
 import nowplaying.upgrades.background
 import nowplaying.obs.exportdialog
 import nowplaying.version  # pylint: disable=no-name-in-module,import-error
+import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.datacache
 import nowplaying.db
@@ -37,6 +39,7 @@ import nowplaying.notifications.charts
 import nowplaying.oauth2
 import nowplaying.settingsui
 import nowplaying.subprocesses
+import nowplaying.tlstrust
 import nowplaying.trackrequests
 import nowplaying.twitch.chat
 import nowplaying.utils.charts_api
@@ -121,6 +124,10 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         # System setup
         self._setup_database_and_processes()
 
+        # Settle the trust store before anything opens a TLS connection --
+        # _setup_charts_key() is the first thing that does.
+        self._settle_catrust()
+
         # Charts initialization
         self._setup_charts_key()
 
@@ -140,6 +147,10 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self._update_startup_progress("Loading configuration...")
 
         self.config = config or nowplaying.config.ConfigFile()
+
+        # Started as early as possible so it overlaps the UI and database work
+        # below; _settle_catrust() collects it before the first TLS call.
+        self._catrust_probe = self._start_catrust_probe()
 
         # Clean up any stray temporary OAuth2 credentials from previous sessions
         self._update_startup_progress("Cleaning OAuth2 credentials...")
@@ -592,6 +603,40 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         PySide6 does not call ~QThread() while the OS thread is still running.
         """
         self._wait_for_vacuum_thread()
+
+    def _catrust_mode(self) -> str:
+        """The user's configured preference; the only part that is a setting."""
+        return str(
+            self.config.cparser.value(
+                nowplaying.tlstrust.MODE_KEY, defaultValue=nowplaying.tlstrust.MODE_AUTO
+            )
+        )
+
+    def _start_catrust_probe(self) -> "nowplaying.tlstrust.TrustProbe | None":
+        """Begin a trust-store probe if the cached verdict is missing or stale."""
+        _, verdict, checked = nowplaying.tlstrust.load_state(
+            nowplaying.bootstrap.catrust_state_path()
+        )
+        if not nowplaying.tlstrust.needs_probe(self._catrust_mode(), verdict, checked):
+            return None
+        return nowplaying.tlstrust.TrustProbe().start()
+
+    def _settle_catrust(self) -> None:
+        """Apply the trust decision and cache it for the next launch.
+
+        Runs every startup, not only when a probe was warranted, so that a
+        change to the setting reaches the cache the next launch reads before
+        upgrade() -- the setting itself cannot be consulted that early.
+        """
+        path = nowplaying.bootstrap.catrust_state_path()
+        _, verdict, checked = nowplaying.tlstrust.load_state(path)
+        if self._catrust_probe:
+            if fresh := self._catrust_probe.result(nowplaying.tlstrust.PROBE_JOIN_TIMEOUT):
+                verdict, checked = fresh, int(time.time())
+            self._catrust_probe = None
+        effective = nowplaying.tlstrust.resolve(self._catrust_mode(), verdict)
+        nowplaying.tlstrust.apply_mode(effective)
+        nowplaying.tlstrust.save_state(path, effective, verdict, checked)
 
     def _setup_charts_key(self) -> None:
         """Generate anonymous charts key if none exists, or ping version if key already present"""

--- a/nowplaying/tlstrust.py
+++ b/nowplaying/tlstrust.py
@@ -80,14 +80,25 @@ RECHECK_SECONDS = 7 * 24 * 3600
 _effective_mode: str | None = None  # pylint: disable=invalid-name
 
 
+def _floor_tls(context: ssl.SSLContext) -> ssl.SSLContext:
+    """Pin the protocol floor rather than inheriting whatever OpenSSL defaults to.
+
+    Current builds already land on TLS 1.2, but that is a property of how
+    OpenSSL was configured, not a guarantee we make.  Every context WNP uses
+    comes from here, so this is the one place to state it.
+    """
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
+
+
 def _certifi_context() -> ssl.SSLContext:
     """context pinned to the Mozilla roots shipped with certifi"""
-    return ssl.create_default_context(cafile=certifi.where())
+    return _floor_tls(ssl.create_default_context(cafile=certifi.where()))
 
 
 def _system_context() -> ssl.SSLContext:
     """context that defers to the OS trust store"""
-    return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    return _floor_tls(truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
 
 
 def _handshake(context: ssl.SSLContext, host: str, port: int = 443) -> bool | None:

--- a/nowplaying/tlstrust.py
+++ b/nowplaying/tlstrust.py
@@ -107,9 +107,11 @@ def _handshake(context: ssl.SSLContext, host: str, port: int = 443) -> bool | No
 def probe() -> str | None:
     """Decide which trust store to use, or None if nothing could be reached.
 
-    Every host gets asked, not just the first one that answers: a stale store
-    typically still has the older roots, so one success proves nothing about
-    the rest.  One host failing the stale-root test is enough to switch.
+    A success proves nothing, so keep going: a stale store typically still has
+    the older roots, and one host verifying says nothing about the rest.  A
+    confirmed failure does prove something, so stop there -- one host the OS
+    store rejects and certifi accepts is the whole diagnosis, and asking the
+    remaining hosts cannot change it.
 
     A rejection only counts once certifi has verified the same host: both
     stores failing means something else is wrong (captive portal, MITM proxy,
@@ -134,11 +136,32 @@ def probe() -> str | None:
     return MODE_SYSTEM if verified_any else None
 
 
+def _release_bundle_env() -> None:
+    """Drop bundle variables that point at our own certifi copy.
+
+    frozen.py sets SSL_CERT_FILE to the bundled cacert.pem before we get a say,
+    so choosing the OS store has to undo that or every default HTTP client
+    keeps verifying against certifi.  That matters most to the one user who
+    picks this deliberately: a workplace whose inspecting root is in the system
+    store and not in certifi.
+
+    Only our own path is removed.  An operator who exported a bundle of their
+    own still outranks us, in both directions.
+    """
+    ours = pathlib.Path(certifi.where())
+    os.environ.pop(BUNDLE_ENV, None)
+    for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        value = os.environ.get(name)
+        if value and pathlib.Path(value) == ours:
+            del os.environ[name]
+
+
 def apply_mode(mode: str) -> str:
     """Point this process at the chosen trust store and remember the choice."""
     global _effective_mode  # pylint: disable=global-statement
     _effective_mode = mode
     if mode != MODE_CERTIFI:
+        _release_bundle_env()
         logging.debug(
             "CA trust: OS trust store; SSL_CERT_FILE=%s, openssl cafile=%s",
             os.environ.get("SSL_CERT_FILE"),
@@ -206,7 +229,7 @@ def needs_probe(mode: str, cached_verdict: str, checked: int) -> bool:
 def load_state(path: "pathlib.Path") -> tuple[str, str, int]:
     """Return (effective, verdict, checked) from the cache, with safe defaults.
 
-    This file lives in the user's Documents tree, so treat it as untrusted:
+    This file lives under Qt's cache location, so treat it as untrusted:
     every field is validated against values we already defined, and nothing in
     it can name a path or a bundle -- the worst a hostile edit can do is pick
     between the OS trust store and our own certifi copy.  Anything unreadable,

--- a/nowplaying/tlstrust.py
+++ b/nowplaying/tlstrust.py
@@ -26,6 +26,7 @@ inside a live process would mean chasing every session and context already
 built from it.
 """
 
+import json
 import logging
 import os
 import pathlib
@@ -35,7 +36,6 @@ import threading
 import time
 
 import certifi
-import orjson
 import truststore
 
 MODE_AUTO = "auto"
@@ -240,7 +240,7 @@ def load_state(path: "pathlib.Path") -> tuple[str, str, int]:
         if path.stat().st_size > _MAX_STATE_BYTES:
             logging.warning("CA trust cache at %s is implausibly large; ignoring it", path)
             return MODE_SYSTEM, "", 0
-        raw = orjson.loads(path.read_bytes())
+        raw = json.loads(path.read_bytes())
     except (OSError, ValueError):
         return MODE_SYSTEM, "", 0
 
@@ -264,8 +264,9 @@ def save_state(path: "pathlib.Path", effective: str, verdict: str, checked: int)
     """Record the resolved mode and the probe result for the next launch."""
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(
-            orjson.dumps({"effective": effective, "verdict": verdict, "checked": checked})
+        path.write_text(
+            json.dumps({"effective": effective, "verdict": verdict, "checked": checked}),
+            encoding="utf-8",
         )
     except OSError:
         logging.exception("Could not write the CA trust cache to %s", path)

--- a/nowplaying/tlstrust.py
+++ b/nowplaying/tlstrust.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""pick a TLS trust store, falling back to certifi when the OS store is stale
+
+A machine that has not taken an OS update in years carries a root store that
+predates the CAs MusicBrainz, Discogs, and the rest chain to today.  Every
+handshake fails with CERTIFICATE_VERIFY_FAILED and the DJ just sees empty
+metadata with nothing obviously wrong.  Probe once in the background; if the
+bundled Mozilla roots validate a host the system store rejects, move the whole
+app onto certifi.
+
+Three kinds of consumer have to agree on the answer:
+
+* code that builds its own context -- ``create_ssl_context()``
+* wnpmb, which takes a path -- ``ca_bundle()``
+* everything reached only through library defaults (twitchAPI, discord.py,
+  tufup, bare ``aiohttp.ClientSession()``) -- the environment variables set by
+  ``apply_mode()``
+
+This module only answers "are the certs bad?" -- it never touches config.
+The caller reads the settings, decides whether a probe is warranted, and owns
+writing any verdict back, because config must not be written before
+nowplaying.upgrade.upgrade() has run.
+
+Mode changes take effect on the next launch.  Un-doing an applied fallback
+inside a live process would mean chasing every session and context already
+built from it.
+"""
+
+import logging
+import os
+import pathlib
+import socket
+import ssl
+import threading
+import time
+
+import certifi
+import orjson
+import truststore
+
+MODE_AUTO = "auto"
+MODE_SYSTEM = "system"
+MODE_CERTIFI = "certifi"
+MODES = (MODE_AUTO, MODE_SYSTEM, MODE_CERTIFI)
+# What a probe can conclude and what can actually be applied; "auto" is a
+# question, not an answer.
+APPLIED_MODES = (MODE_SYSTEM, MODE_CERTIFI)
+
+# The user's preference is a setting.  The probe result is not -- it is a cache,
+# and it lives in a plain file so startup can read it before upgrade() runs,
+# when opening QSettings at all is off limits.
+MODE_KEY = "settings/catrust"
+STATE_FILE = "catrust.json"
+_MAX_STATE_BYTES = 4096
+
+# Set to the bundle path while the fallback is live.  Spawned subprocesses
+# inherit it, which is both how they learn the verdict and how wnppyi.py knows
+# to leave the system store alone instead of re-injecting truststore.
+BUNDLE_ENV = "WNP_CA_BUNDLE"
+
+# One host per distinct root we depend on, newest root first.  A stale store is
+# rarely empty -- it is missing the *recent* roots, so probing only an old root
+# like DigiCert G2 would pass while every Let's Encrypt-backed image fails.
+#   coverartarchive.org   ISRG Root X2 (2020)  -- also fanart.tv and wikimedia
+#   ws.audioscrobbler.com Sectigo R46  (2021)
+#   api.discogs.com       GTS Root R4  (2016)  -- also theaudiodb
+#   musicbrainz.org       DigiCert G2  (2013)  -- the baseline everyone has
+PROBE_HOSTS = (
+    "coverartarchive.org",
+    "ws.audioscrobbler.com",
+    "api.discogs.com",
+    "musicbrainz.org",
+)
+PROBE_TIMEOUT = 3.0
+# Startup waits at most this long for a verdict.  An offline machine would
+# otherwise pay PROBE_TIMEOUT per host before the tray could continue.
+PROBE_JOIN_TIMEOUT = 5.0
+RECHECK_SECONDS = 7 * 24 * 3600
+
+_effective_mode: str | None = None  # pylint: disable=invalid-name
+
+
+def _certifi_context() -> ssl.SSLContext:
+    """context pinned to the Mozilla roots shipped with certifi"""
+    return ssl.create_default_context(cafile=certifi.where())
+
+
+def _system_context() -> ssl.SSLContext:
+    """context that defers to the OS trust store"""
+    return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+
+def _handshake(context: ssl.SSLContext, host: str, port: int = 443) -> bool | None:
+    """True if the chain verified, False if it was rejected, None if unreachable"""
+    try:
+        with (
+            socket.create_connection((host, port), timeout=PROBE_TIMEOUT) as sock,
+            context.wrap_socket(sock, server_hostname=host),
+        ):
+            return True
+    except ssl.SSLCertVerificationError:
+        return False
+    except (OSError, ssl.SSLError):
+        return None
+
+
+def probe() -> str | None:
+    """Decide which trust store to use, or None if nothing could be reached.
+
+    Every host gets asked, not just the first one that answers: a stale store
+    typically still has the older roots, so one success proves nothing about
+    the rest.  One host failing the stale-root test is enough to switch.
+
+    A rejection only counts once certifi has verified the same host: both
+    stores failing means something else is wrong (captive portal, MITM proxy,
+    an actually-expired server cert) and swapping roots would not help.
+    """
+    verified_any = False
+    for host in PROBE_HOSTS:
+        result = _handshake(_system_context(), host)
+        if result is None:
+            continue
+        if result is True:
+            verified_any = True
+            continue
+        if _handshake(_certifi_context(), host) is True:
+            logging.warning(
+                "System CA store rejected %s but the bundled roots accepted it; "
+                "the machine's certificates are out of date",
+                host,
+            )
+            return MODE_CERTIFI
+        logging.warning("Neither trust store could verify %s; not a stale-root problem", host)
+    return MODE_SYSTEM if verified_any else None
+
+
+def apply_mode(mode: str) -> str:
+    """Point this process at the chosen trust store and remember the choice."""
+    global _effective_mode  # pylint: disable=global-statement
+    _effective_mode = mode
+    if mode != MODE_CERTIFI:
+        logging.debug(
+            "CA trust: OS trust store; SSL_CERT_FILE=%s, openssl cafile=%s",
+            os.environ.get("SSL_CERT_FILE"),
+            ssl.get_default_verify_paths().cafile,
+        )
+        return mode
+
+    bundle = certifi.where()
+    os.environ[BUNDLE_ENV] = bundle
+    # setdefault, not assignment: an operator who exported their own bundle
+    # (corporate root, test rig) outranks our verdict.
+    os.environ.setdefault("SSL_CERT_FILE", bundle)
+    os.environ.setdefault("REQUESTS_CA_BUNDLE", bundle)
+    truststore.extract_from_ssl()
+    # SSL_CERT_FILE is named separately because an operator export outranks our
+    # bundle, so the two can legitimately disagree.
+    logging.info(
+        "CA trust: bundled certifi roots (%s); SSL_CERT_FILE=%s",
+        bundle,
+        os.environ.get("SSL_CERT_FILE"),
+    )
+    return mode
+
+
+def effective_mode() -> str:
+    """Trust store in force for this process."""
+    if _effective_mode:
+        return _effective_mode
+    # A process that never applied a mode -- a subprocess mid-startup, a test
+    # importing a client directly -- still honours an inherited verdict.
+    return MODE_CERTIFI if os.environ.get(BUNDLE_ENV) else MODE_SYSTEM
+
+
+def ca_bundle() -> str | None:
+    """Path to force on clients that take one, or None to keep their default."""
+    return certifi.where() if effective_mode() == MODE_CERTIFI else None
+
+
+def create_ssl_context() -> ssl.SSLContext:
+    """The one place WNP builds a client-side TLS context."""
+    if effective_mode() == MODE_CERTIFI:
+        return _certifi_context()
+    return _system_context()
+
+
+def resolve(mode: str, cached_verdict: str) -> str:
+    """Fold the configured mode and any cached verdict into one answer."""
+    if mode not in MODES:
+        logging.warning("Unknown CA trust mode %r; treating as %s", mode, MODE_AUTO)
+        mode = MODE_AUTO
+    if mode != MODE_AUTO:
+        return mode
+    return cached_verdict if cached_verdict in MODES else MODE_SYSTEM
+
+
+def needs_probe(mode: str, cached_verdict: str, checked: int) -> bool:
+    """True when auto mode has no verdict, or one old enough to re-test."""
+    if mode != MODE_AUTO:
+        return False
+    if cached_verdict not in MODES or checked <= 0:
+        return True
+    return time.time() - checked >= RECHECK_SECONDS
+
+
+def load_state(path: "pathlib.Path") -> tuple[str, str, int]:
+    """Return (effective, verdict, checked) from the cache, with safe defaults.
+
+    This file lives in the user's Documents tree, so treat it as untrusted:
+    every field is validated against values we already defined, and nothing in
+    it can name a path or a bundle -- the worst a hostile edit can do is pick
+    between the OS trust store and our own certifi copy.  Anything unreadable,
+    oversized, or unrecognised degrades to the OS trust store, which is what an
+    install with no cache has always done.
+    """
+    try:
+        if path.stat().st_size > _MAX_STATE_BYTES:
+            logging.warning("CA trust cache at %s is implausibly large; ignoring it", path)
+            return MODE_SYSTEM, "", 0
+        raw = orjson.loads(path.read_bytes())
+    except (OSError, ValueError):
+        return MODE_SYSTEM, "", 0
+
+    if not isinstance(raw, dict):
+        return MODE_SYSTEM, "", 0
+    effective = raw.get("effective")
+    verdict = raw.get("verdict")
+    checked = raw.get("checked")
+    # bool is an int; a timestamp from the future means a wrong clock or a hand
+    # edit, and either way the honest move is to probe again.
+    if isinstance(checked, bool) or not isinstance(checked, int) or not 0 < checked <= time.time():
+        checked = 0
+    return (
+        effective if effective in APPLIED_MODES else MODE_SYSTEM,
+        verdict if verdict in APPLIED_MODES else "",
+        checked,
+    )
+
+
+def save_state(path: "pathlib.Path", effective: str, verdict: str, checked: int) -> None:
+    """Record the resolved mode and the probe result for the next launch."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(
+            orjson.dumps({"effective": effective, "verdict": verdict, "checked": checked})
+        )
+    except OSError:
+        logging.exception("Could not write the CA trust cache to %s", path)
+
+
+class TrustProbe:
+    """Runs probe() on a worker so startup can overlap it.
+
+    Deliberately inert: it reports a verdict and nothing else.  The caller
+    joins it before the first TLS of the session and decides what to persist.
+    """
+
+    def __init__(self) -> None:
+        self.verdict: str | None = None
+        self._thread = threading.Thread(target=self._run, name="catrust-probe", daemon=True)
+
+    def start(self) -> "TrustProbe":
+        """Begin probing in the background."""
+        self._thread.start()
+        return self
+
+    def _run(self) -> None:
+        self.verdict = probe()
+
+    def result(self, timeout: float) -> str | None:
+        """Verdict if the probe finished in time, else None.
+
+        A probe that overruns is abandoned rather than waited out -- startup
+        matters more than the answer, and the next launch tries again.
+        """
+        self._thread.join(timeout)
+        if self._thread.is_alive():
+            logging.debug("CA trust probe still running after %ss; carrying on", timeout)
+            return None
+        return self.verdict

--- a/nowplaying/tlstrust.py
+++ b/nowplaying/tlstrust.py
@@ -1,29 +1,16 @@
 #!/usr/bin/env python3
 """pick a TLS trust store, falling back to certifi when the OS store is stale
 
-A machine that has not taken an OS update in years carries a root store that
-predates the CAs MusicBrainz, Discogs, and the rest chain to today.  Every
-handshake fails with CERTIFICATE_VERIFY_FAILED and the DJ just sees empty
-metadata with nothing obviously wrong.  Probe once in the background; if the
-bundled Mozilla roots validate a host the system store rejects, move the whole
-app onto certifi.
+A trust store that cannot verify our hosts shows up as empty artwork and bios,
+not as an error: the artistextras plugins swallow exceptions to keep a set
+running.  So probe for it explicitly.
 
-Three kinds of consumer have to agree on the answer:
+Callers get the answer three ways because three kinds of consumer need it:
+create_ssl_context() for our own clients, ca_bundle() for wnpmb, and the
+environment for libraries we only reach through their defaults.
 
-* code that builds its own context -- ``create_ssl_context()``
-* wnpmb, which takes a path -- ``ca_bundle()``
-* everything reached only through library defaults (twitchAPI, discord.py,
-  tufup, bare ``aiohttp.ClientSession()``) -- the environment variables set by
-  ``apply_mode()``
-
-This module only answers "are the certs bad?" -- it never touches config.
-The caller reads the settings, decides whether a probe is warranted, and owns
-writing any verdict back, because config must not be written before
-nowplaying.upgrade.upgrade() has run.
-
-Mode changes take effect on the next launch.  Un-doing an applied fallback
-inside a live process would mean chasing every session and context already
-built from it.
+Reports only -- never touches config, which is unreadable and unwritable until
+nowplaying.upgrade.upgrade() has run.  Takes effect on the next launch.
 """
 
 import json
@@ -42,13 +29,10 @@ MODE_AUTO = "auto"
 MODE_SYSTEM = "system"
 MODE_CERTIFI = "certifi"
 MODES = (MODE_AUTO, MODE_SYSTEM, MODE_CERTIFI)
-# What a probe can conclude and what can actually be applied; "auto" is a
-# question, not an answer.
-APPLIED_MODES = (MODE_SYSTEM, MODE_CERTIFI)
+VERDICTS = (MODE_SYSTEM, MODE_CERTIFI)
 
-# The user's preference is a setting.  The probe result is not -- it is a cache,
-# and it lives in a plain file so startup can read it before upgrade() runs,
-# when opening QSettings at all is off limits.
+# The preference is a setting; the probe result is a cache, in a plain file
+# because startup needs it before QSettings may be opened at all.
 MODE_KEY = "settings/catrust"
 STATE_FILE = "catrust.json"
 _MAX_STATE_BYTES = 4096
@@ -72,33 +56,25 @@ PROBE_HOSTS = (
     "musicbrainz.org",
 )
 PROBE_TIMEOUT = 3.0
-# Startup waits at most this long for a verdict.  An offline machine would
-# otherwise pay PROBE_TIMEOUT per host before the tray could continue.
+# Cap on the startup wait; offline would otherwise cost PROBE_TIMEOUT per host.
 PROBE_JOIN_TIMEOUT = 5.0
 RECHECK_SECONDS = 7 * 24 * 3600
 
 _effective_mode: str | None = None  # pylint: disable=invalid-name
 
 
-def _floor_tls(context: ssl.SSLContext) -> ssl.SSLContext:
-    """Pin the protocol floor rather than inheriting whatever OpenSSL defaults to.
-
-    Current builds already land on TLS 1.2, but that is a property of how
-    OpenSSL was configured, not a guarantee we make.  Every context WNP uses
-    comes from here, so this is the one place to state it.
-    """
+def _certifi_context() -> ssl.SSLContext:
+    """context pinned to the Mozilla roots shipped with certifi"""
+    context = ssl.create_default_context(cafile=certifi.where())
     context.minimum_version = ssl.TLSVersion.TLSv1_2
     return context
 
 
-def _certifi_context() -> ssl.SSLContext:
-    """context pinned to the Mozilla roots shipped with certifi"""
-    return _floor_tls(ssl.create_default_context(cafile=certifi.where()))
-
-
 def _system_context() -> ssl.SSLContext:
     """context that defers to the OS trust store"""
-    return _floor_tls(truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
+    context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
 
 
 def _handshake(context: ssl.SSLContext, host: str, port: int = 443) -> bool | None:
@@ -118,15 +94,10 @@ def _handshake(context: ssl.SSLContext, host: str, port: int = 443) -> bool | No
 def probe() -> str | None:
     """Decide which trust store to use, or None if nothing could be reached.
 
-    A success proves nothing, so keep going: a stale store typically still has
-    the older roots, and one host verifying says nothing about the rest.  A
-    confirmed failure does prove something, so stop there -- one host the OS
-    store rejects and certifi accepts is the whole diagnosis, and asking the
-    remaining hosts cannot change it.
-
-    A rejection only counts once certifi has verified the same host: both
-    stores failing means something else is wrong (captive portal, MITM proxy,
-    an actually-expired server cert) and swapping roots would not help.
+    A success proves nothing about the other hosts, so keep going; a confirmed
+    failure is the whole diagnosis, so stop.  A rejection only counts once
+    certifi has verified the same host -- both stores failing means a portal, a
+    proxy, or a bad server cert, none of which swapping roots would fix.
     """
     verified_any = False
     for host in PROBE_HOSTS:
@@ -147,32 +118,24 @@ def probe() -> str | None:
     return MODE_SYSTEM if verified_any else None
 
 
-def _release_bundle_env() -> None:
-    """Drop bundle variables that point at our own certifi copy.
-
-    frozen.py sets SSL_CERT_FILE to the bundled cacert.pem before we get a say,
-    so choosing the OS store has to undo that or every default HTTP client
-    keeps verifying against certifi.  That matters most to the one user who
-    picks this deliberately: a workplace whose inspecting root is in the system
-    store and not in certifi.
-
-    Only our own path is removed.  An operator who exported a bundle of their
-    own still outranks us, in both directions.
-    """
-    ours = pathlib.Path(certifi.where())
-    os.environ.pop(BUNDLE_ENV, None)
-    for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
-        value = os.environ.get(name)
-        if value and pathlib.Path(value) == ours:
-            del os.environ[name]
-
-
 def apply_mode(mode: str) -> str:
-    """Point this process at the chosen trust store and remember the choice."""
+    """Point this process at the chosen trust store and remember the choice.
+
+    The environment carries the answer to spawned subprocesses and to libraries
+    we only reach through their defaults.  An operator who exported their own
+    bundle outranks us in both directions, so we only ever set what is unset and
+    only ever remove our own path -- frozen.py plants ours before we get a say,
+    and leaving it would quietly keep certifi in force after a switch away.
+    """
     global _effective_mode  # pylint: disable=global-statement
     _effective_mode = mode
+    bundle = certifi.where()
+
     if mode != MODE_CERTIFI:
-        _release_bundle_env()
+        os.environ.pop(BUNDLE_ENV, None)
+        for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+            if (value := os.environ.get(name)) and pathlib.Path(value) == pathlib.Path(bundle):
+                del os.environ[name]
         logging.debug(
             "CA trust: OS trust store; SSL_CERT_FILE=%s, openssl cafile=%s",
             os.environ.get("SSL_CERT_FILE"),
@@ -180,15 +143,10 @@ def apply_mode(mode: str) -> str:
         )
         return mode
 
-    bundle = certifi.where()
     os.environ[BUNDLE_ENV] = bundle
-    # setdefault, not assignment: an operator who exported their own bundle
-    # (corporate root, test rig) outranks our verdict.
     os.environ.setdefault("SSL_CERT_FILE", bundle)
     os.environ.setdefault("REQUESTS_CA_BUNDLE", bundle)
     truststore.extract_from_ssl()
-    # SSL_CERT_FILE is named separately because an operator export outranks our
-    # bundle, so the two can legitimately disagree.
     logging.info(
         "CA trust: bundled certifi roots (%s); SSL_CERT_FILE=%s",
         bundle,
@@ -197,23 +155,21 @@ def apply_mode(mode: str) -> str:
     return mode
 
 
-def effective_mode() -> str:
-    """Trust store in force for this process."""
+def _current_mode() -> str:
+    """A subprocess that never applied a mode still honours an inherited one."""
     if _effective_mode:
         return _effective_mode
-    # A process that never applied a mode -- a subprocess mid-startup, a test
-    # importing a client directly -- still honours an inherited verdict.
     return MODE_CERTIFI if os.environ.get(BUNDLE_ENV) else MODE_SYSTEM
 
 
 def ca_bundle() -> str | None:
     """Path to force on clients that take one, or None to keep their default."""
-    return certifi.where() if effective_mode() == MODE_CERTIFI else None
+    return certifi.where() if _current_mode() == MODE_CERTIFI else None
 
 
 def create_ssl_context() -> ssl.SSLContext:
     """The one place WNP builds a client-side TLS context."""
-    if effective_mode() == MODE_CERTIFI:
+    if _current_mode() == MODE_CERTIFI:
         return _certifi_context()
     return _system_context()
 
@@ -225,14 +181,14 @@ def resolve(mode: str, cached_verdict: str) -> str:
         mode = MODE_AUTO
     if mode != MODE_AUTO:
         return mode
-    return cached_verdict if cached_verdict in MODES else MODE_SYSTEM
+    return cached_verdict if cached_verdict in VERDICTS else MODE_SYSTEM
 
 
 def needs_probe(mode: str, cached_verdict: str, checked: int) -> bool:
     """True when auto mode has no verdict, or one old enough to re-test."""
     if mode != MODE_AUTO:
         return False
-    if cached_verdict not in MODES or checked <= 0:
+    if cached_verdict not in VERDICTS or checked <= 0:
         return True
     return time.time() - checked >= RECHECK_SECONDS
 
@@ -240,12 +196,9 @@ def needs_probe(mode: str, cached_verdict: str, checked: int) -> bool:
 def load_state(path: "pathlib.Path") -> tuple[str, str, int]:
     """Return (effective, verdict, checked) from the cache, with safe defaults.
 
-    This file lives under Qt's cache location, so treat it as untrusted:
-    every field is validated against values we already defined, and nothing in
-    it can name a path or a bundle -- the worst a hostile edit can do is pick
-    between the OS trust store and our own certifi copy.  Anything unreadable,
-    oversized, or unrecognised degrades to the OS trust store, which is what an
-    install with no cache has always done.
+    Untrusted input: no field can name a path or a bundle, so the worst a hand
+    edit achieves is choosing between the OS store and our own certifi copy.
+    Anything unrecognised degrades to the OS store.
     """
     try:
         if path.stat().st_size > _MAX_STATE_BYTES:
@@ -260,13 +213,12 @@ def load_state(path: "pathlib.Path") -> tuple[str, str, int]:
     effective = raw.get("effective")
     verdict = raw.get("verdict")
     checked = raw.get("checked")
-    # bool is an int; a timestamp from the future means a wrong clock or a hand
-    # edit, and either way the honest move is to probe again.
+    # bool is an int, and a future timestamp means a bad clock or a hand edit
     if isinstance(checked, bool) or not isinstance(checked, int) or not 0 < checked <= time.time():
         checked = 0
     return (
-        effective if effective in APPLIED_MODES else MODE_SYSTEM,
-        verdict if verdict in APPLIED_MODES else "",
+        effective if effective in VERDICTS else MODE_SYSTEM,
+        verdict if verdict in VERDICTS else "",
         checked,
     )
 
@@ -284,11 +236,7 @@ def save_state(path: "pathlib.Path", effective: str, verdict: str, checked: int)
 
 
 class TrustProbe:
-    """Runs probe() on a worker so startup can overlap it.
-
-    Deliberately inert: it reports a verdict and nothing else.  The caller
-    joins it before the first TLS of the session and decides what to persist.
-    """
+    """Runs probe() on a worker so startup can overlap it."""
 
     def __init__(self) -> None:
         self.verdict: str | None = None
@@ -305,8 +253,7 @@ class TrustProbe:
     def result(self, timeout: float) -> str | None:
         """Verdict if the probe finished in time, else None.
 
-        A probe that overruns is abandoned rather than waited out -- startup
-        matters more than the answer, and the next launch tries again.
+        An overrunning probe is abandoned, not waited out; next launch retries.
         """
         self._thread.join(timeout)
         if self._thread.is_alive():

--- a/nowplaying/utils/__init__.py
+++ b/nowplaying/utils/__init__.py
@@ -28,6 +28,8 @@ from wnpmb import (
     unsmartquotes,
 )
 
+import nowplaying.tlstrust
+
 if TYPE_CHECKING:
     import nowplaying.config
     from nowplaying.types import TrackMetadata
@@ -285,7 +287,7 @@ def create_http_connector(
     Create a standardized aiohttp TCPConnector with optimized SSL settings.
 
     Args:
-        ssl_context: Optional SSL context. If None, creates default context.
+        ssl_context: Optional SSL context. If None, uses the app-wide trust store.
         service_type: Type of service ('musicbrainz' for stricter limits, 'default' for others)
 
     Returns:
@@ -293,7 +295,7 @@ def create_http_connector(
     """
 
     if ssl_context is None:
-        ssl_context = ssl.create_default_context()
+        ssl_context = nowplaying.tlstrust.create_ssl_context()
 
     base_config = {
         "ssl": ssl_context,

--- a/nowplaying/wikiclient.py
+++ b/nowplaying/wikiclient.py
@@ -10,7 +10,6 @@ with just the functionality needed by the nowplaying application.
 
 import asyncio
 import logging
-import ssl
 import time
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -20,6 +19,7 @@ from urllib.parse import quote
 import aiohttp
 
 import nowplaying
+import nowplaying.tlstrust
 import nowplaying.utils
 
 
@@ -71,8 +71,7 @@ class AsyncWikiClient:
     def __init__(self, timeout: int = 30):
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.session: aiohttp.ClientSession | None = None
-        # Create SSL context with proper certificate verification
-        self.ssl_context = ssl.create_default_context()
+        self.ssl_context = nowplaying.tlstrust.create_ssl_context()
 
     @classmethod
     def _raise_if_rate_limited(cls) -> None:

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -3,6 +3,7 @@ aiofiles==25.1.0
 aiohttp==3.14.3
 httpx2[http2]==2.12.0
 aiosqlite==0.22.1
+certifi==2026.6.17
 chardet<8 # required by requests
 charset-normalizer==3.4.7
 defusedxml==0.7.1
@@ -35,7 +36,7 @@ tufup==0.10.0
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.3.0/wnpmb-0.3.0-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.4.1/wnpmb-0.4.1-py3-none-any.whl
 wnp-templates @ https://github.com/whatsnowplaying/wnp-templates/releases/download/0.1.4/wnp_templates-0.1.4-py3-none-any.whl
 zeroconf==0.150.0
 

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -1,7 +1,7 @@
 aiocache==0.12.3
 aiofiles==25.1.0
 aiohttp==3.14.3
-httpx[http2]==0.28.1
+httpx2[http2]==2.12.0
 aiosqlite==0.22.1
 chardet<8 # required by requests
 charset-normalizer==3.4.7

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,10 @@
 # tests
 #
 aiointercept==0.1.9
+# pytest-httpx2 is respx plus an httpcore2 mocker; respx alone only
+# intercepts httpcore, so httpx2 clients would sail past the mocks.
 respx==0.23.1
+pytest-httpx2==1.0.0
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0

--- a/tests/datacache/test_client.py
+++ b/tests/datacache/test_client.py
@@ -10,7 +10,8 @@ import unittest.mock
 from pathlib import Path
 
 import aiosqlite
-import httpx
+import httpx  # respx type-checks its canned replies as httpx.Response, even under httpcore2
+import httpx2
 import orjson
 import pytest
 import pytest_asyncio
@@ -186,7 +187,7 @@ async def test_fetch_and_store_json_response(temp_client):  # pylint: disable=re
     """Test fetching and storing JSON response"""
     test_data = {"test": "data", "id": 123}
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get("https://api.example.com/test.json").mock(
             return_value=httpx.Response(
                 200, json=test_data, headers={"content-type": "application/json"}
@@ -218,7 +219,7 @@ async def test_fetch_and_store_binary_response(temp_client):  # pylint: disable=
     """Test fetching and storing binary response"""
     test_data = b"fake_jpeg_data"
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get("https://example.com/image.jpg").mock(
             return_value=httpx.Response(
                 200, content=test_data, headers={"content-type": "image/jpeg"}
@@ -243,7 +244,7 @@ async def test_fetch_and_store_binary_response(temp_client):  # pylint: disable=
 @pytest.mark.asyncio
 async def test_fetch_and_store_http_error(temp_client):  # pylint: disable=redefined-outer-name
     """Test handling HTTP error responses"""
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get("https://example.com/notfound.jpg").mock(
             return_value=httpx.Response(404)
         )
@@ -265,7 +266,7 @@ async def test_fetch_and_store_http_error(temp_client):  # pylint: disable=redef
 @pytest.mark.asyncio
 async def test_fetch_and_store_rate_limit_handling(temp_client):  # pylint: disable=redefined-outer-name
     """Test rate limit response handling"""
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get("https://example.com/ratelimited.jpg").mock(
             return_value=httpx.Response(429, headers={"Retry-After": "1"})
         )
@@ -289,9 +290,9 @@ async def test_fetch_and_store_rate_limit_handling(temp_client):  # pylint: disa
 @pytest.mark.asyncio
 async def test_fetch_and_store_timeout_handling(temp_client):  # pylint: disable=redefined-outer-name
     """Test timeout handling with retries"""
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get("https://example.com/timeout.jpg").mock(
-            side_effect=httpx.ReadTimeout("timed out")
+            side_effect=httpx2.ReadTimeout("timed out")
         )
         result = await temp_client._fetch_and_store(  # pylint: disable=protected-access
             url="https://example.com/timeout.jpg",
@@ -329,7 +330,7 @@ async def test_process_queue_single_request(temp_client):  # pylint: disable=red
         priority=2,
     )
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(url).mock(
             return_value=httpx.Response(
                 200, content=expected_data, headers={"content-type": "image/jpeg"}
@@ -441,7 +442,7 @@ async def test_4xx_not_stored_in_cache(temp_client):  # pylint: disable=redefine
     """404 returns None and nothing is written to the cache"""
     url = "https://example.com/gone.jpg"
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(url).mock(return_value=httpx.Response(404))
 
         result = await temp_client._fetch_and_store(  # pylint: disable=protected-access
@@ -472,7 +473,7 @@ async def test_404_is_not_retried(temp_client):  # pylint: disable=redefined-out
         call_count += 1
         return httpx.Response(404)
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(url).mock(side_effect=_count)
 
         result = await temp_client._fetch_and_store(  # pylint: disable=protected-access
@@ -505,7 +506,7 @@ async def test_5xx_retry_then_success_stores_item(temp_client):  # pylint: disab
             return httpx.Response(503)
         return httpx.Response(200, content=good_data, headers={"content-type": "image/jpeg"})
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(url).mock(side_effect=_seq)
 
         result = await temp_client._fetch_and_store(  # pylint: disable=protected-access
@@ -552,7 +553,7 @@ async def test_process_queue_all_failed_drains_queue(temp_client):  # pylint: di
             priority=2,
         )
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         for url in urls:
             mock_responses.get(url).mock(return_value=httpx.Response(503))
 
@@ -576,7 +577,7 @@ async def test_rate_limiter_integration(temp_client):  # pylint: disable=redefin
     tokens_before = rate_limiter.available_tokens()
     assert tokens_before > 0
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get("https://example.com/ratelimit_test.txt").mock(
             return_value=httpx.Response(
                 200, text="test data", headers={"content-type": "text/plain"}

--- a/tests/datacache/test_integration.py
+++ b/tests/datacache/test_integration.py
@@ -31,7 +31,7 @@ async def test_full_image_caching_workflow(bootstrap, isolated_datacache_client)
     test_image_data = b"fake_image_bytes"
     test_url = "https://example.com/artist_thumb.jpg"
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(test_url).mock(
             return_value=httpx.Response(
                 200, content=test_image_data, headers={"content-type": "image/jpeg"}
@@ -65,7 +65,7 @@ async def test_randomimage_functionality_integration(bootstrap, isolated_datacac
         "https://example.com/thumb3.jpg",
     ]
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         # Mock all image responses
         for i, url in enumerate(image_urls):
             mock_responses.get(url).mock(
@@ -114,7 +114,7 @@ async def test_queue_and_process_workflow(bootstrap, isolated_datacache_client):
     test_url = "https://example.com/queued_image.jpg"
     test_data = b"queued_image_data"
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(test_url).mock(
             return_value=httpx.Response(
                 200, content=test_data, headers={"content-type": "image/jpeg"}
@@ -149,7 +149,7 @@ async def test_cache_hit_avoids_http_request(bootstrap, isolated_datacache_clien
     test_data = b"cached_test_data"
 
     # First request with mock
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(test_url).mock(
             return_value=httpx.Response(
                 200, content=test_data, headers={"content-type": "image/jpeg"}
@@ -192,7 +192,7 @@ async def test_provider_filtering_works(bootstrap, isolated_datacache_client):  
         "discogs": "https://discogs.com/image2.jpg",
     }
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         # Mock responses from different providers
         mock_responses.get(test_urls["theaudiodb"]).mock(
             return_value=httpx.Response(
@@ -256,7 +256,7 @@ async def test_api_response_caching_integration(bootstrap, isolated_datacache_cl
         "genre": "Electronic",
     }
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         mock_responses.get(test_url).mock(
             return_value=httpx.Response(
                 200, json=test_bio_data, headers={"content-type": "application/json"}
@@ -345,7 +345,7 @@ async def test_concurrent_storage_operations(bootstrap, isolated_datacache_clien
         "https://example.com/concurrent3.jpg",
     ]
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         # Mock all responses
         for i, url in enumerate(test_urls):
             mock_responses.get(url).mock(
@@ -398,7 +398,7 @@ async def test_queue_and_process_random_image_bytes(bootstrap, isolated_datacach
         "https://example.com/fanart3.jpg",
     ]
 
-    with respx.mock() as mock_responses:
+    with respx.mock(using="httpcore2") as mock_responses:
         for i, url in enumerate(image_urls):
             mock_responses.get(url).mock(
                 return_value=httpx.Response(

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -64,7 +64,7 @@ async def test_fanarttv_datacache_api_call_count(bootstrap):  # pylint: disable=
         "musicbrainzartistid": [mbid],
     }
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(url).mock(return_value=httpx.Response(200, json=mock_payload))
         await plugin.download_async(metadata.copy())
         first_count = mock_http.calls.call_count
@@ -89,13 +89,13 @@ async def test_fanarttv_datacache_api_failure_behavior(bootstrap):  # pylint: di
     }
 
     # First call: 500 (transient server error) → not cached → returns None
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(url).mock(side_effect=lambda _: httpx.Response(500))
         result1 = await plugin.download_async(metadata.copy())
         assert result1 is None
 
     # Second call: success → should reach API (transient failure was not cached)
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(url).mock(return_value=httpx.Response(200, json={"name": "Test Artist"}))
         result2 = await plugin.download_async(metadata.copy())
         assert mock_http.calls.call_count >= 1, "Transient failure must not have been cached"

--- a/tests/test_artistextras_lastfm.py
+++ b/tests/test_artistextras_lastfm.py
@@ -142,7 +142,7 @@ async def test_lastfm_bio_and_website(bootstrap):
     """successful fetch returns bio and website"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
 
         result = await plugin.download_async(
@@ -160,7 +160,7 @@ async def test_lastfm_bio_stripped(bootstrap):
     """Last.fm attribution is stripped from bio"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -177,7 +177,7 @@ async def test_lastfm_bio_disabled(bootstrap):
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/bio", False)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -194,7 +194,7 @@ async def test_lastfm_websites_disabled(bootstrap):
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/websites", False)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -210,7 +210,7 @@ async def test_lastfm_existing_bio_not_overwritten(bootstrap):
     """does not overwrite existing artistlongbio"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {
@@ -231,7 +231,7 @@ async def test_lastfm_api_error(bootstrap):
     """Last.fm API error response returns None"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(XYZ_URL).mock(
             return_value=httpx.Response(200, json={"error": 6, "message": "Artist not found"})
         )
@@ -247,7 +247,7 @@ async def test_lastfm_http_error(bootstrap):
     """HTTP error returns None without raising"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(side_effect=lambda _r: httpx.Response(503))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -261,7 +261,7 @@ async def test_lastfm_429_sets_cooldown(bootstrap, isolated_datacache_client):  
     """429 response sets provider cooldown; second call skips network"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(
             side_effect=lambda _r: httpx.Response(429, headers={"Retry-After": "60"})
         )
@@ -273,8 +273,10 @@ async def test_lastfm_429_sets_cooldown(bootstrap, isolated_datacache_client):  
     assert isolated_datacache_client.in_cooldown("lastfm")
 
     # Second call during cooldown must not touch the network
-    with respx.mock(assert_all_called=False) as mock_http2:
-        mock_http2.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http2:
+        mock_http2.get(WNP_MOCK_URL).mock(
+            return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE)
+        )
         result2 = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
         )
@@ -287,7 +289,7 @@ async def test_lastfm_429_cooldown_expires_allows_retry(bootstrap, isolated_data
     """After cooldown expires the next call hits the network again"""
     plugin = _setup_plugin(bootstrap)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(
             side_effect=lambda _r: httpx.Response(429, headers={"Retry-After": "60"})
         )
@@ -303,8 +305,10 @@ async def test_lastfm_429_cooldown_expires_allows_retry(bootstrap, isolated_data
     # After clearing, cooldown should be gone
     assert not isolated_datacache_client.in_cooldown("lastfm")
 
-    with respx.mock(assert_all_called=False) as mock_http2:
-        mock_http2.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http2:
+        mock_http2.get(WNP_MOCK_URL).mock(
+            return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE)
+        )
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
         )
@@ -319,7 +323,7 @@ async def test_lastfm_both_disabled_returns_none(bootstrap):
     bootstrap.cparser.setValue("lastfm/bio", False)
     bootstrap.cparser.setValue("lastfm/websites", False)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -353,7 +357,7 @@ async def test_lastfm_lang_returned(bootstrap):
         }
     }
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(de_url).mock(return_value=httpx.Response(200, json=de_response))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -378,7 +382,7 @@ async def test_lastfm_lang_fallback_to_en(bootstrap):
         }
     }
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(ko_url).mock(return_value=httpx.Response(200, json=ko_response))
         mock_http.get(en_url).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
@@ -404,7 +408,7 @@ async def test_lastfm_lang_no_fallback(bootstrap):
         }
     }
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(ko_url).mock(return_value=httpx.Response(200, json=ko_response))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -490,12 +494,14 @@ async def test_lastfm_coverart_queued(bootstrap):  # pylint: disable=redefined-o
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         mock_http.get(WNP_MOCK_ALBUM_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ALBUM_RESPONSE)
         )
-        mock_http.get(COVER_IMAGE_URL).mock(return_value=httpx.Response(200, content=MINIMAL_JPEG))
+        mock_http.get(COVER_IMAGE_URL).mock(
+            return_value=httpx.Response(200, content=MINIMAL_JPEG)
+        )
         result = await plugin.download_async(
             {
                 "artist": "WNP Mock Artist",
@@ -518,7 +524,7 @@ async def test_lastfm_coverart_disabled(bootstrap):  # pylint: disable=redefined
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", False)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {
@@ -542,7 +548,7 @@ async def test_lastfm_coverart_skipped_when_coverimageraw_present(
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {
@@ -565,7 +571,7 @@ async def test_lastfm_coverart_no_album(bootstrap):  # pylint: disable=redefined
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         result = await plugin.download_async(
             {"artist": "WNP Mock Artist", "imagecacheartist": "wnpmockartist"},
@@ -583,7 +589,7 @@ async def test_lastfm_coverart_album_api_error(bootstrap):  # pylint: disable=re
     plugin = _setup_plugin(bootstrap)
     bootstrap.cparser.setValue("lastfm/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         mock_http.get(WNP_MOCK_ALBUM_URL).mock(
             return_value=httpx.Response(200, json={"error": 6, "message": "Album not found"})
@@ -611,12 +617,14 @@ async def test_lastfm_coverart_with_album_mbid(bootstrap):  # pylint: disable=re
     album_mbid = "00000000-0000-0000-0000-000000000002"
     mbid_url = _album_mbid_url(album_mbid)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_URL).mock(return_value=httpx.Response(200, json=WNP_MOCK_RESPONSE))
         mock_http.get(mbid_url).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ALBUM_RESPONSE)
         )
-        mock_http.get(COVER_IMAGE_URL).mock(return_value=httpx.Response(200, content=MINIMAL_JPEG))
+        mock_http.get(COVER_IMAGE_URL).mock(
+            return_value=httpx.Response(200, content=MINIMAL_JPEG)
+        )
         result = await plugin.download_async(
             {
                 "artist": "WNP Mock Artist",

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -262,7 +262,7 @@ async def test_theaudiodb_api_call_count(bootstrap):  # pylint: disable=redefine
     artist_url = f"{TADB_BASE_URL}/artist-mb.php?i={fake_mbid}"
     mock_payload = {"artists": [{"strArtist": "WNP Mock Artist", "idArtist": "999999"}]}
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(artist_url).mock(return_value=httpx.Response(200, json=mock_payload))
 
         await plugin.download_async(metadata.copy())
@@ -280,7 +280,7 @@ async def test_theaudiodb_other_http_errors(bootstrap):  # pylint: disable=redef
     url = f"{TADB_BASE_URL}/search.php?s=notfound"
 
     # Use side_effect callable so the mock persists across retries
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(url).mock(side_effect=lambda _: httpx.Response(404))
         result = await plugin._fetch_cached(  # pylint: disable=protected-access
             DEFAULT_THEAUDIODB_API_KEY, "search.php?s=notfound", "testartist"
@@ -296,7 +296,7 @@ async def test_theaudiodb_429_not_cached(bootstrap, isolated_datacache_client): 
 
     # Side-effect callable keeps responding 429 across all retry attempts.
     # Retry-After: 1 caps the per-retry sleep to 1 s.
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(url).mock(
             side_effect=lambda _: httpx.Response(429, headers={"Retry-After": "1"})
         )
@@ -311,7 +311,7 @@ async def test_theaudiodb_429_not_cached(bootstrap, isolated_datacache_client): 
     isolated_datacache_client.set_retry_after("theaudiodb", -1)  # negative = already expired
 
     # Second call: if 429 had been cached to disk, this would also return None
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(url).mock(
             return_value=httpx.Response(200, json={"artists": [{"strArtist": "Test"}]})
         )
@@ -367,7 +367,7 @@ async def test_theaudiodb_coverart_queued(bootstrap):  # pylint: disable=redefin
     plugin = _setup_theaudiodb_plugin_no_key(bootstrap)
     bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_ARTIST_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ARTIST_RESPONSE)
         )
@@ -395,7 +395,7 @@ async def test_theaudiodb_coverart_prefers_hq(bootstrap):  # pylint: disable=red
     plugin = _setup_theaudiodb_plugin_no_key(bootstrap)
     bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_ARTIST_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ARTIST_RESPONSE)
         )
@@ -423,7 +423,7 @@ async def test_theaudiodb_coverart_disabled(bootstrap):  # pylint: disable=redef
     plugin = _setup_theaudiodb_plugin_no_key(bootstrap)
     bootstrap.cparser.setValue("theaudiodb/coverart", False)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_ARTIST_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ARTIST_RESPONSE)
         )
@@ -447,7 +447,7 @@ async def test_theaudiodb_coverart_skipped_when_coverimageraw_present(  # pylint
     plugin = _setup_theaudiodb_plugin_no_key(bootstrap)
     bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_ARTIST_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ARTIST_RESPONSE)
         )
@@ -472,7 +472,7 @@ async def test_theaudiodb_coverart_no_album(bootstrap):  # pylint: disable=redef
     plugin = _setup_theaudiodb_plugin_no_key(bootstrap)
     bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_ARTIST_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ARTIST_RESPONSE)
         )
@@ -492,7 +492,7 @@ async def test_theaudiodb_coverart_album_api_error(bootstrap):  # pylint: disabl
     plugin = _setup_theaudiodb_plugin_no_key(bootstrap)
     bootstrap.cparser.setValue("theaudiodb/coverart", True)
 
-    with respx.mock(assert_all_called=False) as mock_http:
+    with respx.mock(using="httpcore2", assert_all_called=False) as mock_http:
         mock_http.get(WNP_MOCK_ARTIST_URL).mock(
             return_value=httpx.Response(200, json=WNP_MOCK_ARTIST_RESPONSE)
         )

--- a/tests/test_tlstrust.py
+++ b/tests/test_tlstrust.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""tests for the CA trust-store probe and certifi fallback"""
+
+import os
+import ssl
+import threading
+import time
+
+import orjson
+
+import certifi
+import pytest
+
+import nowplaying.tlstrust
+
+
+@pytest.fixture(autouse=True)
+def restore_process_state():
+    """tlstrust deliberately mutates process-wide state; put it back afterwards"""
+    saved_mode = nowplaying.tlstrust._effective_mode  # pylint: disable=protected-access
+    saved_env = {
+        key: os.environ.get(key)
+        for key in (nowplaying.tlstrust.BUNDLE_ENV, "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE")
+    }
+    yield
+    nowplaying.tlstrust._effective_mode = saved_mode  # pylint: disable=protected-access
+    for key, value in saved_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def test_default_mode_is_system():
+    """no configured mode and no verdict leaves the OS trust store in charge"""
+    mode = nowplaying.tlstrust.resolve(nowplaying.tlstrust.MODE_AUTO, "")
+    assert nowplaying.tlstrust.apply_mode(mode) == nowplaying.tlstrust.MODE_SYSTEM
+    assert nowplaying.tlstrust.ca_bundle() is None
+    assert type(nowplaying.tlstrust.create_ssl_context()).__module__ == "truststore._api"
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        (nowplaying.tlstrust.MODE_SYSTEM, nowplaying.tlstrust.MODE_SYSTEM),
+        (nowplaying.tlstrust.MODE_CERTIFI, nowplaying.tlstrust.MODE_CERTIFI),
+        ("nonsense", nowplaying.tlstrust.MODE_SYSTEM),
+    ],
+)
+def test_explicit_mode_overrides_probe(mode, expected):
+    """a forced mode wins, and an unreadable one degrades to the OS store"""
+    assert nowplaying.tlstrust.resolve(mode, "") == expected
+
+
+def test_auto_follows_cached_verdict():
+    """auto mode replays whatever the last probe decided"""
+    mode = nowplaying.tlstrust.resolve(
+        nowplaying.tlstrust.MODE_AUTO, nowplaying.tlstrust.MODE_CERTIFI
+    )
+    assert nowplaying.tlstrust.apply_mode(mode) == nowplaying.tlstrust.MODE_CERTIFI
+    assert nowplaying.tlstrust.ca_bundle() == certifi.where()
+
+
+def test_certifi_mode_sets_bundle_for_subprocesses():
+    """the fallback has to reach libraries we never touch, so it goes in the environment"""
+    nowplaying.tlstrust.apply_mode(nowplaying.tlstrust.MODE_CERTIFI)
+    assert os.environ[nowplaying.tlstrust.BUNDLE_ENV] == certifi.where()
+    assert os.environ["SSL_CERT_FILE"]
+    assert os.environ["REQUESTS_CA_BUNDLE"]
+    assert ssl.SSLContext.__module__ == "ssl"
+    assert type(nowplaying.tlstrust.create_ssl_context()).__module__ == "ssl"
+
+
+def test_operator_bundle_outranks_the_verdict(monkeypatch):
+    """someone who exported their own bundle meant it"""
+    monkeypatch.setenv("SSL_CERT_FILE", "/somewhere/corporate.pem")
+    nowplaying.tlstrust.apply_mode(nowplaying.tlstrust.MODE_CERTIFI)
+    assert os.environ["SSL_CERT_FILE"] == "/somewhere/corporate.pem"
+
+
+def test_inherited_bundle_survives_without_apply(monkeypatch):
+    """a subprocess reads the verdict off the environment before its config exists"""
+    monkeypatch.setattr(nowplaying.tlstrust, "_effective_mode", None)
+    monkeypatch.setenv(nowplaying.tlstrust.BUNDLE_ENV, certifi.where())
+    assert nowplaying.tlstrust.effective_mode() == nowplaying.tlstrust.MODE_CERTIFI
+
+
+@pytest.mark.parametrize(
+    "system_result,certifi_result,expected",
+    [
+        (True, None, nowplaying.tlstrust.MODE_SYSTEM),
+        (False, True, nowplaying.tlstrust.MODE_CERTIFI),
+        (False, False, None),
+        (None, None, None),
+    ],
+)
+def test_probe_verdicts(monkeypatch, system_result, certifi_result, expected):
+    """certifi only wins when it verifies a host the system store rejected"""
+    results = {"truststore._api": system_result, "ssl": certifi_result}
+
+    def fake_handshake(context, host, port=443):  # pylint: disable=unused-argument
+        return results[type(context).__module__]
+
+    monkeypatch.setattr(nowplaying.tlstrust, "_handshake", fake_handshake)
+    monkeypatch.setattr(nowplaying.tlstrust, "PROBE_HOSTS", ("example.invalid",))
+    assert nowplaying.tlstrust.probe() == expected
+
+
+def test_probe_catches_a_partial_trust_gap(monkeypatch):
+    """an old store keeps its old roots, so one host verifying proves nothing
+
+    The realistic failure is a machine that still trusts DigiCert G2 from 2013
+    but never picked up ISRG Root X2 from 2020: MusicBrainz works while every
+    Let's Encrypt-backed image fails.  Stopping at the first success would call
+    that healthy.
+    """
+    old_root_ok = "musicbrainz.org"
+
+    def fake_handshake(context, host, port=443):  # pylint: disable=unused-argument
+        if host == old_root_ok:
+            return True
+        return type(context).__module__ != "truststore._api"
+
+    monkeypatch.setattr(nowplaying.tlstrust, "_handshake", fake_handshake)
+    monkeypatch.setattr(nowplaying.tlstrust, "PROBE_HOSTS", (old_root_ok, "coverartarchive.org"))
+    assert nowplaying.tlstrust.probe() == nowplaying.tlstrust.MODE_CERTIFI
+
+
+def test_probe_newest_roots_come_first():
+    """the canary has to be a root an unpatched machine would actually lack"""
+    assert nowplaying.tlstrust.PROBE_HOSTS[0] == "coverartarchive.org"
+    assert nowplaying.tlstrust.PROBE_HOSTS[-1] == "musicbrainz.org"
+
+
+def test_probe_moves_past_an_unreachable_host(monkeypatch):
+    """one dead host must not stop the probe from asking the next one"""
+    seen: list[str] = []
+
+    def fake_handshake(context, host, port=443):  # pylint: disable=unused-argument
+        seen.append(host)
+        return None if host == "dead.invalid" else True
+
+    monkeypatch.setattr(nowplaying.tlstrust, "_handshake", fake_handshake)
+    monkeypatch.setattr(nowplaying.tlstrust, "PROBE_HOSTS", ("dead.invalid", "live.invalid"))
+    assert nowplaying.tlstrust.probe() == nowplaying.tlstrust.MODE_SYSTEM
+    assert seen == ["dead.invalid", "live.invalid"]
+
+
+def test_handshake_reports_unreachable_as_none():
+    """an unresolvable host is not evidence about anyone's certificates"""
+    context = nowplaying.tlstrust.create_ssl_context()
+    assert nowplaying.tlstrust._handshake(context, "no-such-host.invalid") is None  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    "mode,verdict,checked_offset,expected",
+    [
+        (nowplaying.tlstrust.MODE_AUTO, "", 0, True),
+        (nowplaying.tlstrust.MODE_AUTO, nowplaying.tlstrust.MODE_SYSTEM, -60, False),
+        (
+            nowplaying.tlstrust.MODE_AUTO,
+            nowplaying.tlstrust.MODE_SYSTEM,
+            -(nowplaying.tlstrust.RECHECK_SECONDS + 60),
+            True,
+        ),
+        (nowplaying.tlstrust.MODE_AUTO, "garbage", 0, True),
+        (nowplaying.tlstrust.MODE_SYSTEM, "", 0, False),
+        (nowplaying.tlstrust.MODE_CERTIFI, "", 0, False),
+    ],
+)
+def test_needs_probe(mode, verdict, checked_offset, expected):
+    """probing is a network call on the startup path, so only when warranted"""
+    checked = int(time.time()) + checked_offset if verdict else 0
+    assert nowplaying.tlstrust.needs_probe(mode, verdict, checked) is expected
+
+
+def test_trustprobe_hands_back_the_verdict(monkeypatch):
+    """the probe reports; it never writes anything itself"""
+    monkeypatch.setattr(nowplaying.tlstrust, "probe", lambda: nowplaying.tlstrust.MODE_CERTIFI)
+    assert (
+        nowplaying.tlstrust.TrustProbe().start().result(timeout=10)
+        == nowplaying.tlstrust.MODE_CERTIFI
+    )
+
+
+def test_trustprobe_reports_nothing_when_inconclusive(monkeypatch):
+    """an offline machine keeps whatever verdict the caller already had"""
+    monkeypatch.setattr(nowplaying.tlstrust, "probe", lambda: None)
+    assert nowplaying.tlstrust.TrustProbe().start().result(timeout=10) is None
+
+
+def test_trustprobe_is_abandoned_rather_than_waited_out(monkeypatch):
+    """startup matters more than the answer; a slow probe is dropped"""
+    started = threading.Event()
+
+    def slow_probe():
+        started.set()
+        time.sleep(30)
+        return nowplaying.tlstrust.MODE_CERTIFI
+
+    monkeypatch.setattr(nowplaying.tlstrust, "probe", slow_probe)
+    handle = nowplaying.tlstrust.TrustProbe().start()
+    assert started.wait(timeout=10)
+    assert handle.result(timeout=0.2) is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        b"",
+        b"hello",
+        b'["certifi"]',
+        b'"certifi"',
+        b"null",
+        b'{"effective": "evil", "verdict": "evil", "checked": 1}',
+        b'{"effective": "auto", "verdict": "auto", "checked": 1}',
+    ],
+)
+def test_load_state_degrades_to_the_os_store(tmp_path, body):
+    """the cache sits in the user's Documents tree, so it is untrusted input"""
+    path = tmp_path / nowplaying.tlstrust.STATE_FILE
+    if body is not None:
+        path.write_bytes(body)
+    effective, verdict, _ = nowplaying.tlstrust.load_state(path)
+    assert effective == nowplaying.tlstrust.MODE_SYSTEM
+    assert verdict == ""
+
+
+@pytest.mark.parametrize("checked", [True, -5, "99", 0, 2**40])
+def test_load_state_rejects_unusable_timestamps(tmp_path, checked):
+    """a bool, a string, or a time in the future all mean: probe again"""
+    path = tmp_path / nowplaying.tlstrust.STATE_FILE
+    path.write_bytes(
+        orjson.dumps(
+            {
+                "effective": nowplaying.tlstrust.MODE_CERTIFI,
+                "verdict": nowplaying.tlstrust.MODE_CERTIFI,
+                "checked": checked,
+            }
+        )
+    )
+    assert nowplaying.tlstrust.load_state(path)[2] == 0
+
+
+def test_load_state_ignores_an_oversized_file(tmp_path):
+    """nobody hand-edits a megabyte of trust cache; do not read it in"""
+    path = tmp_path / nowplaying.tlstrust.STATE_FILE
+    path.write_bytes(b'{"effective":"certifi","pad":"' + b"x" * 8000 + b'"}')
+    assert nowplaying.tlstrust.load_state(path)[0] == nowplaying.tlstrust.MODE_SYSTEM
+
+
+def test_state_round_trips(tmp_path):
+    """what the tray saves is what the next launch applies"""
+    path = tmp_path / "nested" / nowplaying.tlstrust.STATE_FILE
+    stamp = int(time.time()) - 10
+    nowplaying.tlstrust.save_state(
+        path, nowplaying.tlstrust.MODE_CERTIFI, nowplaying.tlstrust.MODE_CERTIFI, stamp
+    )
+    assert nowplaying.tlstrust.load_state(path) == (
+        nowplaying.tlstrust.MODE_CERTIFI,
+        nowplaying.tlstrust.MODE_CERTIFI,
+        stamp,
+    )
+
+
+def test_save_state_survives_an_unwritable_path(tmp_path):
+    """a cache we cannot write is not worth crashing a DJ's startup over"""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    nowplaying.tlstrust.save_state(
+        blocker / nowplaying.tlstrust.STATE_FILE, nowplaying.tlstrust.MODE_SYSTEM, "", 1
+    )

--- a/tests/test_tlstrust.py
+++ b/tests/test_tlstrust.py
@@ -71,6 +71,45 @@ def test_certifi_mode_sets_bundle_for_subprocesses():
     assert type(nowplaying.tlstrust.create_ssl_context()).__module__ == "ssl"
 
 
+def test_system_mode_releases_our_own_bundle(monkeypatch):
+    """frozen.py points SSL_CERT_FILE at the bundled certifi before we decide
+
+    Choosing the OS store has to undo that, or the escape hatch does nothing
+    for the workplace whose inspecting root is in the system store only.
+    """
+    monkeypatch.setenv("SSL_CERT_FILE", certifi.where())
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", certifi.where())
+    monkeypatch.setenv(nowplaying.tlstrust.BUNDLE_ENV, certifi.where())
+
+    nowplaying.tlstrust.apply_mode(nowplaying.tlstrust.MODE_SYSTEM)
+
+    assert nowplaying.tlstrust.BUNDLE_ENV not in os.environ
+    assert "SSL_CERT_FILE" not in os.environ
+    assert "REQUESTS_CA_BUNDLE" not in os.environ
+    assert nowplaying.tlstrust.ca_bundle() is None
+
+
+def test_system_mode_leaves_an_operator_bundle_alone(monkeypatch):
+    """someone else's export is not ours to remove, in either direction"""
+    monkeypatch.setenv("SSL_CERT_FILE", "/somewhere/corporate.pem")
+    nowplaying.tlstrust.apply_mode(nowplaying.tlstrust.MODE_SYSTEM)
+    assert os.environ["SSL_CERT_FILE"] == "/somewhere/corporate.pem"
+
+
+def test_certifi_then_system_round_trips(monkeypatch):
+    """flipping the setting back has to actually flip the process back"""
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv(nowplaying.tlstrust.BUNDLE_ENV, raising=False)
+
+    nowplaying.tlstrust.apply_mode(nowplaying.tlstrust.MODE_CERTIFI)
+    assert os.environ[nowplaying.tlstrust.BUNDLE_ENV] == certifi.where()
+
+    nowplaying.tlstrust.apply_mode(nowplaying.tlstrust.MODE_SYSTEM)
+    assert nowplaying.tlstrust.BUNDLE_ENV not in os.environ
+    assert type(nowplaying.tlstrust.create_ssl_context()).__module__ == "truststore._api"
+
+
 def test_operator_bundle_outranks_the_verdict(monkeypatch):
     """someone who exported their own bundle meant it"""
     monkeypatch.setenv("SSL_CERT_FILE", "/somewhere/corporate.pem")

--- a/tests/test_tlstrust.py
+++ b/tests/test_tlstrust.py
@@ -4,9 +4,8 @@
 import os
 import ssl
 import threading
+import json
 import time
-
-import orjson
 
 import certifi
 import pytest
@@ -270,8 +269,8 @@ def test_load_state_degrades_to_the_os_store(tmp_path, body):
 def test_load_state_rejects_unusable_timestamps(tmp_path, checked):
     """a bool, a string, or a time in the future all mean: probe again"""
     path = tmp_path / nowplaying.tlstrust.STATE_FILE
-    path.write_bytes(
-        orjson.dumps(
+    path.write_text(
+        json.dumps(
             {
                 "effective": nowplaying.tlstrust.MODE_CERTIFI,
                 "verdict": nowplaying.tlstrust.MODE_CERTIFI,

--- a/tests/test_tlstrust.py
+++ b/tests/test_tlstrust.py
@@ -30,6 +30,15 @@ def restore_process_state():
             os.environ[key] = value
 
 
+@pytest.mark.parametrize(
+    "mode", [nowplaying.tlstrust.MODE_SYSTEM, nowplaying.tlstrust.MODE_CERTIFI]
+)
+def test_contexts_floor_tls_at_1_2(mode):
+    """the floor is ours to state, not OpenSSL's to choose"""
+    nowplaying.tlstrust.apply_mode(mode)
+    assert nowplaying.tlstrust.create_ssl_context().minimum_version == ssl.TLSVersion.TLSv1_2
+
+
 def test_default_mode_is_system():
     """no configured mode and no verdict leaves the OS trust store in charge"""
     mode = nowplaying.tlstrust.resolve(nowplaying.tlstrust.MODE_AUTO, "")

--- a/tests/test_tlstrust.py
+++ b/tests/test_tlstrust.py
@@ -129,7 +129,8 @@ def test_inherited_bundle_survives_without_apply(monkeypatch):
     """a subprocess reads the verdict off the environment before its config exists"""
     monkeypatch.setattr(nowplaying.tlstrust, "_effective_mode", None)
     monkeypatch.setenv(nowplaying.tlstrust.BUNDLE_ENV, certifi.where())
-    assert nowplaying.tlstrust.effective_mode() == nowplaying.tlstrust.MODE_CERTIFI
+    assert nowplaying.tlstrust.ca_bundle() == certifi.where()
+    assert type(nowplaying.tlstrust.create_ssl_context()).__module__ == "ssl"
 
 
 @pytest.mark.parametrize(

--- a/tools/catrust_diag.py
+++ b/tools/catrust_diag.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Report what this machine's TLS trust store can and cannot verify.
+
+Runs the same probe the app runs, against the same hosts, so the verdict here
+is the verdict the app will reach.  Useful on a machine where artwork and
+biographies come back empty for no obvious reason.
+
+    python tools/catrust_diag.py
+"""
+
+import argparse
+import platform
+import ssl
+import sys
+
+import certifi
+
+import nowplaying.tlstrust
+
+# Mirrors truststore's own platform.system() dispatch in truststore/_api.py.
+# Only the openssl backend reads the cafile below; the other two ask the OS and
+# ignore it, which is what makes an upgraded Homebrew openssl look relevant on
+# macOS when it changes nothing about what "system" trusts.
+_SYSTEM_STORES = {
+    "Windows": "Windows certificate store (CryptoAPI)",
+    "Darwin": "macOS Keychain (SecTrust)",
+}
+
+
+def _describe(result: bool | None) -> str:
+    return {True: "verified", False: "REJECTED", None: "unreachable"}[result]
+
+
+def main() -> int:
+    """probe each host with both trust stores and report"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "hosts",
+        nargs="*",
+        default=list(nowplaying.tlstrust.PROBE_HOSTS),
+        help="hosts to test (default: the ones the app probes)",
+    )
+    args = parser.parse_args()
+    # probe() reads PROBE_HOSTS, so point it at whatever was asked for rather
+    # than letting the table and the verdict disagree about which hosts ran.
+    nowplaying.tlstrust.PROBE_HOSTS = tuple(args.hosts)
+
+    print(f"platform      : {platform.platform()}")
+    print(f"python        : {sys.version.split()[0]}")
+    print(f"openssl       : {ssl.OPENSSL_VERSION}")
+    print(f"system store  : {_SYSTEM_STORES.get(platform.system(), 'openssl cafile below')}")
+    print(f"openssl cafile: {ssl.get_default_verify_paths().cafile}")
+    print(f"certifi       : {certifi.where()}")
+    print()
+
+    stores = {
+        "system": nowplaying.tlstrust._system_context,  # pylint: disable=protected-access
+        "certifi": nowplaying.tlstrust._certifi_context,  # pylint: disable=protected-access
+    }
+    print(f"{'host':32} {'system':<12} certifi")
+    for host in nowplaying.tlstrust.PROBE_HOSTS:
+        results = {
+            name: nowplaying.tlstrust._handshake(factory(), host)  # pylint: disable=protected-access
+            for name, factory in stores.items()
+        }
+        print(f"{host:32} {_describe(results['system']):<12} {_describe(results['certifi'])}")
+
+    print()
+    verdict = nowplaying.tlstrust.probe()
+    if verdict is None:
+        print("verdict: inconclusive -- nothing answered, or both stores failed the same host")
+        print("         the app leaves its cached verdict alone in this case")
+    elif verdict == nowplaying.tlstrust.MODE_CERTIFI:
+        print("verdict: certifi -- this machine's certificates are too old, fallback would engage")
+    else:
+        print("verdict: system -- this machine's certificates are fine, no fallback needed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wnppyi.py
+++ b/wnppyi.py
@@ -18,7 +18,11 @@ if sys.stderr is None:
 
 multiprocessing.freeze_support()
 
-truststore.inject_into_ssl()
+# WNP_CA_BUNDLE means the parent process decided the OS trust store is too old
+# to be usable (see nowplaying/tlstrust.py).  Injecting truststore here would
+# drag this subprocess right back onto it.
+if not os.environ.get("WNP_CA_BUNDLE"):
+    truststore.inject_into_ssl()
 
 # Ensure the current directory is in sys.path
 if __name__ == "__main__":


### PR DESCRIPTION
wnpmb 0.4.0 switched to httpx2, the maintained fork, so the app was about
to carry two HTTP stacks with two different default trust stores: httpx
verifies against certifi, httpx2 against the OS store via truststore.
Consolidating on httpx2 means one stack, one default, and one place to
override when the next commit adds the CA fallback.

Test mocking moves with it.  respx patches httpcore, and httpx2 speaks
httpcore2, so the existing mocks would have stopped intercepting and the
suite would have gone to the real network.  pytest-httpx2 is respx plus a
registered httpcore2 mocker, which makes the change respx.mock(...) ->
respx.mock(using="httpcore2", ...).  The canned replies stay httpx.Response
because that is the type respx constructs and validates; only the client
and the exceptions it raises are httpx2.

## Summary by Sourcery

Consolidate HTTP clients on httpx2 and add resilient, configurable certificate trust handling with a bundled-CA fallback.

New Features:
- Add automatic, system, and bundled certificate trust modes with cached probing and a diagnostic utility.
- Provide a bundled-CA fallback for older systems whose operating-system certificates cannot verify supported music services.

Bug Fixes:
- Prevent HTTP test mocks from bypassing requests after migrating clients to the httpcore2 stack.
- Ensure early startup trust selection is applied before upgrade checks and propagated to subprocesses.

Enhancements:
- Migrate application HTTP clients and related exception handling from httpx to httpx2.
- Centralize TLS context and CA-bundle selection across HTTP libraries and services.
- Expose certificate trust selection in the general settings UI and persist the probe result outside user configuration.

Build:
- Preserve httpx2 package metadata in PyInstaller bundles so frozen builds can determine their version.

Documentation:
- Document the certificate trust fallback and its user-configurable modes.

Tests:
- Update HTTP request mocks to target httpcore2 and add coverage for trust-store selection, probing, caching, and environment propagation.

Chores:
- Document startup configuration and QSettings restrictions relevant to upgrades.