### PR TITLE
Log unhandled GUI exceptions instead of losing them to devnull

### DIFF
--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -29,6 +29,17 @@ import nowplaying.upgrade
 #
 
 
+def log_unhandled(exctype, value, tbobj):  # pragma: no cover
+    """Log an exception that escapes a Qt slot instead of losing it.
+
+    A windowed build has no stderr -- wnppyi.py points it at devnull -- so the
+    default hook writes the traceback nowhere and PySide6 then aborts.  The
+    subprocesses wrap their own entry points; this is the GUI process only.
+    """
+    logging.critical("Unhandled exception", exc_info=(exctype, value, tbobj))
+    sys.__excepthook__(exctype, value, tbobj)
+
+
 def run_bootstrap(bundledir: str | None = None) -> pathlib.Path:  # pragma: no cover
     """bootstrap the app"""
     # we are in a hurry to get results.  If it takes longer than
@@ -36,6 +47,7 @@ def run_bootstrap(bundledir: str | None = None) -> pathlib.Path:  # pragma: no c
     # point this should be configurable but this is good enough for now
     socket.setdefaulttimeout(5.0)
     logpath = nowplaying.bootstrap.setuplogging(rotate=True)
+    sys.excepthook = log_unhandled
     plat = platform.platform()
     logging.info("starting up v%s on %s", nowplaying.__version__, plat)
     # upgrade() checks whatsnowplaying.com for a new version, the first TLS this


### PR DESCRIPTION
A windowed build has no stderr, so an exception escaping a Qt slot printed its traceback nowhere and PySide6 aborted -- the user saw the app vanish and debug.log simply stopped.  Subprocess entry points already wrap themselves; this covers the GUI process.

## Summary by Sourcery

Bug Fixes:
- Log unhandled exceptions from the GUI process so failures in windowed builds are preserved in the application log instead of being silently lost.