### PR TITLE
Rebuild a datacache session that went away mid-fetch

### DIFF
--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -118,6 +118,21 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
             )
             self._initialized = True
 
+    async def _ensure_session(self) -> "httpx2.AsyncClient | None":
+        """Return a usable session, rebuilding it if it has gone.
+
+        A fetch can get past the guard in _fetch_and_store and still find the
+        session missing: reset_client() drops a live one during test teardown,
+        and initialize() and close() can interleave. Rebuilding here rather than
+        letting the AttributeError fall into the network-retry path, which spent
+        the backoff on an error waiting could not fix and read as a connection
+        failure in the log. The rate limit token for this request is already
+        spent either way -- the bucket has no way to give one back.
+        """
+        if self._session is None:
+            await self.initialize()
+        return self._session
+
     async def close(self) -> None:
         """Close the client and cleanup resources"""
         self._initialized = False
@@ -292,7 +307,7 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
         logging.warning("Rate limited by %s on final attempt, cooldown %ds", provider, retry_after)
         return False
 
-    async def _fetch_with_retry(  # pylint: disable=too-many-arguments
+    async def _fetch_with_retry(  # pylint: disable=too-many-arguments,too-many-locals
         self,
         url: str,
         provider: str,
@@ -310,8 +325,12 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
         """
         last_result = FetchResult()
         for attempt in range(retries + 1):
+            session = await self._ensure_session()
+            if session is None:
+                logging.error("no HTTP session for %s", self._redact_url(url))
+                return FetchResult(terminal=True)
             try:
-                async with self._session.stream(  # type: ignore[union-attr]
+                async with session.stream(
                     "GET", url, timeout=httpx2.Timeout(timeout), headers=headers
                 ) as response:
                     if response.status_code == 200:

--- a/nowplaying/datacache/client.py
+++ b/nowplaying/datacache/client.py
@@ -130,7 +130,15 @@ class DataCacheClient:  # pylint: disable=too-many-instance-attributes
         spent either way -- the bucket has no way to give one back.
         """
         if self._session is None:
-            await self.initialize()
+            try:
+                await self.initialize()
+            except Exception:  # pylint: disable=broad-except
+                # Returned rather than raised: the caller turns None into a
+                # terminal FetchResult, and an exception here would escape
+                # _fetch_with_retry entirely, since this runs outside its try.
+                # Artist extras must degrade rather than raise mid-set.
+                logging.exception("could not rebuild the HTTP session")
+                return None
         return self._session
 
     async def close(self) -> None:

--- a/tests/datacache/test_client.py
+++ b/tests/datacache/test_client.py
@@ -688,3 +688,30 @@ async def test_fetch_gives_up_when_the_session_cannot_be_rebuilt(temp_client):  
     assert not result.ok
     assert result.terminal, "must be terminal so callers do not treat it as retryable"
     assert ensure.await_count == 1, "one look, not one per retry"
+
+
+@pytest.mark.asyncio
+async def test_fetch_survives_a_failed_session_rebuild(temp_client):  # pylint: disable=redefined-outer-name
+    """A rebuild that itself fails must not raise out of the fetch.
+
+    _ensure_session() runs outside the retry loop's try, so an exception from
+    initialize() would escape _fetch_with_retry and reach the artist extras
+    plugins, which have to degrade rather than raise during a set.
+    """
+    temp_client._session = None  # pylint: disable=protected-access
+    temp_client._initialized = False  # pylint: disable=protected-access
+
+    with unittest.mock.patch.object(
+        temp_client, "initialize", side_effect=RuntimeError("no ssl context for you")
+    ):
+        result = await temp_client._fetch_with_retry(  # pylint: disable=protected-access
+            url="https://api.example.com/broken.json",
+            provider="test",
+            timeout=30.0,
+            retries=3,
+            headers=None,
+            rate_limiter=temp_client.rate_limiters.get_limiter("test"),
+        )
+
+    assert not result.ok
+    assert result.terminal, "a failed rebuild is not worth retrying"

--- a/tests/datacache/test_client.py
+++ b/tests/datacache/test_client.py
@@ -636,3 +636,55 @@ async def test_negative_ttl_caches_404_and_suppresses_retry(
         )
         assert result2 is None, "negative cache hit should suppress retry and return None"
         assert call_count == 1, "fetch_func must NOT be called again on negative cache hit"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rebuilds_a_session_that_went_away(temp_client):  # pylint: disable=redefined-outer-name
+    """A session dropped mid-flight must be rebuilt, not retried against.
+
+    reset_client() nulls a live session during test teardown, so a fetch already
+    past the guard in _fetch_and_store can find it gone. Retrying an
+    AttributeError spends the backoff on something waiting cannot fix, and the
+    rate limit token for the request is already gone: the bucket has no release.
+    """
+    test_data = {"recovered": True}
+
+    with respx.mock(using="httpcore2") as mock_responses:
+        mock_responses.get("https://api.example.com/dropped.json").mock(
+            return_value=httpx.Response(
+                200, json=test_data, headers={"content-type": "application/json"}
+            )
+        )
+
+        temp_client._session = None  # pylint: disable=protected-access
+        temp_client._initialized = False  # pylint: disable=protected-access
+
+        result = await temp_client._fetch_with_retry(  # pylint: disable=protected-access
+            url="https://api.example.com/dropped.json",
+            provider="test",
+            timeout=30.0,
+            retries=0,  # no retry budget, so recovery cannot come from a second attempt
+            headers=None,
+            rate_limiter=temp_client.rate_limiters.get_limiter("test"),
+        )
+
+        assert result.ok, "a dropped session should be rebuilt on the first attempt"
+        assert orjson.loads(result.data) == test_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_gives_up_when_the_session_cannot_be_rebuilt(temp_client):  # pylint: disable=redefined-outer-name
+    """With no session obtainable, stop rather than burn the retry budget."""
+    with unittest.mock.patch.object(temp_client, "_ensure_session", return_value=None) as ensure:
+        result = await temp_client._fetch_with_retry(  # pylint: disable=protected-access
+            url="https://api.example.com/never.json",
+            provider="test",
+            timeout=30.0,
+            retries=3,
+            headers=None,
+            rate_limiter=temp_client.rate_limiters.get_limiter("test"),
+        )
+
+    assert not result.ok
+    assert result.terminal, "must be terminal so callers do not treat it as retryable"
+    assert ensure.await_count == 1, "one look, not one per retry"


### PR DESCRIPTION
reset_client() drops a live session so Windows does not warn about unclosed transports, and initialize() and close() can interleave, so a fetch already past the guard in _fetch_and_store could find it gone. The resulting AttributeError fell into the network-retry path: two ERROR lines reading like a connection failure, backoff spent on something waiting could not fix, and recovery only if another coroutine happened to re-initialize.

The rate limit token is the part that costs. It is taken before the retry loop and the bucket has no release, so a request that never goes out spends one anyway. CI showed theaudiodb doing this at 0.0 remaining.

_ensure_session() rebuilds instead, and gives up terminally when it cannot, so the retry budget is not spent on a missing session. The entry guard in _fetch_and_store still raises for a deliberate fetch after close.

## Summary by Sourcery

Make datacache fetches recover safely when their HTTP session disappears mid-request.

Bug Fixes:
- Rebuild missing HTTP sessions during in-flight fetches instead of treating the missing session as a retryable network failure.
- Return terminal fetch failures when a session cannot be rebuilt, preventing futile retries and unhandled exceptions.

Enhancements:
- Add coverage for session recovery, unrecoverable rebuilds, and graceful degradation when session initialization fails.

Tests:
- Add tests covering dropped-session recovery and terminal handling of failed session reconstruction.