### PR TITLE
Open settings at 540 high instead of 580

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,35 @@ playing" information from various DJ software.
 
 - Qt6/PySide6 is used for the GUI framework
 - We control the UI files. No need for hasattr/getattr patterns.
+- **Never grow a `.ui` file's size without being asked, and check before you
+  assume you haven't.** WNP runs on small laptops and VMs — 1200x600 is a real
+  target. Adding widgets to a settings page raises that page's
+  `minimumSizeHint()`, and the settings dialog's minimum is the *tallest page
+  plus about 40px of shell*, so one page growing pushes the whole window past
+  the screen. The dialog also opens at the geometry in `settings.ui`, which is
+  a separate number from the minimum: if the default is larger than the
+  minimum, every user gets the larger window regardless. Measure both before
+  and after any UI edit:
+
+```bash
+QT_QPA_PLATFORM=offscreen python -c "
+import sys, pathlib
+from PySide6.QtWidgets import QApplication, QStackedWidget
+from PySide6.QtUiTools import QUiLoader
+app = QApplication(sys.argv); l = QUiLoader()
+shell = l.load('nowplaying/resources/ui/settings.ui')
+stack = shell.findChild(QStackedWidget, 'settings_stack')
+for f in sorted(pathlib.Path('nowplaying/resources/ui').glob('*.ui')):
+    if f.name != 'settings.ui' and (w := l.load(str(f))): stack.addWidget(w)
+print('minimum', shell.minimumSizeHint(), 'opens at', shell.size())
+"
+```
+
+- Prefer `QLabel` with `wordWrap` over `QTextBrowser` for static description
+  text. `QTextBrowser` reserves space for a scrollable document and costs
+  ~60px of minimum height per page even for one sentence. Long settings pages
+  that scroll are not an acceptable fix — split into tabs
+  (`TabGroup` in `nowplaying/settings/categories.py`) or reflow into columns.
 - **Never import from conftest.py.** conftest.py is loaded automatically by pytest — importing
   from it creates circular dependencies and is a pytest anti-pattern. Put shared test utilities
   in `tests/utils_artistextras.py` or another utils module instead.

--- a/nowplaying/resources/ui/settings.ui
+++ b/nowplaying/resources/ui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>840</width>
-    <height>580</height>
+    <height>540</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
The dialog's minimum is 790x539 but it opened at 840x580, so on a 1200x600 screen it appeared taller than the space available even though it could already have fitted.  540 is the tightest legal default.

Adds a CLAUDE.md rule with the measurement, since the default and the minimum are separate numbers and only the minimum is obvious from the code.

## Summary by Sourcery

Set a compact default settings-dialog height and document UI sizing practices for small screens.

Bug Fixes:
- Reduce the settings dialog’s default height so it fits available space on 1200x600 displays while remaining above its minimum size.

Enhancements:
- Document UI sizing constraints and measurement guidance, including the cost of scrollable static text and preferred layout approaches.