### PR TITLE
Add 5.2.3 entries for the three changes merged since

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,13 +69,25 @@
 * Album matching is more accurate: MusicBrainz lookups now treat "&" and
     "and" as the same, so a track tagged one way still matches a release
     tagged the other
+* A momentary MusicBrainz outage no longer leaves a track missing its album,
+    label, and date for up to a week afterward
+
+### Platform
+
+* The private directory inside a build now carries the version in its name,
+    so an upgrade can put the new copy in place before removing the old one
 
 ### Security
 
+* Artist images and biographies from fanart.tv are now fetched over an
+    encrypted connection. The request previously went out unencrypted with
+    the fanart.tv API key attached, exposing the key to anything between
+    this computer and fanart.tv
 * Updated nltk to 3.10.3 (security advisory)
-* Updated aiohttp to 3.14.3, pillow to 12.3.0, pillow-avif-plugin to 1.6.0,
-    zeroconf to 0.150.0, pypresence to 4.6.2, pyinstaller to 6.22.1,
-    requests-cache to 1.3.3, and setuptools
+* Updated aiohttp to 3.14.3, certifi to 2026.7.22, lxml to 6.1.2,
+    pillow to 12.3.0, pillow-avif-plugin to 1.6.0, pyinstaller to 6.22.2,
+    pypresence to 4.6.2, requests-cache to 1.3.3, setuptools to 83.0.0,
+    wnpmb to 0.6.0, and zeroconf to 0.150.0
 
 ## Version 5.2.2 - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 
 ### Security
 
-* Artist images and biographies from fanart.tv are now fetched over an
+* Artist images and album artwork from fanart.tv are now fetched over an
     encrypted connection. The request previously went out unencrypted with
     the fanart.tv API key attached, exposing the key to anything between
     this computer and fanart.tv


### PR DESCRIPTION
Dependency list re-derived from the requirements diff against the 5.2.2 tag: pyinstaller is 6.22.2 rather than 6.22.1, and certifi, lxml and wnpmb were missing.

## Summary by Sourcery

Prepare the 5.2.3 changelog with the three merged fixes, platform improvement, security change, and updated dependencies.

Bug Fixes:
- Prevent MusicBrainz outages from leaving tracks without album metadata for up to a week.
- Fetch fanart.tv artist images and album artwork over encrypted connections to protect API keys.

Enhancements:
- Allow upgraded builds to be installed before the previous private directory is removed.

Build:
- Refresh dependency entries, adding certifi, lxml, and wnpmb and updating pyinstaller and other packages.