### PR TITLE
Fit the settings window on a 1200x600 screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,35 @@ playing" information from various DJ software.
 
 - Qt6/PySide6 is used for the GUI framework
 - We control the UI files. No need for hasattr/getattr patterns.
+- **Never grow a `.ui` file's size without being asked, and check before you
+  assume you haven't.** WNP runs on small laptops and VMs — 1200x600 is a real
+  target. Adding widgets to a settings page raises that page's
+  `minimumSizeHint()`, and the settings dialog's minimum is the *tallest page
+  plus about 40px of shell*, so one page growing pushes the whole window past
+  the screen. The dialog also opens at the geometry in `settings.ui`, which is
+  a separate number from the minimum: if the default is larger than the
+  minimum, every user gets the larger window regardless. Measure both before
+  and after any UI edit:
+
+```bash
+QT_QPA_PLATFORM=offscreen python -c "
+import sys, pathlib
+from PySide6.QtWidgets import QApplication, QStackedWidget
+from PySide6.QtUiTools import QUiLoader
+app = QApplication(sys.argv); l = QUiLoader()
+shell = l.load('nowplaying/resources/ui/settings.ui')
+stack = shell.findChild(QStackedWidget, 'settings_stack')
+for f in sorted(pathlib.Path('nowplaying/resources/ui').glob('*.ui')):
+    if f.name != 'settings.ui' and (w := l.load(str(f))): stack.addWidget(w)
+print('minimum', shell.minimumSizeHint(), 'opens at', shell.size())
+"
+```
+
+- Prefer `QLabel` with `wordWrap` over `QTextBrowser` for static description
+  text. `QTextBrowser` reserves space for a scrollable document and costs
+  ~60px of minimum height per page even for one sentence. Long settings pages
+  that scroll are not an acceptable fix — split into tabs
+  (`TabGroup` in `nowplaying/settings/categories.py`) or reflow into columns.
 - Configuration uses Qt's QSettings with cross-platform support
 - **NEVER touch the user config from `nowplaying/__main__.py`, or from anything that
   runs before `nowplaying.upgrade.upgrade()` finishes.** `UpgradeConfig.upgrade()` does

--- a/nowplaying/resources/ui/general.ui
+++ b/nowplaying/resources/ui/general.ui
@@ -190,6 +190,9 @@
      </item>
      <item>
       <widget class="QComboBox" name="catrust_combobox">
+       <property name="toolTip">
+        <string>Automatic switches to the bundled certificates when this computer's own are too old to verify the sites What's Now Playing connects to. Takes effect after a restart.</string>
+       </property>
        <item>
         <property name="text">
          <string>Automatic</string>
@@ -221,16 +224,6 @@
       </spacer>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="catrust_help_label">
-     <property name="text">
-      <string>Automatic switches to the bundled certificates when this computer's own are too old to verify the sites What's Now Playing connects to. Takes effect after a restart.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QLabel" name="prerelease_label">
@@ -363,14 +356,26 @@
     </layout>
    </item>
    <item>
-    <widget class="QTextBrowser" name="config_warning_label">
+    <widget class="QLabel" name="config_warning_label">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
+       <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="html">
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <property name="margin">
+      <number>6</number>
+     </property>
+     <property name="text">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/nowplaying/resources/ui/settings.ui
+++ b/nowplaying/resources/ui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>840</width>
-    <height>580</height>
+    <height>540</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
The Certificate Trust control took general.ui from 509 to 592, and the dialog's minimum is the tallest page plus shell, so the window needed 633 -- more than such a screen can show.  The help sentence becomes the combo's tooltip and the export warning moves from QTextBrowser to a framed QLabel, which reserves no scroll viewport; general.ui is now 506.

The default geometry was also 580 against a 539 minimum, so it opened larger than it had to.  Minimum is now 570, opening at 540.

CLAUDE.md gains the measurement, since the default and the minimum are separate numbers and neither is obvious from the diff.

## Summary by Sourcery

Make the settings window fit small screens while preserving its existing content and behavior.

Bug Fixes:
- Reduce the settings window’s minimum and default sizes so it fits on 1200x600 displays.

Enhancements:
- Replace space-intensive static text controls with compact tooltips and framed labels.

Documentation:
- Document UI sizing measurements and guidance for avoiding unnecessary minimum-height increases.