### PR TITLE
Bump wnpmb to 0.6.0

### DIFF
--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -47,7 +47,11 @@ class MusicBrainzHelper:
         self.emailaddressset = False
         self.mb_client = MusicBrainzClient(
             timeout=5.0,
-            retry_settings=RetrySettings(max_retries=2, wait=0.5, timeout_retries=1),
+            # timeout_wait is set rather than inherited: wnpmb defaults it to 2.0,
+            # which is most of the budget a track has before the next one starts.
+            retry_settings=RetrySettings(
+                max_retries=2, wait=0.5, timeout_retries=1, timeout_wait=0.5
+            ),
             ca_bundle=nowplaying.tlstrust.ca_bundle(),
         )
 

--- a/requirements-run.txt
+++ b/requirements-run.txt
@@ -31,7 +31,7 @@ truststore==0.10.4
 twitchAPI==4.5.0
 url_normalize==3.0.0
 watchdog==6.0.0
-wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.4.1/wnpmb-0.4.1-py3-none-any.whl
+wnpmb @ https://github.com/whatsnowplaying/wnpmb/releases/download/0.6.0/wnpmb-0.6.0-py3-none-any.whl
 zeroconf==0.150.0
 
 #


### PR DESCRIPTION
0.4.1 returned None from a timeout, connect error or non-404 5xx exactly as it did for a confirmed 404, so _recordingid_uncached turned a MusicBrainz outage into {} and apicache stored it for the full seven-day TTL -- a real recording marked as having no album, label or date for a week.  0.6.0 raises instead, _mb_op_with_retry catches it, and apicache skips None.

Also pin timeout_wait, which was inheriting wnpmb's 2.0 while the other three retry fields were already tuned down for live use.

## Summary by Sourcery

Update MusicBrainz integration to avoid persisting transient lookup failures and reduce timeout retry delays.

Bug Fixes:
- Prevent MusicBrainz failures from being cached as empty recording metadata by updating wnpmb to raise on transient errors and allowing retry handling to bypass the cache.

Enhancements:
- Set the MusicBrainz timeout retry wait explicitly to 0.5 seconds for more responsive live playback.

Build:
- Update the runtime dependency on wnpmb to version 0.6.0.