### PR TITLE
Fetch fanart.tv over HTTPS

### DIFF
--- a/nowplaying/artistextras/fanarttv.py
+++ b/nowplaying/artistextras/fanarttv.py
@@ -27,7 +27,7 @@ class Plugin(ArtistExtrasPlugin):
         delay = self.calculate_delay()
 
         try:
-            baseurl = f"http://webservice.fanart.tv/v3/music/{artistid}"
+            baseurl = f"https://webservice.fanart.tv/v3/music/{artistid}"
             logging.debug("fanarttv async: calling %s", baseurl)
             connector = nowplaying.utils.create_http_connector()
             async with aiohttp.ClientSession(connector=connector) as session:


### PR DESCRIPTION
The artist lookup went out as http:// with the API key in the query string, so the key was readable by anything on the path and recorded in any intervening proxy or access log.  webservice.fanart.tv serves HTTPS with a valid chain.

## Summary by Sourcery

Bug Fixes:
- Protect fanart.tv API keys in transit by fetching artist metadata over HTTPS.