### PR TITLE
Version the PyInstaller contents directory

### DIFF
--- a/WhatsNowPlaying.spec
+++ b/WhatsNowPlaying.spec
@@ -150,6 +150,12 @@ block_cipher = None
 # __version__.py is literally version("httpx2") at module scope.
 KEEP_METADATA = ('httpx2',)
 
+# Versioned contents directory so each build's _internal-X.Y.Z/ is unique.
+# Two installs can then sit side by side without their private directories
+# colliding, which is what an in-place upgrade needs in order to move a new
+# bundle in before removing the old one.
+_CONTENTS_DIR = '_internal-' + __VERSION__.replace('+', '-')
+
 executables = {
     'WhatsNowPlaying': 'wnppyi.py',
 }
@@ -216,6 +222,7 @@ for execname, execpy in executables.items():
             strip=False,
             upx=False,
             #console=False,
+            contents_directory=_CONTENTS_DIR,
             icon=geticon(),
             codesign_identity=os.environ.get('MACOS_SIGN_IDENTITY'),
             entitlements_file='bincomponents/entitlements.plist')
@@ -256,6 +263,7 @@ for execname, execpy in executables.items():
             strip=False,
             upx=False,
             console=False,
+            contents_directory=_CONTENTS_DIR,
             version=WINVERSFILE,
             icon=geticon())
         coll = COLLECT(  # pylint: disable=undefined-variable
@@ -281,6 +289,7 @@ for execname, execpy in executables.items():
             strip=False,
             upx=False,
             console=False,
+            contents_directory=_CONTENTS_DIR,
             icon=geticon())
         coll = COLLECT(  # pylint: disable=undefined-variable
             exe,


### PR DESCRIPTION
Backport of the _internal rename from main, without the tufup client changes that motivated it there -- 5.2 has only the publishing half of tufup, so nothing here consumes the name yet.

Doing it now is forward preparation: a build that lays out _internal-5.2.3/ will not collide with a later release's _internal-{new}/, which is what lets an in-place upgrade move the new bundle in before removing the old one rather than having to delete first and hope.

Three EXE blocks, matching main's three.  contents_directory needs PyInstaller 6.0+, and this branch is on 6.22.1.

## Summary by Sourcery

Version PyInstaller bundle contents directories to support collision-free in-place upgrades.

Enhancements:
- Use version-specific PyInstaller contents directories across macOS, Windows, and Linux builds to allow side-by-side bundles during in-place upgrades.

Build:
- Configure generated bundles to place private contents under a versioned _internal directory.