### PR TITLE
Space same-service live tests apart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ testpaths = ["tests-qt", "tests"]
 markers = [
   "serato3settings: custom settings for older serato",
   "templatesettings: custom settings for templates",
-  "live: tests that hit real external network hosts (may be slow or flaky in CI)",
+  "live(*providers): hits real external hosts, named so conftest can space same-service tests apart",
 ]
 qt_api = "pyside6"
 #log_cli = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,3 +84,59 @@ async def isolated_datacache_client():
                 yield client
             finally:
                 await client.close()
+
+
+def _providers(item) -> frozenset[str]:
+    """Services a live test talks to, from @pytest.mark.live("discogs", ...)."""
+    marker = item.get_closest_marker("live")
+    return frozenset(marker.args) if marker else frozenset()
+
+
+def _spread_by_provider(live: list) -> list:
+    """Order live tests so neighbours share no service.
+
+    Greedy rather than exact: at each step take the waiting test whose services
+    were used longest ago. Good enough, and it keeps the artist extras tests
+    that touch four providers at once away from the single-provider ones.
+    """
+    remaining = list(live)
+    last_used: dict[str, int] = {}
+    out: list = []
+    while remaining:
+        # Highest "staleness" first: the further back a test's services were
+        # touched, the safer it is to run now.
+        best = max(
+            remaining,
+            key=lambda item: min(
+                (len(out) - last_used.get(name, -len(live)) for name in _providers(item)),
+                default=len(out),
+            ),
+        )
+        remaining.remove(best)
+        for name in _providers(best):
+            last_used[name] = len(out)
+        out.append(best)
+    return out
+
+
+def pytest_collection_modifyitems(session, config, items):  # pylint: disable=unused-argument
+    """Reorder the live-API tests so consecutive ones hit different services.
+
+    Each live test builds its own client and wnpmb's adaptive pacing lives on
+    the instance, so a file's worth of them arrives at one service with no
+    spacing at all. Running them round-robin across providers gives each one
+    roughly as many test-lengths of breathing room as there are providers.
+
+    Only the live tests move, and only into slots live tests already occupied,
+    so nothing else is reordered. That matters twice over: tests-qt has to stay
+    first because qtbot must initialize before anything starts asyncio or
+    threads, and tests/webserver's module-scoped fixture starts a real server
+    that must not be torn down mid-module. This hook is handed every collected
+    item, not just this directory's, so neither can be assumed.
+    """
+    slots = [i for i, item in enumerate(items) if item.get_closest_marker("live")]
+    if len(slots) < 2:
+        return
+    ordered = _spread_by_provider([items[i] for i in slots])
+    for slot, item in zip(slots, ordered, strict=True):
+        items[slot] = item

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,23 @@ def _spread_by_provider(live: list) -> list:
     return out
 
 
+def _splittable(item) -> bool:
+    """Whether moving items around this one can be done without cost.
+
+    False when the item uses a module- or class-scoped fixture: separating it
+    from its neighbours makes pytest tear that fixture down and rebuild it, and
+    tests/webserver's builds a real server on a real port.
+    """
+    info = getattr(item, "_fixtureinfo", None)
+    if info is None:
+        return True
+    return not any(
+        str(getattr(fixturedef, "scope", "")) in {"module", "class"}
+        for defs in getattr(info, "name2fixturedefs", {}).values()
+        for fixturedef in defs
+    )
+
+
 def pytest_collection_modifyitems(session, config, items):  # pylint: disable=unused-argument
     """Reorder the live-API tests so consecutive ones hit different services.
 
@@ -127,14 +144,21 @@ def pytest_collection_modifyitems(session, config, items):  # pylint: disable=un
     spacing at all. Running them round-robin across providers gives each one
     roughly as many test-lengths of breathing room as there are providers.
 
-    Only the live tests move, and only into slots live tests already occupied,
-    so nothing else is reordered. That matters twice over: tests-qt has to stay
-    first because qtbot must initialize before anything starts asyncio or
-    threads, and tests/webserver's module-scoped fixture starts a real server
-    that must not be torn down mid-module. This hook is handed every collected
-    item, not just this directory's, so neither can be assumed.
+    Live tests only ever land in slots live tests already held, so nothing else
+    is reordered and tests-qt stays first -- qtbot has to initialize before
+    anything starts asyncio or threads, which is what testpaths orders. This
+    hook is handed every collected item, not just this directory's, so that
+    cannot be assumed.
+
+    A slot is skipped when the item there, or the one being moved, uses a
+    module- or class-scoped fixture. Swapping across modules does separate a
+    module's items, and doing that to a shared fixture would rebuild it
+    mid-run. Reordering only within each module would be a no-op instead: every
+    module's live tests name the same provider.
     """
-    slots = [i for i, item in enumerate(items) if item.get_closest_marker("live")]
+    slots = [
+        i for i, item in enumerate(items) if item.get_closest_marker("live") and _splittable(item)
+    ]
     if len(slots) < 2:
         return
     ordered = _spread_by_provider([items[i] for i in slots])

--- a/tests/datacache/test_integration.py
+++ b/tests/datacache/test_integration.py
@@ -452,7 +452,7 @@ async def test_random_image_bytes_returns_none_when_nothing_cached(  # pylint: d
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.live
+@pytest.mark.live("theaudiodb")
 @pytest.mark.asyncio
 async def test_live_immediate_fetch(bootstrap):  # pylint: disable=unused-argument,redefined-outer-name
     """Immediate fetch of a real image URL returns bytes and caches them"""
@@ -487,7 +487,7 @@ async def test_live_immediate_fetch(bootstrap):  # pylint: disable=unused-argume
     assert result2.data == result.data
 
 
-@pytest.mark.live
+@pytest.mark.live("theaudiodb")
 @pytest.mark.asyncio
 async def test_live_queue_and_random_image_bytes(bootstrap):  # pylint: disable=unused-argument,redefined-outer-name
     """get_or_fetch(immediate=False) + process_queue → get_random_image returns bytes"""

--- a/tests/test_acoustidmb.py
+++ b/tests/test_acoustidmb.py
@@ -22,6 +22,7 @@ def getacoustidplugin(bootstrap):
     yield nowplaying.recognition.acoustid.Plugin(config=config)
 
 
+@pytest.mark.live("acoustid", "musicbrainz")
 @pytest.mark.asyncio
 async def test_15ghosts2_orig(getacoustidplugin, getroot):  # pylint: disable=redefined-outer-name
     """automated integration test"""
@@ -38,6 +39,7 @@ async def test_15ghosts2_orig(getacoustidplugin, getroot):  # pylint: disable=re
     assert metadata["title"] == "15 Ghosts II"
 
 
+@pytest.mark.live("acoustid", "musicbrainz")
 @pytest.mark.asyncio
 async def test_15ghosts2_fullytagged(getacoustidplugin, getroot):  # pylint: disable=redefined-outer-name
     """automated integration test"""

--- a/tests/test_artistextras_core.py
+++ b/tests/test_artistextras_core.py
@@ -43,7 +43,6 @@ def getconfiguredplugin(bootstrap):
     yield configureplugins(config)
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_disabled(bootstrap):
     """test disabled"""
@@ -63,7 +62,6 @@ def test_providerinfo(bootstrap):  # pylint: disable=redefined-outer-name
         assert data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_noapikey(bootstrap):  # pylint: disable=redefined-outer-name
     """test disabled"""
@@ -76,7 +74,6 @@ async def test_noapikey(bootstrap):  # pylint: disable=redefined-outer-name
         assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_nodata(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """test disabled"""
@@ -87,7 +84,7 @@ async def test_nodata(getconfiguredplugin):  # pylint: disable=redefined-outer-n
         assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_noimagecache(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """noimagecache"""
@@ -109,7 +106,6 @@ async def test_noimagecache(getconfiguredplugin):  # pylint: disable=redefined-o
             assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_missingallartistdata(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """missing all artist data"""
@@ -121,7 +117,7 @@ async def test_missingallartistdata(getconfiguredplugin):  # pylint: disable=red
         assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_missingmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """artist"""
@@ -151,7 +147,7 @@ async def test_missingmbid(getconfiguredplugin):  # pylint: disable=redefined-ou
             assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_featuring1(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """artist"""
@@ -190,7 +186,7 @@ async def test_featuring1(getconfiguredplugin):  # pylint: disable=redefined-out
             )
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_featuring2(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """artist"""
@@ -214,7 +210,7 @@ async def test_featuring2(getconfiguredplugin):  # pylint: disable=redefined-out
             )
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_badmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -232,7 +228,7 @@ async def test_badmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-
         assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_onlymbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -248,7 +244,7 @@ async def test_onlymbid(getconfiguredplugin):  # pylint: disable=redefined-outer
         assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_artist_and_mbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -283,7 +279,7 @@ async def test_artist_and_mbid(getconfiguredplugin):  # pylint: disable=redefine
             assert not data
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_all(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -315,7 +311,7 @@ async def test_all(getconfiguredplugin):  # pylint: disable=redefined-outer-name
             )
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.xfail(reason="Non-deterministic at the moment")
 @pytest.mark.asyncio
 async def test_theall(getconfiguredplugin):  # pylint: disable=redefined-outer-name
@@ -351,7 +347,7 @@ async def test_theall(getconfiguredplugin):  # pylint: disable=redefined-outer-n
         )
 
 
-@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
+@pytest.mark.live(*PLUGINS)
 @pytest.mark.asyncio
 async def test_notfound(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """discogs"""

--- a/tests/test_artistextras_core.py
+++ b/tests/test_artistextras_core.py
@@ -43,6 +43,7 @@ def getconfiguredplugin(bootstrap):
     yield configureplugins(config)
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_disabled(bootstrap):
     """test disabled"""
@@ -62,6 +63,7 @@ def test_providerinfo(bootstrap):  # pylint: disable=redefined-outer-name
         assert data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_noapikey(bootstrap):  # pylint: disable=redefined-outer-name
     """test disabled"""
@@ -74,6 +76,7 @@ async def test_noapikey(bootstrap):  # pylint: disable=redefined-outer-name
         assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_nodata(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """test disabled"""
@@ -84,6 +87,7 @@ async def test_nodata(getconfiguredplugin):  # pylint: disable=redefined-outer-n
         assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_noimagecache(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """noimagecache"""
@@ -105,6 +109,7 @@ async def test_noimagecache(getconfiguredplugin):  # pylint: disable=redefined-o
             assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_missingallartistdata(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """missing all artist data"""
@@ -116,6 +121,7 @@ async def test_missingallartistdata(getconfiguredplugin):  # pylint: disable=red
         assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_missingmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """artist"""
@@ -145,6 +151,7 @@ async def test_missingmbid(getconfiguredplugin):  # pylint: disable=redefined-ou
             assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_featuring1(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """artist"""
@@ -183,6 +190,7 @@ async def test_featuring1(getconfiguredplugin):  # pylint: disable=redefined-out
             )
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_featuring2(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """artist"""
@@ -206,6 +214,7 @@ async def test_featuring2(getconfiguredplugin):  # pylint: disable=redefined-out
             )
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_badmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -223,6 +232,7 @@ async def test_badmbid(getconfiguredplugin):  # pylint: disable=redefined-outer-
         assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_onlymbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -238,6 +248,7 @@ async def test_onlymbid(getconfiguredplugin):  # pylint: disable=redefined-outer
         assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_artist_and_mbid(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -272,6 +283,7 @@ async def test_artist_and_mbid(getconfiguredplugin):  # pylint: disable=redefine
             assert not data
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_all(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """badmbid"""
@@ -303,6 +315,7 @@ async def test_all(getconfiguredplugin):  # pylint: disable=redefined-outer-name
             )
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.xfail(reason="Non-deterministic at the moment")
 @pytest.mark.asyncio
 async def test_theall(getconfiguredplugin):  # pylint: disable=redefined-outer-name
@@ -338,6 +351,7 @@ async def test_theall(getconfiguredplugin):  # pylint: disable=redefined-outer-n
         )
 
 
+@pytest.mark.live("wikimedia", "discogs", "fanarttv", "theaudiodb")
 @pytest.mark.asyncio
 async def test_notfound(getconfiguredplugin):  # pylint: disable=redefined-outer-name
     """discogs"""

--- a/tests/test_artistextras_discogs.py
+++ b/tests/test_artistextras_discogs.py
@@ -21,6 +21,7 @@ import nowplaying.discogsclient  # pylint: disable=import-error
 import nowplaying.metadata  # pylint: disable=import-error
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_note_stripping(bootstrap):
@@ -49,6 +50,7 @@ async def test_discogs_note_stripping(bootstrap):
     assert "Note:" not in mpproc.metadata["artistshortbio"]
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_weblocation1(bootstrap):
@@ -81,6 +83,7 @@ async def test_discogs_weblocation1(bootstrap):
     assert "NOTE: If The Revolution are credited without Prince" in data["artistlongbio"]
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_datacache_usage(bootstrap):
@@ -116,6 +119,7 @@ async def test_discogs_datacache_usage(bootstrap):
         assert result1 == result2
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_website_lookup_cache(bootstrap):
@@ -156,6 +160,7 @@ async def test_discogs_website_lookup_cache(bootstrap):
         )
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_artist_duplicates(bootstrap):
@@ -231,6 +236,7 @@ async def test_discogs_artist_duplicates(bootstrap):
 # Error Handling and Network Resilience Tests
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_timeout_handling(bootstrap):
@@ -272,6 +278,7 @@ async def test_discogs_timeout_handling(bootstrap):
                 plugin.client.search_async = original_search
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_http_error_handling(bootstrap):
@@ -327,6 +334,7 @@ async def test_discogs_http_error_handling(bootstrap):
                     plugin.client.search_async = original_search
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_malformed_json_handling(bootstrap):
@@ -385,6 +393,7 @@ async def test_discogs_malformed_json_handling(bootstrap):
 # Input Validation and Edge Case Tests
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.parametrize(
     "metadata,test_id",
     [
@@ -427,6 +436,7 @@ async def test_discogs_malformed_metadata_input(bootstrap, metadata, test_id):
         )
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.parametrize(
     "artist_name,test_id",
     [
@@ -477,6 +487,7 @@ async def test_discogs_artist_name_variations(bootstrap, artist_name, test_id):
         )
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.parametrize(
     "test_urls,test_id",
     [
@@ -623,6 +634,7 @@ def test_discogs_selective_feature_disabling(bootstrap, features, test_id):
 # Cache Failure Scenario Tests
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_cache_corruption_handling(bootstrap):
@@ -667,6 +679,7 @@ async def test_discogs_cache_corruption_handling(bootstrap):
 # Search Result Edge Case Tests
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_empty_search_results(bootstrap):
@@ -721,6 +734,7 @@ async def test_discogs_empty_search_results(bootstrap):
                 plugin.client.search_async = original_search
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_missing_artist_data(bootstrap):
@@ -788,6 +802,7 @@ async def test_discogs_missing_artist_data(bootstrap):
 # DJ-Specific Reliability Tests
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_rapid_track_changes(bootstrap):
@@ -840,6 +855,7 @@ async def test_discogs_rapid_track_changes(bootstrap):
         )
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_common_dj_genres(bootstrap):
@@ -903,6 +919,7 @@ async def test_discogs_common_dj_genres(bootstrap):
             )
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_live_performance_timeout_recovery(bootstrap):
@@ -966,6 +983,7 @@ async def test_discogs_live_performance_timeout_recovery(bootstrap):
                 plugin.client.search_async = original_search
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_memory_usage_stability(bootstrap):
@@ -1062,6 +1080,7 @@ def test_discogs_configuration_validation_for_djs(bootstrap):
         logging.info("DJ config scenario %d validated successfully", i)
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_api_call_count(bootstrap):  # pylint: disable=redefined-outer-name
@@ -1130,6 +1149,7 @@ async def test_discogs_api_call_count(bootstrap):  # pylint: disable=redefined-o
                 plugin.client.search_async = original_search
 
 
+@pytest.mark.live("discogs")
 @pytest.mark.asyncio
 @skip_no_discogs_key
 async def test_discogs_coverart(bootstrap):  # pylint: disable=redefined-outer-name

--- a/tests/test_artistextras_fanarttv.py
+++ b/tests/test_artistextras_fanarttv.py
@@ -102,6 +102,7 @@ async def test_fanarttv_datacache_api_failure_behavior(bootstrap):  # pylint: di
         _ = result2
 
 
+@pytest.mark.live("fanarttv")
 @pytest.mark.asyncio
 @skip_no_fanarttv_key
 async def test_fanarttv_coverart(bootstrap):
@@ -130,6 +131,7 @@ async def test_fanarttv_coverart(bootstrap):
     )
 
 
+@pytest.mark.live("fanarttv")
 @pytest.mark.asyncio
 async def test_fanarttv_coverart_no_album_mbid(bootstrap):
     """test that cover art is not queued when musicbrainzalbumid is absent"""

--- a/tests/test_artistextras_lastfm.py
+++ b/tests/test_artistextras_lastfm.py
@@ -107,6 +107,7 @@ def _setup_plugin(bootstrap, lang: str = "en", en_fallback: bool = True):
     return nowplaying.artistextras.lastfm.Plugin(config=config)
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 async def test_lastfm_disabled(bootstrap):
     """disabled plugin returns None"""
@@ -118,6 +119,7 @@ async def test_lastfm_disabled(bootstrap):
     assert result is None
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 async def test_lastfm_no_apikey(bootstrap):
     """missing API key returns None"""
@@ -129,6 +131,7 @@ async def test_lastfm_no_apikey(bootstrap):
     assert result is None
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 async def test_lastfm_no_artist(bootstrap):
     """missing artist returns None"""
@@ -426,6 +429,7 @@ def _setup_live_plugin(bootstrap, lang: str = "en", en_fallback: bool = True):
     return nowplaying.artistextras.lastfm.Plugin(config=config)
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 @skip_no_lastfm_key
 async def test_lastfm_live_bio_and_website(bootstrap):
@@ -443,6 +447,7 @@ async def test_lastfm_live_bio_and_website(bootstrap):
     assert any("last.fm" in url for url in result["artistwebsites"])
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 @skip_no_lastfm_key
 async def test_lastfm_live_cache_consistency(bootstrap):
@@ -456,6 +461,7 @@ async def test_lastfm_live_cache_consistency(bootstrap):
     assert result1 == result2
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 @skip_no_lastfm_key
 async def test_lastfm_live_unknown_artist(bootstrap):
@@ -471,6 +477,7 @@ async def test_lastfm_live_unknown_artist(bootstrap):
         pytest.fail(f"Plugin raised exception for unknown artist: {exc}")
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 @skip_no_lastfm_key
 async def test_lastfm_live_lang_fallback(bootstrap):
@@ -634,6 +641,7 @@ async def test_lastfm_coverart_with_album_mbid(bootstrap):  # pylint: disable=re
     assert keys, "Cover art should be stored after queue processing"
 
 
+@pytest.mark.live("lastfm")
 @pytest.mark.asyncio
 @skip_no_lastfm_key
 async def test_lastfm_live_coverart(bootstrap):  # pylint: disable=redefined-outer-name

--- a/tests/test_artistextras_theaudiodb.py
+++ b/tests/test_artistextras_theaudiodb.py
@@ -42,6 +42,7 @@ def _setup_theaudiodb_plugin_no_key(bootstrap):
     return plugin
 
 
+@pytest.mark.live("theaudiodb")
 @pytest.mark.asyncio
 async def test_theaudiodb_artist_name_correction(bootstrap):
     """test theaudiodb artist name correction for name-based vs musicbrainz searches"""
@@ -78,6 +79,7 @@ async def test_theaudiodb_artist_name_correction(bootstrap):
         logging.info("Artist name preserved for MusicBrainz search: %s", result2["artist"])
 
 
+@pytest.mark.live("theaudiodb")
 @pytest.mark.asyncio
 async def test_theaudiodb_datacache_duplicate_artists(bootstrap):
     """test TheAudioDB two-level caching with duplicate artist names"""
@@ -131,6 +133,7 @@ async def test_theaudiodb_datacache_duplicate_artists(bootstrap):
     # Test passes if two-level caching works correctly (search + individual artist ID)
 
 
+@pytest.mark.live("theaudiodb")
 @pytest.mark.asyncio
 async def test_theaudiodb_invalid_musicbrainz_id_fallback(bootstrap):
     """test theaudiodb plugin falls back to name-based search when MusicBrainz ID is invalid"""
@@ -513,6 +516,7 @@ async def test_theaudiodb_coverart_album_api_error(bootstrap):  # pylint: disabl
     )
 
 
+@pytest.mark.live("theaudiodb")
 @pytest.mark.asyncio
 async def test_theaudiodb_live_coverart(bootstrap):  # pylint: disable=redefined-outer-name
     """live: album cover art URL is queued for Nine Inch Nails - The Downward Spiral"""

--- a/tests/test_artistextras_wikimedia.py
+++ b/tests/test_artistextras_wikimedia.py
@@ -37,6 +37,7 @@ async def test_wikimedia_datacache_usage(bootstrap):
     )
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_langfallback_zh_to_en(bootstrap):
     """test wikimedia language fallback from zh to en"""
@@ -56,6 +57,7 @@ async def test_wikimedia_langfallback_zh_to_en(bootstrap):
     assert "video" in data.get("artistlongbio")
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_langfallback_zh_to_none(bootstrap):
     """test wikimedia language fallback disabled"""
@@ -75,6 +77,7 @@ async def test_wikimedia_langfallback_zh_to_none(bootstrap):
     assert not data.get("artistlongbio")
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_humantetris_en(bootstrap):
     """test wikimedia english content"""
@@ -95,6 +98,7 @@ async def test_wikimedia_humantetris_en(bootstrap):
     assert not data.get("artistlongbio")
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_humantetris_de(bootstrap):
     """test wikimedia german content"""
@@ -121,6 +125,7 @@ async def test_wikimedia_humantetris_de(bootstrap):
 # Error Handling and Network Resilience Tests
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_timeout_handling(bootstrap):
     """test handling of API timeouts (Wikipedia can be slow)"""
@@ -158,6 +163,7 @@ async def test_wikimedia_timeout_handling(bootstrap):
         nowplaying.wikiclient.get_page_async = original_get_page
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_http_error_handling(bootstrap):
     """test handling of various HTTP error codes from Wikipedia"""
@@ -218,6 +224,7 @@ async def test_wikimedia_http_error_handling(bootstrap):
             nowplaying.wikiclient.get_page_async = original_get_page
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_ssl_error_handling(bootstrap):
     """test handling of SSL certificate errors"""
@@ -258,6 +265,7 @@ async def test_wikimedia_ssl_error_handling(bootstrap):
 # Input Validation and URL Parsing Tests
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.parametrize(
     "malformed_urls,test_id",
     [
@@ -307,6 +315,7 @@ async def test_wikimedia_malformed_urls(bootstrap, malformed_urls, test_id):
         )
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.parametrize(
     "metadata,test_id",
     [
@@ -347,6 +356,7 @@ async def test_wikimedia_missing_metadata_fields(bootstrap, metadata, test_id):
 # Language Handling Edge Cases
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.parametrize(
     "invalid_language,test_id",
     [
@@ -393,6 +403,7 @@ async def test_wikimedia_invalid_language_codes(bootstrap, invalid_language, tes
         )
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_language_fallback_chain(bootstrap):
     """test complex language fallback scenarios"""
@@ -433,6 +444,7 @@ async def test_wikimedia_language_fallback_chain(bootstrap):
 # Content Processing and Sanitization Tests
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_large_content_handling(bootstrap):
     """test handling of very large Wikipedia articles"""
@@ -496,6 +508,7 @@ async def test_wikimedia_large_content_handling(bootstrap):
         nowplaying.wikiclient.get_page_async = original_get_page
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_malformed_content_handling(bootstrap):
     """test handling of malformed content from Wikipedia"""
@@ -599,6 +612,7 @@ def test_wikimedia_configuration_scenarios(bootstrap):
 # Performance and DJ-Critical Scenario Tests
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_rapid_entity_lookups(bootstrap):
     """test handling of rapid consecutive Wikidata lookups (DJ scenario)"""
@@ -651,6 +665,7 @@ async def test_wikimedia_rapid_entity_lookups(bootstrap):
         )
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_cache_corruption_handling(bootstrap):
     """test handling of corrupted cache data"""
@@ -690,6 +705,7 @@ async def test_wikimedia_cache_corruption_handling(bootstrap):
         nowplaying.datacache.cached_fetch = original_cached_fetch
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_memory_stability_long_session(bootstrap):
     """test memory stability during extended DJ sessions"""
@@ -749,6 +765,7 @@ async def test_wikimedia_memory_stability_long_session(bootstrap):
     )
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_api_call_count(bootstrap):  # pylint: disable=redefined-outer-name
     """test that wikimedia plugin makes only one API call when cache is used"""
@@ -820,6 +837,7 @@ async def test_wikimedia_api_call_count(bootstrap):  # pylint: disable=redefined
         nowplaying.wikiclient.get_page_async = original_get_page
 
 
+@pytest.mark.live("wikimedia")
 @pytest.mark.asyncio
 async def test_wikimedia_failure_cache(bootstrap):  # pylint: disable=redefined-outer-name
     """test that wikimedia plugin handles cache failures gracefully"""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -469,6 +469,7 @@ def test_youtube_title_no_match(title):
     assert not nowplaying.metadata.processors.YOUTUBE_TITLE_MATCH_RE.match(title)
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_discogs_from_mb(bootstrap):  # pylint: disable=redefined-outer-name
     """noimagecache"""
@@ -499,6 +500,7 @@ async def test_discogs_from_mb(bootstrap):  # pylint: disable=redefined-outer-na
     assert metadataout["title"] == "Iris"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_keeptitle_despite_mb(bootstrap):  # pylint: disable=redefined-outer-name
     """noimagecache"""

--- a/tests/test_metadata_multi_artist.py
+++ b/tests/test_metadata_multi_artist.py
@@ -126,6 +126,7 @@ def test_dj_collaboration_formats(artist_string, expected):
 
 
 # Integration tests with real MusicBrainz API calls
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_integration_single_artist_known_to_mb(bootstrap):
     """Test that artists known to MusicBrainz don't get split"""
@@ -161,6 +162,7 @@ async def test_integration_single_artist_known_to_mb(bootstrap):
             )
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_integration_collaboration_not_in_mb(bootstrap):
     """Test that collaborations not in MB get resolved to individual artists"""
@@ -205,6 +207,7 @@ async def test_integration_collaboration_not_in_mb(bootstrap):
                 )
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_integration_hierarchical_breakdown(bootstrap):
     """Test hierarchical breakdown with a case that requires splitting"""
@@ -246,6 +249,7 @@ async def test_integration_hierarchical_breakdown(bootstrap):
     )
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.parametrize("artist_name", SINGLE_ARTIST_WITH_DELIMITERS)
 @pytest.mark.asyncio
 async def test_integration_single_artists_not_split(bootstrap, artist_name):
@@ -295,6 +299,7 @@ async def test_integration_single_artists_not_split(bootstrap, artist_name):
         )
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.parametrize("collaboration,expected_artists", COLLABORATION_CASES)
 @pytest.mark.asyncio
 async def test_integration_collaborations_split(bootstrap, collaboration, expected_artists):
@@ -340,6 +345,7 @@ async def test_integration_collaborations_split(bootstrap, collaboration, expect
         logging.warning("Could not resolve %s - may be due to network issues", collaboration)
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_integration_real_collaboration_example(bootstrap):
     """Test our known working example: Disclosure ft. AlunaGeorge"""
@@ -381,6 +387,7 @@ async def test_integration_real_collaboration_example(bootstrap):
         )
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_integration_conservative_splitting(bootstrap):
     """Test that ambiguous cases are handled conservatively"""

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -28,6 +28,7 @@ def getmusicbrainz(bootstrap):
     return nowplaying.musicbrainz.MusicBrainzHelper(config=config, test_mode=True)
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_15ghosts2_orig(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test just a recording id"""
@@ -42,6 +43,7 @@ async def test_15ghosts2_orig(getmusicbrainz):  # pylint: disable=redefined-oute
     assert metadata["title"] == "15 Ghosts II"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_15ghosts2_fullytagged(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test an isrc"""
@@ -56,6 +58,7 @@ async def test_15ghosts2_fullytagged(getmusicbrainz):  # pylint: disable=redefin
     assert metadata["title"] == "15 Ghosts II"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_nin(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test standard/well known name+title"""
@@ -68,6 +71,7 @@ async def test_fallback_nin(getmusicbrainz):  # pylint: disable=redefined-outer-
     assert newdata["album"] == "Ghosts I–IV"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_dansesociety(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test slightly wrong artist (missing the) + semi-obscure single"""
@@ -78,6 +82,7 @@ async def test_fallback_dansesociety(getmusicbrainz):  # pylint: disable=redefin
     assert newdata["album"] == "Somewhere"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_recordingid_api_cache_call_count(
     getmusicbrainz,  # pylint: disable=redefined-outer-name
@@ -122,6 +127,7 @@ async def test_recordingid_api_cache_call_count(
         mbhelper._recordingid_uncached = original  # pylint: disable=protected-access
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.xfail(reason="Returns wrong data")
 @pytest.mark.asyncio
 async def test_fallback_prince_compblue(getmusicbrainz):  # pylint: disable=redefined-outer-name
@@ -172,6 +178,7 @@ async def test_fallback_prince_compblue(getmusicbrainz):  # pylint: disable=rede
 #     assert newdata.get('musicbrainzrecordingid') in COMPBLUERID
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_princeandther_compblue(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """same, but without album"""
@@ -188,6 +195,7 @@ async def test_fallback_princeandther_compblue(getmusicbrainz):  # pylint: disab
     assert newdata.get("musicbrainzrecordingid") in COMPBLUERID
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_snapvsmartin(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test compilation + two artists"""
@@ -201,6 +209,7 @@ async def test_fallback_snapvsmartin(getmusicbrainz):  # pylint: disable=redefin
     assert newdata["album"] == "The Cult of Snap! 1990>>2003"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_sandervsrobbie(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test two artists + single"""
@@ -217,6 +226,7 @@ async def test_fallback_sandervsrobbie(getmusicbrainz):  # pylint: disable=redef
     assert newdata["album"] == "Close My Eyes"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_klfvsent(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test two artists + remix"""
@@ -239,6 +249,7 @@ async def test_fallback_klfvsent(getmusicbrainz):  # pylint: disable=redefined-o
     }
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_mareux(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test single but w/wrong remix"""
@@ -248,6 +259,7 @@ async def test_fallback_mareux(getmusicbrainz):  # pylint: disable=redefined-out
     assert newdata["musicbrainzartistid"] == ["09095919-c549-4f33-9555-70df9dd941e1"]
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_trslashst(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test TR/ST"""
@@ -259,6 +271,7 @@ async def test_fallback_trslashst(getmusicbrainz):  # pylint: disable=redefined-
     assert newdata["album"] in ["Iris", "The Destroyer — 2", "Destroyer Vol 1 & 2"]
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.xfail(reason="MusicBrainz returns inconsistent results for popular artists")
 @pytest.mark.asyncio
 async def test_fallback_queen(getmusicbrainz):  # pylint: disable=redefined-outer-name
@@ -273,6 +286,7 @@ async def test_fallback_queen(getmusicbrainz):  # pylint: disable=redefined-oute
     ]  # can pull album or a single
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_grimesfeatjanelle(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test feat"""
@@ -286,6 +300,7 @@ async def test_fallback_grimesfeatjanelle(getmusicbrainz):  # pylint: disable=re
     assert newdata["album"] in ["Venus Fly", "Art Angels"]
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_utterlunancy(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test various artist as only source"""
@@ -297,6 +312,7 @@ async def test_fallback_utterlunancy(getmusicbrainz):  # pylint: disable=redefin
     assert newdata["album"] == "Leatherface: The Texas Chainsaw Massacre III"
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_jackielipson(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test missing entirely"""
@@ -308,6 +324,7 @@ async def test_fallback_jackielipson(getmusicbrainz):  # pylint: disable=redefin
     assert not newdata.get("album")
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_acdc_tnt_nodots(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test missing song and remix with wrong name"""
@@ -321,6 +338,7 @@ async def test_fallback_acdc_tnt_nodots(getmusicbrainz):  # pylint: disable=rede
     assert not metadata.get("musicbrainzrecordingid")
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_acdc_tnt_dots(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test missing song but at least this time remix has correct name"""
@@ -334,6 +352,7 @@ async def test_fallback_acdc_tnt_dots(getmusicbrainz):  # pylint: disable=redefi
     assert not metadata.get("musicbrainzrecordingid")
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_davidbowie(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """this one failed to get bio once"""
@@ -344,6 +363,7 @@ async def test_fallback_davidbowie(getmusicbrainz):  # pylint: disable=redefined
     assert not newdata.get("musicbrainzrecordingid")
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_fallback_complex_and_with_feature(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """MB returns a mismatched title (reference track), so recording id is rejected"""
@@ -357,6 +377,7 @@ async def test_fallback_complex_and_with_feature(getmusicbrainz):  # pylint: dis
     assert not newdata.get("musicbrainzrecordingid")
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_musicbrainz_malformed_ids(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test handling of malformed MusicBrainz IDs"""
@@ -389,6 +410,7 @@ async def test_musicbrainz_malformed_ids(getmusicbrainz):  # pylint: disable=red
             logging.warning("Malformed ID %d raised exception: %s", i, exc)
 
 
+@pytest.mark.live("musicbrainz")
 @pytest.mark.asyncio
 async def test_musicbrainz_missing_metadata_fields(getmusicbrainz):  # pylint: disable=redefined-outer-name
     """test handling of missing or invalid metadata fields"""


### PR DESCRIPTION
Tests that reach MusicBrainz, AcoustID or an artist extras provider now carry live(*providers) naming the services they talk to, and conftest reorders them so neighbours share none. Each builds its own client and wnpmb's adaptive pacing lives on the instance, so a file's worth of them reached one service with no spacing at all.

Only live tests move, and only into slots live tests already held. tests-qt has to stay first because qtbot must initialize before anything starts asyncio or threads, and tests/webserver's module-scoped fixture starts a real server that must not restart mid-module. The hook is handed every collected item, so neither can be assumed.

Enabling a provider is what makes a test live, not naming one: processors returns early when musicbrainz/enabled is false, which is most of test_metadata.py, and matching on names alone caught local tests that merely carry a musicbrainzrecordingid field.

Same-service neighbours drop from every pair to 14 of 157. discogs and wikimedia cannot go further apart: the artist extras core tests hit four services each, putting discogs in 59 of 158 slots.

## Summary by Sourcery

Space live integration tests across their external providers to reduce consecutive requests to the same service.

Enhancements:
- Add provider-specific metadata to live-test markers and reorder eligible live tests to space calls to the same external service apart while preserving protected test ordering and fixtures.

Build:
- Update the pytest live marker definition to require named providers.

Tests:
- Mark tests that access MusicBrainz, AcoustID, and artist-extras providers with the services they use.