### PR TITLE
Stop muting wnpmb's logger

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,13 +50,12 @@ def enforce_single_pytest_instance():
     _PYTEST_LOCKFILE.unlink(missing_ok=True)
 
 
-# These libraries are extremely verbose at DEBUG level; suppress them so they
-# don't overwhelm test output.  (bootstrap.setuplogging() does the same for
-# the running app but is not called during tests.)
-logging.getLogger("hpack").setLevel(logging.WARNING)
-logging.getLogger("httpx2").setLevel(logging.WARNING)
-logging.getLogger("httpcore").setLevel(logging.WARNING)  # respx still pulls httpx
-logging.getLogger("httpcore2").setLevel(logging.WARNING)
+# setuplogging() is not called during tests, so borrow its list rather than
+# keeping a second copy: the copies drifted, and aiosqlite statement tracing
+# ended up burying everything else in CI.
+nowplaying.bootstrap.quiet_noisy_libraries(
+    extra=("httpcore",)  # respx still pulls plain httpx
+)
 
 # DO NOT CHANGE THIS TO BE com.github.whatsnowplaying
 # otherwise your actual bits will disappear!

--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -123,7 +123,18 @@ def setuplogging(
     )
     logging.captureWarnings(True)
     # These libraries emit very noisy DEBUG-level tracing
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logging.getLogger("httpcore2").setLevel(logging.WARNING)
-    logging.getLogger("hpack").setLevel(logging.WARNING)
+    for noisy in (
+        "httpx2",
+        "httpcore2",
+        "hpack",
+        # Named here rather than silenced by a blanket dictConfig in the module
+        # that imported them: disable_existing_loggers takes out every logger
+        # that already exists, which included wnpmb's and cost us all of its
+        # rate-limit and retry reporting.
+        "aiosqlite",
+        "aiohttp",
+        "zeroconf",
+        "simpleobsws",
+    ):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
     return logpath

--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -76,6 +76,31 @@ def set_qt_names(
     app.setApplicationName(appname)
 
 
+# Extremely verbose at DEBUG. Named individually rather than silenced with a
+# dictConfig(disable_existing_loggers=True), which takes out every logger that
+# already exists -- that used to include wnpmb's, costing us all of its
+# rate-limit and 503 reporting.
+NOISY_LIBRARIES: tuple[str, ...] = (
+    "aiohttp",
+    "aiosqlite",
+    "hpack",
+    "httpcore2",
+    "httpx2",
+    "simpleobsws",
+    "zeroconf",
+)
+
+
+def quiet_noisy_libraries(extra: tuple[str, ...] = ()) -> None:
+    """Hold the noisy libraries down to WARNING.
+
+    Shared with the test suite, which does not call setuplogging() and would
+    otherwise drown in aiosqlite statement tracing.
+    """
+    for name in NOISY_LIBRARIES + extra:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
 def setuplogging(
     logdir: pathlib.Path | str | None = None, logname: str = "debug.log", rotate: bool = False
 ) -> pathlib.Path:
@@ -123,18 +148,5 @@ def setuplogging(
     )
     logging.captureWarnings(True)
     # These libraries emit very noisy DEBUG-level tracing
-    for noisy in (
-        "httpx2",
-        "httpcore2",
-        "hpack",
-        # Named here rather than silenced by a blanket dictConfig in the module
-        # that imported them: disable_existing_loggers takes out every logger
-        # that already exists, which included wnpmb's and cost us all of its
-        # rate-limit and retry reporting.
-        "aiosqlite",
-        "aiohttp",
-        "zeroconf",
-        "simpleobsws",
-    ):
-        logging.getLogger(noisy).setLevel(logging.WARNING)
+    quiet_noisy_libraries()
     return logpath

--- a/nowplaying/inputs/traktor.py
+++ b/nowplaying/inputs/traktor.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-import logging.config
 import os
 import pathlib
 import sqlite3
@@ -18,15 +17,6 @@ from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-modu
     QVBoxLayout,
     QWidget,
 )
-
-logging.config.dictConfig(
-    {
-        "version": 1,
-        "disable_existing_loggers": True,
-    }
-)
-
-# pylint: disable=wrong-import-position
 
 import nowplaying.utils.xml
 import nowplaying.wizard

--- a/nowplaying/processes/obsws.py
+++ b/nowplaying/processes/obsws.py
@@ -4,20 +4,10 @@ see https://github.com/Palakis/obs-websocket"""
 
 import asyncio
 import logging
-import logging.config
 import sys
 import threading
 
 import simpleobsws
-
-logging.config.dictConfig(
-    {
-        "version": 1,
-        "disable_existing_loggers": True,
-    }
-)
-
-# pylint: disable=wrong-import-position
 
 import nowplaying.bootstrap
 import nowplaying.config

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -32,10 +32,6 @@ from nowplaying.webserver.images_websocket import ImagesWebSocketHandler
 from nowplaying.webserver.requests_handlers import RequestsHandler
 from nowplaying.webserver.static_handlers import StaticContentHandler
 
-#
-# quiet down our imports
-#
-
 import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -5,7 +5,6 @@ import asyncio
 import base64
 import contextlib
 import logging
-import logging.config
 import os
 import pathlib
 import secrets
@@ -36,15 +35,6 @@ from nowplaying.webserver.static_handlers import StaticContentHandler
 #
 # quiet down our imports
 #
-
-logging.config.dictConfig(
-    {
-        "version": 1,
-        "disable_existing_loggers": True,
-    }
-)
-
-# pylint: disable=wrong-import-position
 
 import nowplaying.bootstrap
 import nowplaying.config


### PR DESCRIPTION
traktor, webserver and obsws each ran dictConfig with disable_existing_loggers at import time, which takes out every logger that already exists. wnpmb's is one of them, so all of its rate-limit and retry reporting was discarded, in normal runs as well as tests. That cost real time chasing MusicBrainz flakiness: no "Rate limited" line could appear, so its absence meant nothing.

It applied to every run, not just some import orders. processors imports nowplaying.musicbrainz at module level, so wnpmb exists before ConfigFile() loads the input plugins, and SubprocessManager imports every process module in the main process, so fixing traktor alone left two more paths that re-muted it.

The noise those calls were aimed at is now named in bootstrap alongside httpx2 and friends. If something else turns out to be chatty, add it there by name rather than disabling everything that happens to exist.

## Summary by Sourcery

Preserve application logging while explicitly quieting known noisy libraries.

Bug Fixes:
- Preserve wnpmb logging so rate-limit, retry, and MusicBrainz failure reports remain visible across application and test runs.

Enhancements:
- Replace import-time global logger disabling with an explicit shared list of noisy libraries set to WARNING.
- Reuse the shared logging-noise configuration in the test suite to keep CI output focused without muting unrelated loggers.