### PR TITLE
Send the release track when fetching release notes

### DIFF
--- a/nowplaying/upgrade.py
+++ b/nowplaying/upgrade.py
@@ -32,12 +32,23 @@ from nowplaying.upgrades.templates import TemplateDirMigration
 class ReleaseNotesDialog(QDialog):  # pylint: disable=too-few-public-methods
     """Modal child dialog showing aggregated release notes since from_version."""
 
-    def __init__(self, newversion: str, from_version: str, parent: QWidget | None = None):
+    def __init__(
+        self,
+        newversion: str,
+        from_version: str,
+        parent: QWidget | None = None,
+        prefer_prerelease: bool = False,
+    ):
         super().__init__(parent)
         self.setWindowTitle(f"What's New in v{newversion}")
         self.resize(660, 540)
 
-        entries = nowplaying.upgrades.fetch_release_notes(from_version) or []
+        entries = (
+            nowplaying.upgrades.fetch_release_notes(
+                from_version, prefer_prerelease=prefer_prerelease
+            )
+            or []
+        )
 
         content = QWidget()
         clayout = QVBoxLayout(content)
@@ -203,7 +214,17 @@ class UpgradeDialog(QDialog):  # pylint: disable=too-few-public-methods
 
     def _show_release_notes(self) -> None:
         if self.newversion and self.oldversion:
-            ReleaseNotesDialog(self.newversion, self.oldversion, parent=self).exec_()
+            # Same setting check_for_update() used, so the notes cover the build
+            # actually being offered rather than only the stable ones.
+            prefer_prerelease = bool(
+                QSettings().value("upgrades/prefer_prerelease", defaultValue=False, type=bool)
+            )
+            ReleaseNotesDialog(
+                self.newversion,
+                self.oldversion,
+                parent=self,
+                prefer_prerelease=prefer_prerelease,
+            ).exec_()
 
     def _view_downloads(self) -> None:
         self.action = _UpgradeAction.VIEW_DOWNLOADS

--- a/nowplaying/upgrades/__init__.py
+++ b/nowplaying/upgrades/__init__.py
@@ -19,16 +19,34 @@ UPDATE_CHECK_URL = "https://whatsnowplaying.com/api/v1/check-version"
 RELEASE_NOTES_URL = "https://whatsnowplaying.com/api/v1/release-notes"
 
 
-def fetch_release_notes(from_version: str) -> list[dict] | None:
+def wants_prerelease(prefer_prerelease: bool = False) -> bool:
+    """Whether this install is on the prerelease track.
+
+    Someone already running a prerelease stays on it whatever the setting says;
+    the setting is how a stable user opts in.
+    """
+    return (
+        Version(nowplaying.version.__VERSION__).is_prerelease()  # pylint: disable=no-member
+        or prefer_prerelease
+    )
+
+
+def fetch_release_notes(from_version: str, prefer_prerelease: bool = False) -> list[dict] | None:
     """Fetch aggregated release notes since from_version from the WNP API.
 
     Returns a list of release entry dicts (version, date, is_prerelease, notes)
     ordered newest-first, or None on any error.
+
+    The track has to match the one check_for_update() asked with, or the notes
+    for the very build being offered are filtered out of the reply.
     """
+    params: dict[str, t.Any] = {"from_version": from_version}
+    if wants_prerelease(prefer_prerelease):
+        params["track"] = "prerelease"
     try:
         response = requests.get(
             RELEASE_NOTES_URL,
-            params={"from_version": from_version},
+            params=params,
             timeout=5,
         )
         response.raise_for_status()
@@ -194,7 +212,7 @@ def _build_version_params(
         params["chipset"] = chipset
     if macos_version := platform_info.get("macos_version"):
         params["macos_version"] = macos_version
-    if Version(current_version).is_prerelease() or prefer_prerelease:
+    if wants_prerelease(prefer_prerelease):
         params["track"] = "prerelease"
 
     return params


### PR DESCRIPTION
check_for_update() asks with track=prerelease but fetch_release_notes() did not, so a prerelease user was offered a build whose notes the API then filtered out of the reply.  The track decision moves into wants_prerelease() rather than being spelled out in both callers.

## Summary by Sourcery

Keep release-note retrieval aligned with the selected update track.

Bug Fixes:
- Ensure release notes are fetched for the same prerelease or stable track as the update being offered, so prerelease builds include their relevant notes.

Enhancements:
- Centralize prerelease-track selection so update checks and release-note requests use consistent behavior, including retaining prerelease status for existing prerelease installations.