### PR TITLE
Bump wnpmb to 0.6.0

### DIFF
--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -13,7 +13,6 @@ from wnpmb import (
     MusicBrainzClient,
     MusicBrainzError,
     RateLimitError,
-    ResponseError,
     extract_artist_urls,
 )
 from wnpmb.client._base import RetrySettings
@@ -100,7 +99,11 @@ class MusicBrainzHelper:
         self.emailaddressset = False
         self.mb_client = MusicBrainzClient(
             timeout=5.0,
-            retry_settings=RetrySettings(max_retries=2, wait=0.5, timeout_retries=1),
+            # timeout_wait is set rather than inherited: wnpmb defaults it to 2.0,
+            # which is most of the budget a track has before the next one starts.
+            retry_settings=RetrySettings(
+                max_retries=2, wait=0.5, timeout_retries=1, timeout_wait=0.5
+            ),
             ca_bundle=nowplaying.tlstrust.ca_bundle(),
         )
 
@@ -360,8 +363,11 @@ class MusicBrainzHelper:
                             )
                             return {"coverimageraw": raw}
                     return None
-                except ResponseError as err:
-                    if "404" in str(err):
+                except MusicBrainzError as err:
+                    # Catch the base class, not ResponseError: a CAA timeout is a
+                    # NetworkError and a 503 is a ServerBusyError, neither of which
+                    # is a ResponseError.
+                    if err.status_code == 404:
                         # No cover art exists for this release — stable negative result
                         logger.debug("CAA 404 for %s/%s", entity_type, entity_id)
                         return {}

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -36,7 +36,7 @@ tufup==0.10.0
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.4.1/wnpmb-0.4.1-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.6.0/wnpmb-0.6.0-py3-none-any.whl
 wnp-templates @ https://github.com/whatsnowplaying/wnp-templates/releases/download/0.1.4/wnp_templates-0.1.4-py3-none-any.whl
 zeroconf==0.150.0
 


### PR DESCRIPTION
0.6.0 raises on transport failure and carries status_code on the exception, so the cover art handler can tell a confirmed 404 from a timeout without string-matching the message.  Catch the base class: image timeouts are now NetworkError and 503s ServerBusyError, neither a ResponseError.

Also pin timeout_wait, which was inheriting wnpmb's 2.0 while the other three retry fields were already tuned down for live use.

## Summary by Sourcery

Upgrade wnpmb and improve MusicBrainz cover-art error handling and retry timing.

Bug Fixes:
- Distinguish confirmed cover-art 404 responses from network timeouts and server-busy failures when handling MusicBrainz errors.

Enhancements:
- Tune MusicBrainz retry timeout waits for live track-processing behavior.

Build:
- Update the runtime dependency pin for wnpmb to version 0.6.0.