### PR TITLE
Keep httpcore2's metadata in frozen builds

### DIFF
--- a/WhatsNowPlaying.spec
+++ b/WhatsNowPlaying.spec
@@ -147,8 +147,12 @@ block_cipher = None
 
 # Packages that read their own version out of importlib.metadata at import
 # time, so they die if their .dist-info is stripped below.  httpx2's
-# __version__.py is literally version("httpx2") at module scope.
-KEEP_METADATA = ('httpx2',)
+# __version__.py is literally version("httpx2") at module scope, and
+# httpcore2/__init__.py ends with the same call.  Transitive dependencies
+# count: httpcore2 is never named in requirements-run.txt, it arrives through
+# httpx2, and --smoke-test exits before any client is built so a green build
+# proves nothing here.
+KEEP_METADATA = ('httpx2', 'httpcore2')
 
 # Versioned contents directory so each build's _internal-X.Y.Z/ is unique.
 # The installer renames the old binary aside and moves the new bundle in;


### PR DESCRIPTION
Stripping its dist-info made the first httpx2 client construction raise PackageNotFoundError, which killed every MusicBrainz lookup in the branch-5.2 Windows binary.

## Summary by Sourcery

Keep httpcore2 package metadata in frozen builds to prevent MusicBrainz lookups from failing when clients are first constructed.

Bug Fixes:
- Preserve httpcore2 metadata in frozen builds so httpx2 client initialization no longer fails with PackageNotFoundError.

Build:
- Update the frozen-build metadata allowlist to retain both httpx2 and its transitive httpcore2 dependency metadata.