### PR TITLE
Fetch fanart.tv over HTTPS

### DIFF
--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -34,7 +34,7 @@ class Plugin(ArtistExtrasPlugin):
         datacache_client = nowplaying.datacache.get_client()
 
         for artistid in metadata["musicbrainzartistid"]:
-            url = f"http://webservice.fanart.tv/v3/music/{artistid}"
+            url = f"https://webservice.fanart.tv/v3/music/{artistid}"
             result = await datacache_client.get_or_fetch(
                 nowplaying.datacache.FetchRequest(
                     url=url,

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -55,7 +55,7 @@ async def test_fanarttv_datacache_api_call_count(bootstrap):  # pylint: disable=
     """test that fanarttv makes only one HTTP call when the cache is warm"""
     plugin = _setup_fanarttv_plugin(bootstrap)
     mbid = "00000000-0000-0000-0000-000000000002"
-    url = f"http://webservice.fanart.tv/v3/music/{mbid}"
+    url = f"https://webservice.fanart.tv/v3/music/{mbid}"
     mock_payload = {"name": "WNP Mock Artist"}
     metadata = {
         "artist": "WNP Mock Artist",
@@ -80,7 +80,7 @@ async def test_fanarttv_datacache_api_failure_behavior(bootstrap):  # pylint: di
     """test that fanarttv doesn't cache failed API calls; second call retries"""
     plugin = _setup_fanarttv_plugin(bootstrap)
     mbid = "00000000-0000-0000-0000-000000000099"
-    url = f"http://webservice.fanart.tv/v3/music/{mbid}"
+    url = f"https://webservice.fanart.tv/v3/music/{mbid}"
     metadata = {
         "album": "WNP Mock Album",
         "artist": "WNP Mock Artist",


### PR DESCRIPTION
The artist lookup went out as http:// with the API key in a client-key header, so the key crossed the network in cleartext on every enrichment and the response was unauthenticated.  webservice.fanart.tv serves HTTPS with a valid chain.

The URL is the datacache primary key, so existing fanarttv entries under the http:// key are orphaned and will re-fetch once.

## Summary by Sourcery

Secure fanart.tv artist enrichment by switching its API requests from HTTP to HTTPS.

Bug Fixes:
- Fetch fanart.tv artist data over HTTPS to protect API credentials in transit and authenticate responses.

Tests:
- Update fanart.tv cache and retry tests to use the HTTPS endpoint.