### PR TITLE
Handle busy Icecast ports and explain the OBS export

### DIFF
--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -516,6 +516,25 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes, too-many-publ
         inputplugin = self.plugins["inputs"][f"nowplaying.inputs.{plugin}"].Plugin(config=self)
         return inputplugin.getmixmode()
 
+    def input_required_port(self) -> int | None:
+        """The port the configured input has to bind, or None.
+
+        Tolerant of an absent or unknown source, unlike its neighbours here:
+        this runs on the startup path, where the value has not been validated
+        yet and no answer is a fine answer.
+        """
+        plugin = self.cparser.value("settings/input", defaultValue=None)
+        if not plugin:
+            return None
+        module = self.plugins["inputs"].get(f"nowplaying.inputs.{plugin}")
+        if not module:
+            return None
+        try:
+            return module.Plugin(config=self).required_port()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("could not ask %s for its port", plugin)
+            return None
+
     @staticmethod
     def getbundledir() -> pathlib.Path | None:
         """get the bundle dir"""

--- a/nowplaying/inputs/__init__.py
+++ b/nowplaying/inputs/__init__.py
@@ -58,6 +58,15 @@ class InputPlugin(WNPBasePlugin):
         super().__init__(config=config, qsettings=qsettings)
         self.plugintype: str = "input"
 
+    def required_port(self) -> int | None:  # pylint: disable=no-self-use
+        """The TCP port this input has to bind, or None if it binds nothing.
+
+        Reported so the main process can check the port before starting
+        trackpoll, which is where the bind actually happens. Most inputs read a
+        file or a database and have no answer here.
+        """
+        return None
+
     #### Additional UI method
 
     def desc_settingsui(self, qwidget: "QWidget") -> None:  # pylint: disable=no-self-use

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
     QFormLayout,
+    QLabel,
     QVBoxLayout,
     QWidget,
 )
@@ -455,13 +456,27 @@ class _IcecastWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
             config.cparser.value("icecast/port", type=str, defaultValue="8000")
         )
 
+        self._busy_note = QLabel()
+        self._busy_note.setWordWrap(True)
+        self._busy_note.setVisible(False)
+
         form = QFormLayout()
         form.addRow("Icecast port:", self._port_edit)
 
         layout = QVBoxLayout()
         layout.addLayout(form)
+        layout.addWidget(self._busy_note)
         layout.addStretch()
         self.setLayout(layout)
+
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Move off a port something else already holds.
+
+        Checked on show rather than in __init__ so it reflects what is running
+        now. A busy port is silent otherwise: the listener logs the failed bind
+        and carries on, so verification just never sees a track.
+        """
+        self.retune_port_once(self._port_edit, self._busy_note, "8000")
 
     def collected(self) -> dict[str, object]:
         """The port the broadcaster will connect to."""
@@ -565,6 +580,16 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         """give back the current metadata"""
         await self._restart_if_port_changed()
         return self._current_metadata.copy()  # type: ignore
+
+    def required_port(self) -> int | None:
+        """The SOURCE port the broadcaster connects to.
+
+        Subclasses set _port_config_key, so Traktor answers with its own port.
+        """
+        if not self.config:
+            return None
+        port: int = self.config.cparser.value(self._port_config_key, type=int, defaultValue=8000)
+        return port
 
     async def start(self) -> None:
         """any initialization before actual polling starts"""

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import aiosqlite  # pylint: disable=import-error
 from PySide6.QtCore import QStandardPaths  # pylint: disable=import-error, no-name-in-module
 from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-module
+    QFormLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
@@ -154,17 +155,38 @@ class _TraktorWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
             startdir=config.userdocs.joinpath("Native Instruments"),
         )
 
+        self._port_edit = nowplaying.wizard.WizardPage.port_edit("8000")
+        self._port_edit.setText(
+            str(config.cparser.value("traktor/port", type=str, defaultValue="8000"))
+        )
+        self._port_edit.textChanged.connect(self._refresh_prompt)
+
+        self._busy_note = QLabel()
+        self._busy_note.setWordWrap(True)
+        self._busy_note.setVisible(False)
+
+        form = QFormLayout()
+        form.addRow("Broadcast port:", self._port_edit)
+
         layout = QVBoxLayout()
         layout.addWidget(QLabel("Collection file (collection.nml):"))
         layout.addWidget(self._path_edit)
+        layout.addLayout(form)
+        layout.addWidget(self._busy_note)
         layout.addStretch()
         self.setLayout(layout)
 
         self._path_edit.setText(str(config.cparser.value("traktor/collections", defaultValue="")))
+        self._refresh_prompt()
 
-        # Set here rather than as a class attribute so the real port can be
-        # named; this page has no port field of its own to point at.
-        port = config.cparser.value("traktor/port", type=str, defaultValue="8000")
+    def initializePage(self) -> None:  # pylint: disable=invalid-name
+        """Move off a busy port before telling the user which one to broadcast to."""
+        self.retune_port_once(self._port_edit, self._busy_note, "8000")
+        self._refresh_prompt()
+
+    def _refresh_prompt(self) -> None:
+        """Keep the instructions naming the port actually being listened on."""
+        port = self._port_edit.text().strip() or "8000"
         self.verification_prompt = (
             "Traktor sends tracks over Icecast, not through the collection file. "
             "In Traktor, open Preferences → Broadcasting, set the server to "
@@ -172,8 +194,11 @@ class _TraktorWizardPage(nowplaying.wizard.WizardPage):  # pylint: disable=too-f
         )
 
     def collected(self) -> dict[str, object]:
-        """The collection path the user pointed at."""
-        return {"traktor/collections": self._path_edit.text().strip()}
+        """The collection path and the port Traktor will broadcast to."""
+        return {
+            "traktor/collections": self._path_edit.text().strip(),
+            "traktor/port": self._port_edit.text().strip() or "8000",
+        }
 
 
 class Plugin(IcecastPlugin):  # pylint: disable=too-many-instance-attributes

--- a/nowplaying/obs/exportdialog.py
+++ b/nowplaying/obs/exportdialog.py
@@ -52,7 +52,10 @@ class OBSExportDialog(QDialog):  # pylint: disable=too-few-public-methods,too-ma
         self._preview_row: int = -1
         self._templates: list[tuple[str, str]] = self._load_templates()
         self.setWindowTitle("Export for OBS")
-        self.resize(980, 300)
+        # 300 before the intro. 360 is where the longest variant of it stops
+        # needing a scrollbar (sizeHint 356) and no further: the table does not
+        # stretch, so anything above that is dead space under the last row.
+        self.resize(980, 360)
         self._setup_ui()
         self._populate_table()
 
@@ -79,8 +82,41 @@ class OBSExportDialog(QDialog):  # pylint: disable=too-few-public-methods,too-ma
                 entries.append((stem_to_label.get(tmpl.stem, name), name))
         return entries
 
+    _INTRO = (
+        "What's Now Playing can write an OBS scene collection with the track display "
+        "already sized and positioned as a browser source. Nothing is written until "
+        "you pick your sources and press Export.\n\n"
+        "Quit OBS first. OBS rewrites its scene collections when it closes, so "
+        "anything exported while it is running is lost."
+    )
+
+    # Only worth saying to someone who did not come from that menu item.
+    _INTRO_FROM_SETUP = (
+        "\n\nYou can come back to this at any time from Export for OBS in the tray menu."
+    )
+
+    def set_opened_from_setup(self, from_setup: bool) -> None:
+        """Adjust the intro for how the dialog was reached.
+
+        Per showing rather than per construction: the tray keeps one instance and
+        reuses it, so a flag fixed at build time would be wrong on every later
+        open.
+        """
+        self._intro_label.setText(self._INTRO + (self._INTRO_FROM_SETUP if from_setup else ""))
+        # Refreshed here too, since whether OBS is running can change between
+        # showings of the same dialog.
+        self.status_label.setText(
+            "OBS is running right now, so exporting will not work until you quit it."
+            if self._obs_is_running()
+            else ""
+        )
+
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
+
+        self._intro_label = QLabel(self._INTRO)
+        self._intro_label.setWordWrap(True)
+        layout.addWidget(self._intro_label)
 
         self.table = QTableWidget(0, 7)
         self.table.setHorizontalHeaderLabels(
@@ -266,8 +302,8 @@ class OBSExportDialog(QDialog):  # pylint: disable=too-few-public-methods,too-ma
         """Collect checked rows and call scenebuilder.build_and_save."""
         if self._obs_is_running():
             self.status_label.setText(
-                "OBS is running — please quit OBS before exporting, "
-                "then relaunch it to load the new scene collection."
+                "OBS is running. Quit OBS before exporting, then relaunch it to "
+                "load the new scene collection."
             )
             return
 

--- a/nowplaying/subprocesses.py
+++ b/nowplaying/subprocesses.py
@@ -5,7 +5,6 @@ import concurrent.futures
 import importlib
 import logging
 import multiprocessing
-import socket
 import typing as t
 
 from PySide6.QtCore import Qt  # pylint: disable=import-error,no-name-in-module
@@ -16,6 +15,7 @@ from PySide6.QtWidgets import (  # pylint: disable=import-error,no-name-in-modul
 
 import nowplaying
 import nowplaying.config
+import nowplaying.utils.network
 
 PROCESS_NAMES: list[str] = [
     "trackpoll",
@@ -160,12 +160,7 @@ class SubprocessManager:
     @staticmethod
     def _check_port_available(host: str, port: int) -> bool:
         """Check if a port is available for binding"""
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.bind((host, port))
-                return True
-        except OSError:
-            return False
+        return nowplaying.utils.network.port_available(port, host)
 
     def start_process(self, processname: str) -> None:
         """Start a specific process"""
@@ -196,21 +191,50 @@ class SubprocessManager:
             port = self.config.cparser.value("weboutput/httpport", type=int, defaultValue=8899)
             if not self._check_port_available(host, port):
                 logging.error("Cannot start webserver: port %s:%s is already in use", host, port)
-                dialog = QMessageBox(
-                    QMessageBox.Critical,
+                self._port_busy_dialog(
                     "Web Server Error",
                     f"Cannot start web server:\nPort {host}:{port} is already in use.\n\n"
                     f"Please close any application using this port or change the port in "
                     f"Settings → Web Server.",
-                    QMessageBox.Ok,
-                    QApplication.activeWindow(),
                 )
-                dialog.setWindowFlags(dialog.windowFlags() | Qt.WindowStaysOnTopHint)
-                dialog.exec()
                 return
+
+        # Icecast and Traktor bind inside trackpoll, which cannot raise a dialog
+        # from a subprocess, and start_port() only logs a failed bind. Warn here
+        # and start anyway: the source is unusable but the rest of WNP is not.
+        if processname == "trackpoll" and not self.testmode:
+            self._warn_if_input_port_busy()
 
         # trackpoll always starts - it's the core monitoring process
         self._start_process(processname)
+
+    def _warn_if_input_port_busy(self) -> None:
+        """Say so when the configured input cannot bind the port it needs."""
+        if not self.config:
+            return
+        port = self.config.input_required_port()
+        if port is None or nowplaying.utils.network.port_available(port):
+            return
+        logging.error("input source cannot bind port %s; it is already in use", port)
+        self._port_busy_dialog(
+            "Track Source Error",
+            f"Nothing can be received on port {port}: it is already in use by "
+            f"another application.\n\nClose that application, or set a different "
+            f"port in Settings under Input Source and in your DJ software.",
+        )
+
+    @staticmethod
+    def _port_busy_dialog(title: str, text: str) -> None:
+        """Blocking, always on top: a port conflict is worth interrupting startup for."""
+        dialog = QMessageBox(
+            QMessageBox.Critical,
+            title,
+            text,
+            QMessageBox.Ok,
+            QApplication.activeWindow(),
+        )
+        dialog.setWindowFlags(dialog.windowFlags() | Qt.WindowStaysOnTopHint)
+        dialog.exec()
 
     def stop_process(self, processname: str) -> None:
         """Stop a specific process"""

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -227,13 +227,19 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             self._show_installation_error("settings UI files")
             self.settingswindow = None
 
-    def _show_obs_export(self) -> None:
+    def _show_obs_export(self, from_setup: bool = False) -> None:
         """Open the OBS scene export dialog (non-modal)."""
         if self._obs_export_dialog is None:
             self._obs_export_dialog = nowplaying.obs.exportdialog.OBSExportDialog(
                 config=self.config
             )
+        self._obs_export_dialog.set_opened_from_setup(from_setup)
         nowplaying.utils.qt.focus_window(self._obs_export_dialog)
+
+    def _show_obs_export_from_menu(self) -> None:
+        """Tray menu route. Named rather than connected directly, because
+        QAction.triggered would otherwise pass its checked flag as from_setup."""
+        self._show_obs_export(from_setup=False)
 
     def _show_settings(self) -> None:
         """Show settings window and bring it to the front."""
@@ -264,7 +270,7 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.menu.addAction(self.settings_action)
 
         self.obs_export_action = QAction("Export for OBS...")
-        self.obs_export_action.triggered.connect(self._show_obs_export)
+        self.obs_export_action.triggered.connect(self._show_obs_export_from_menu)
         self.menu.addAction(self.obs_export_action)
 
         self.request_action = QAction("Requests")
@@ -398,9 +404,22 @@ class Tray:  # pylint: disable=too-many-instance-attributes
             return
         self.config.cparser.remove("settings/pending_obs_export")
         if nowplaying.obs.scenebuilder.get_obs_scenes_dir() is None:
-            logging.debug("no OBS scenes directory; skipping the export offer")
+            # Setup was asked for this, so say why it is not happening rather
+            # than drop it into the log.
+            logging.debug("no OBS scenes directory; telling the user instead")
+            dialog = QMessageBox(
+                QMessageBox.Information,
+                "Set Up OBS",
+                "OBS Studio was not found on this computer, so there is no scene "
+                "collection to write to.\n\nInstall OBS, then use Export for OBS "
+                "in the tray menu.",
+                QMessageBox.Ok,
+                QApplication.activeWindow(),
+            )
+            dialog.setWindowFlags(dialog.windowFlags() | Qt.WindowStaysOnTopHint)
+            dialog.exec()
             return
-        self._show_obs_export()
+        self._show_obs_export(from_setup=True)
 
     def _on_oauth_poller_finished(self) -> None:
         """Drop our reference to the OAuth poller thread once it finishes."""

--- a/nowplaying/utils/network.py
+++ b/nowplaying/utils/network.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Port availability checks."""
+
+import logging
+import socket
+
+# Enough to clear a run of neighbours on the same base port without wandering
+# far from the number the user was told to enter in their DJ software.
+_SEARCH_RANGE = 20
+
+
+def port_available(port: int, host: str = "") -> bool:
+    """Whether a TCP listener can bind this port right now.
+
+    An empty host binds every interface, which is what the Icecast listener and
+    the web server both do, so a port free only on loopback is still reported
+    busy. Advisory either way: the answer can be stale by the time a caller
+    acts on it.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind((host, port))
+            return True
+    except OSError:
+        return False
+
+
+def first_free_port(start: int, host: str = "", limit: int = _SEARCH_RANGE) -> int | None:
+    """Return the first bindable port at or above start, or None.
+
+    Counts up rather than picking at random: whoever set this has to type the
+    number into another application, so staying near the one they expected is
+    worth more than spreading the choice out.
+    """
+    for port in range(start, start + limit):
+        if port_available(port, host):
+            return port
+    logging.warning("no free port in %s-%s", start, start + limit - 1)
+    return None

--- a/nowplaying/wizard/page.py
+++ b/nowplaying/wizard/page.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
 )
 
 import nowplaying.uihelp
+import nowplaying.utils.network
 from nowplaying.wizard.verify import (
     POLL_TIMEOUT,
     START_TIMEOUT,
@@ -110,6 +111,41 @@ class WizardPage(QWizardPage):  # pylint: disable=too-few-public-methods
         edit.setMaximumWidth(width)
         edit.setValidator(QIntValidator(1, 65535))
         return edit
+
+    # Retuning happens once per page, not on every showing. Verification binds
+    # the port itself and its teardown is not awaited, so a second look can find
+    # our own closing listener and move the user off a port that was fine.
+    _port_retuned: bool = False
+
+    def retune_port_once(self, edit: QLineEdit, note: QLabel, fallback: str) -> None:
+        """Move a port field off a port something else is already holding.
+
+        Says which port it moved to and why, because the number has to be typed
+        into the DJ software by hand, so silently changing it would send the user
+        to a listener that is not there.
+        """
+        if self._port_retuned:
+            return
+        self._port_retuned = True
+
+        current = edit.text().strip() or fallback
+        if not current.isdigit() or nowplaying.utils.network.port_available(int(current)):
+            note.setVisible(False)
+            return
+
+        free = nowplaying.utils.network.first_free_port(int(current) + 1)
+        if free is None:
+            note.setText(
+                f"Port {current} is in use and nothing nearby is free. Enter a "
+                f"port yourself, and use the same one in your DJ software."
+            )
+        else:
+            edit.setText(str(free))
+            note.setText(
+                f"Port {current} is already in use on this computer, so this is "
+                f"set to {free}. Use {free} in your DJ software."
+            )
+        note.setVisible(True)
 
     # Set by the host wizard when it registers the page, for flows that need to
     # leave the declared page order -- the multi-PC DJ role skips the output


### PR DESCRIPTION
Port 8000 is a common conflict and the failure was silent: start_port() logs the failed bind and returns, so verification just never saw a track. Setup now checks on page show, moves to the next free port and names it in the instructions, and Traktor gained the port field it never had, so a conflict no longer leaves the wizard with no way out. At launch the main process checks before starting trackpoll and says which port, since the bind happens in a subprocess that cannot raise a dialog.

Retuning runs once per page. Verification binds the port itself and its teardown is not awaited, so a second look could find our own listener and move the user off a port that was fine.

The OBS export dialog opened straight onto a seven-column table, both from the tray menu and unannounced after setup. It now says what the export does, that nothing is written until Export is pressed, and to quit OBS first. The tray-menu sentence is set per showing, since one instance is reused and pointing someone at the menu item they just used reads badly. Asking for the export with no OBS installed now says so.

## Summary by Sourcery

Handle input port conflicts visibly and make the OBS export workflow clearer.

New Features:
- Detect and report busy input ports at startup, automatically select nearby free ports during setup, and expose the configured broadcast port for Traktor.
- Add explanatory guidance to the OBS export dialog, including export timing, OBS shutdown requirements, setup-origin context, and missing-OBS feedback.

Bug Fixes:
- Prevent silent Icecast and Traktor port conflicts from leaving verification or startup without a usable track source.
- Avoid retuning a port repeatedly when wizard pages are revisited.
- Refresh OBS export messaging correctly when a reused dialog is opened through different entry points.

Enhancements:
- Centralize TCP port availability and nearby free-port discovery for wizard and subprocess startup checks.