### PR TITLE
Document the Ogg requirement on the Icecast page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Discovery announcements are now broadcast on every network
     interface, fixing discovery on multi-NIC systems
 * Connection lifecycle hardening and greatly reduced debug-log volume
+* Many thanks to Nachtraaf for the assistance
 
 ### Icecast
 

--- a/docs/input/icecast.md
+++ b/docs/input/icecast.md
@@ -2,6 +2,8 @@
 
 [Icecast](https://icecast.org/) is a popular system to stream audio over the Internet.
 This page also covers **[MIXXX](#settings-for-mixxx)** and **[butt](#settings-for-butt)**.
+[Traktor](traktor.md) broadcasts over Icecast too, but has its own page because
+**What's Now Playing** reads Traktor's local database as well as the stream.
 
 > NOTE: This source does not support Oldest mix mode.
 
@@ -10,6 +12,24 @@ Icecast is best for:
 - Software without dedicated **What's Now Playing** support (like MIXXX)
 - Generic audio streaming applications (like butt)
 - Custom setups where other inputs don't work
+
+## Audio Format
+
+Set the broadcast format to **Ogg Vorbis** or **Ogg Opus**. Track data is read
+out of the tags carried inside the stream itself, and only Ogg carries them in
+a form **What's Now Playing** can read.
+
+MP3 and other formats still connect, but no track data comes from the audio.
+Metadata then arrives only if the broadcaster separately sends it, which not
+every application does. When the stream is not Ogg, the log says so once:
+
+```text
+icecast: stream carries no Ogg pages (MP3?); track data can only
+arrive via /admin/metadata updates from this source
+```
+
+The bitrate does not matter for metadata, so a low setting such as 32 kbps
+mono is enough if this stream is only feeding **What's Now Playing**.
 
 ## Instructions
 


### PR DESCRIPTION
The format requirement was only implicit in the per-client setup steps, so a DJ who picks MP3 gets the new "no Ogg pages" warning with nothing explaining it.  Also links to Traktor, which the page never mentioned despite being the source most of the recent Icecast work came from.

Picks up the pending Nachtraaf credit in the 5.2.3 Denon section.

## Summary by Sourcery

Clarify Icecast audio-format requirements and metadata behavior while improving related documentation credits and links.

Enhancements:
- Document the Ogg Vorbis/Opus format requirement and explain the metadata limitations of MP3 and other non-Ogg Icecast streams.
- Link the Icecast documentation to the Traktor page and clarify why Traktor has separate documentation.

Documentation:
- Expand the Icecast input documentation with audio-format guidance, metadata behavior, and bitrate recommendations.

Chores:
- Add the pending Nachtraaf credit to the 5.2.3 changelog.