### PR TITLE
Fill 5.2.3 changelog gaps and harden macOS signing in CI

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -80,6 +80,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # PyInstaller downgrades a failed BUNDLE signing to a log warning
+          # and emits the bundle anyway, so a locked keychain or a bad
+          # identity yields a green build and an unsigned .app.  Fail on it.
+          PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR: '1'
         run: |
           export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"

--- a/.github/workflows/macos26-build.yml
+++ b/.github/workflows/macos26-build.yml
@@ -115,6 +115,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # PyInstaller downgrades a failed BUNDLE signing to a log warning
+          # and emits the bundle anyway, so a locked keychain or a bad
+          # identity yields a green build and an unsigned .app.  Fail on it.
+          PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR: '1'
         run: |
           export PATH="$(brew --prefix)/opt/icu4c/bin:$(brew --prefix)/opt/icu4c/sbin:$PATH"
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/icu4c/lib/pkgconfig"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@
 
 * The upgrade prompt can now show aggregated release notes for the
     versions between the installed and the offered build
+* WNP now checks whether this computer's certificate authorities can still
+    verify the music services it fetches from, and falls back to a bundled
+    set when they cannot. On a machine whose certificates have fallen behind,
+    artwork and biographies stopped arriving with nothing in the interface to
+    explain why. General settings has a Certificate Trust control to force
+    either behaviour, which matters on networks that inspect traffic with
+    their own certificate
 
 ### Bug Fixes
 
@@ -54,12 +61,21 @@
     release-candidate builds
 * Fixed configuration restore when cancelling after a settings reset;
     the charts key is preserved
+* Fixed the artist extras image limits, which had been read from a
+    configuration key nothing writes and so were ignored since March 2024.
+    The values on the Artist Extras settings page now take effect. Anyone who
+    never changed them will see fewer images than before, because the
+    defaults are lower than the fallbacks that were silently in use
+* Album matching is more accurate: MusicBrainz lookups now treat "&" and
+    "and" as the same, so a track tagged one way still matches a release
+    tagged the other
 
 ### Security
 
-* Updated nltk to 3.10.0 (security advisory)
-* Updated aiohttp to 3.14.x, pillow to 12.3.0, zeroconf to 0.150.0,
-    requests-cache, and setuptools
+* Updated nltk to 3.10.3 (security advisory)
+* Updated aiohttp to 3.14.3, pillow to 12.3.0, pillow-avif-plugin to 1.6.0,
+    zeroconf to 0.150.0, pypresence to 4.6.2, pyinstaller to 6.22.1,
+    requests-cache to 1.3.3, and setuptools
 
 ## Version 5.2.2 - 2026-06-20
 


### PR DESCRIPTION
Missing from the 5.2.3 entries: the CA fallback, the artist extras image limits, and the album matching from wnpmb 0.4.1.  Security section versions were stale against the requirements diff since the 5.2.2 tag.

Set PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR in both macOS workflows so a failed bundle signing fails the build rather than logging a warning and shipping an unsigned .app.

## Summary by Sourcery

Complete the 5.2.3 release notes and enforce successful macOS application signing in CI.

New Features:
- Document certificate authority fallback and trust controls in the 5.2.3 changelog.

Bug Fixes:
- Document fixes for artist extras image limits and more accurate album matching in the 5.2.3 changelog.

CI:
- Make macOS build workflows fail when PyInstaller bundle code signing fails.

Documentation:
- Complete the 5.2.3 changelog with missing feature, bug-fix, and dependency security updates.