### PR TITLE
Quiet the noisy libraries and fix mDNS address selection

### DIFF
--- a/nowplaying/bootstrap.py
+++ b/nowplaying/bootstrap.py
@@ -83,10 +83,18 @@ def set_qt_names(
 NOISY_LIBRARIES: tuple[str, ...] = (
     "aiohttp",
     "aiosqlite",
+    "discord",
     "hpack",
     "httpcore2",
     "httpx2",
     "simpleobsws",
+    # watchdog narrates every raw filesystem event, but everything that acts on
+    # one says so itself -- "Track change detected in Serato 4" and friends --
+    # so the tracing only repeats what we already log, under paths we write.
+    # The macOS observer hardcodes getLogger("fsevents") instead of __name__,
+    # so it needs naming separately from the inotify observers.
+    "fsevents",
+    "watchdog",
     "zeroconf",
 )
 

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -266,6 +266,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         filename = event.src_path
 
         if filename.endswith("NowPlaying.txt"):
+            logging.debug("processing %s", filename)
             self._check_for_new_track()
             return
 
@@ -283,6 +284,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     def _wal_timer_fired(self) -> None:
         """Called by the debounce timer; clears the timer reference then checks."""
+        logging.debug("processing MediaLibrary.db-wal")
         with self._wal_timer_lock:
             self._wal_timer = None
         if self.config.cparser.value("djaypro/rebuild_location_db", type=bool, defaultValue=False):

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -112,7 +112,6 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         if self.observer:
             return
 
-        self.remotedbfile.unlink(missing_ok=True)
         logging.info("Opening %s for input", self.remotedbfile)
         self.observer = nowplaying.db.DBWatcher(databasefile=str(self.remotedbfile))
         self.observer.start(customhandler=self._read_track)
@@ -121,6 +120,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         if event.is_directory:
             return
 
+        logging.debug("remote db event: %s", event.src_path)
         if not self.remotedb:
             logging.error("remotedb isn't opened yet.")
             return
@@ -134,8 +134,13 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
 
     async def start(self):
         """setup the watcher to run in a separate thread"""
-        await self.setup_watcher()
+        # Discard the last session's tracks, open the database, then watch. The
+        # unlink used to live in setup_watcher(), which put it after the watcher
+        # was already running: its own delete and recreate were the first events
+        # delivered, and they arrived before there was a database to read.
+        self.remotedbfile.unlink(missing_ok=True)
         self.remotedb = nowplaying.db.MetadataDB(databasefile=str(self.remotedbfile))
+        await self.setup_watcher()
 
     async def getplayingtrack(self) -> TrackMetadata | None:
         """wrapper to call getplayingtrack"""

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -4,6 +4,7 @@
 import asyncio
 import base64
 import contextlib
+import ipaddress
 import logging
 import os
 import pathlib
@@ -23,7 +24,7 @@ import netifaces
 import requests
 from aiohttp import WSCloseCode, web
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from zeroconf import IPVersion
+from zeroconf import InterfaceChoice, IPVersion
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 from nowplaying.webserver.gifwords_websocket import GifwordsWebSocketHandler
@@ -161,6 +162,32 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
         self.databasefile.parent.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
+    def _advertisable_address(ip_addr: str, netmask: str | None) -> bool:
+        """Whether an interface address is worth publishing as a way to reach us.
+
+        Anything advertised here is something a client will try to connect to,
+        so an address that cannot answer is worse than one fewer address. macOS
+        bridge interfaces have been seen holding the network address itself
+        (192.168.97.0/24), which nothing can route to.
+        """
+        try:
+            interface = ipaddress.IPv4Interface(f"{ip_addr}/{netmask or '255.255.255.255'}")
+        except ValueError:
+            return False
+
+        address = interface.ip
+        if address.is_loopback or address.is_link_local or address.is_unspecified:
+            return False
+        # /31 and /32 have no network or broadcast address to collide with; a
+        # point-to-point tunnel legitimately sits on what looks like one.
+        if interface.network.prefixlen < 31 and address in (
+            interface.network.network_address,
+            interface.network.broadcast_address,
+        ):
+            return False
+        return True
+
+    @staticmethod
     def _mdns_safe_hostname(raw: str) -> str:
         """Return a valid mDNS label from raw hostname.
 
@@ -195,22 +222,30 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             service_name = "WhatsNowPlaying"
             service_type = "_whatsnowplaying._tcp.local."
 
-            # Get all non-loopback IPv4 addresses from network interfaces
-            addresses = []
+            # Get all reachable IPv4 addresses from network interfaces
+            usable_ips: list[str] = []
             # pylint: disable=no-member
             for interface in netifaces.interfaces():
                 addrs = netifaces.ifaddresses(interface)
                 if netifaces.AF_INET in addrs:
                     for addr_info in addrs[netifaces.AF_INET]:
                         ip_addr = addr_info.get("addr")
-                        # Skip loopback addresses
-                        if ip_addr and not ip_addr.startswith("127."):
-                            addresses.append(socket.inet_aton(ip_addr))
+                        if ip_addr and self._advertisable_address(
+                            ip_addr, addr_info.get("netmask")
+                        ):
+                            usable_ips.append(ip_addr)
+
+            # Left to itself zeroconf opens a socket on every interface, which
+            # on one it cannot send from means a warning and a traceback per
+            # announcement, from inside its own transport where we cannot catch
+            # it. Hand it the same addresses we are willing to advertise.
+            listen_on: list[str] | InterfaceChoice = usable_ips or InterfaceChoice.Default
 
             # Fallback to localhost if no network interfaces found
-            if not addresses:
+            if not usable_ips:
                 logging.warning("No network interfaces found, using localhost")
-                addresses = [socket.inet_aton("127.0.0.1")]
+                usable_ips = ["127.0.0.1"]
+            addresses = [socket.inet_aton(ip) for ip in usable_ips]
 
             hostname = self._mdns_safe_hostname(socket.gethostname())
 
@@ -229,7 +264,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             )
 
             # Register the service
-            self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Only)
+            self.aiozc = AsyncZeroconf(interfaces=listen_on, ip_version=IPVersion.V4Only)
             await self.aiozc.async_register_service(info, allow_name_change=True)
             self.service_info = info
 

--- a/nowplaying/processes/webserver.py
+++ b/nowplaying/processes/webserver.py
@@ -24,7 +24,7 @@ import netifaces
 import requests
 from aiohttp import WSCloseCode, web
 from PySide6.QtCore import QStandardPaths  # pylint: disable=no-name-in-module
-from zeroconf import InterfaceChoice, IPVersion
+from zeroconf import IPVersion
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 from nowplaying.webserver.gifwords_websocket import GifwordsWebSocketHandler
@@ -235,16 +235,16 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
                         ):
                             usable_ips.append(ip_addr)
 
-            # Left to itself zeroconf opens a socket on every interface, which
-            # on one it cannot send from means a warning and a traceback per
-            # announcement, from inside its own transport where we cannot catch
-            # it. Hand it the same addresses we are willing to advertise.
-            listen_on: list[str] | InterfaceChoice = usable_ips or InterfaceChoice.Default
-
             # Fallback to localhost if no network interfaces found
             if not usable_ips:
                 logging.warning("No network interfaces found, using localhost")
                 usable_ips = ["127.0.0.1"]
+
+            # Left to itself zeroconf opens a socket on every interface, which
+            # on one it cannot send from means a warning and a traceback per
+            # announcement, from inside its own transport where we cannot catch
+            # it. It announces from exactly the addresses we advertise, so a
+            # service reachable only on loopback is announced only there.
             addresses = [socket.inet_aton(ip) for ip in usable_ips]
 
             hostname = self._mdns_safe_hostname(socket.gethostname())
@@ -264,7 +264,7 @@ class WebHandler:  # pylint: disable=too-many-public-methods,too-many-instance-a
             )
 
             # Register the service
-            self.aiozc = AsyncZeroconf(interfaces=listen_on, ip_version=IPVersion.V4Only)
+            self.aiozc = AsyncZeroconf(interfaces=usable_ips, ip_version=IPVersion.V4Only)
             await self.aiozc.async_register_service(info, allow_name_change=True)
             self.service_info = info
 

--- a/nowplaying/rekordbox/plugin.py
+++ b/nowplaying/rekordbox/plugin.py
@@ -165,9 +165,8 @@ class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attribu
             "Requires Performance Mode."
         )
 
-    def _fs_event(self, event):
+    def _fs_event(self, event):  # pylint: disable=unused-argument
         """File system event handler - called from watchdog thread"""
-        logging.debug("Rekordbox FS event: %s", event.src_path)
         with self._wal_timer_lock:
             if self._wal_timer is not None:
                 self._wal_timer.cancel()
@@ -177,6 +176,7 @@ class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attribu
 
     def _wal_timer_fired(self) -> None:
         """Called after debounce silence; clears the timer reference and flags a refresh."""
+        logging.debug("processing rekordbox database change")
         with self._wal_timer_lock:
             self._wal_timer = None
         self._needs_refresh = True

--- a/nowplaying/serato/handler.py
+++ b/nowplaying/serato/handler.py
@@ -102,9 +102,13 @@ class Serato4Handler:  # pylint: disable=too-many-instance-attributes
 
         self.tasks.clear()
 
-    def process_sessions(self, event):  # pylint: disable=unused-argument
+    def process_sessions(self, event):
         """handle incoming session file updates"""
-        # Simple synchronous processing - just set a flag that async methods can check
+        # The pattern here is "*", so a burst of writes to the library database
+        # lands here in full. They all collapse into the one refresh the async
+        # side will do, so only the edge into that state is worth a line.
+        if not self._db_needs_refresh:
+            logging.debug("processing %s", event.src_path)
         self._db_needs_refresh = True
 
     def _has_track_changed(self, new_track: dict[str, t.Any] | None) -> bool:

--- a/tests/webserver/test_webserver_mdns_addresses.py
+++ b/tests/webserver/test_webserver_mdns_addresses.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""test which interface addresses get advertised over mDNS
+
+Anything advertised here is somewhere a client will try to connect, and it is
+also the interface list handed to zeroconf, so a wrong answer either sends
+EarShot to an address that cannot answer or stops the announcement reaching the
+network at all.  The awkward cases come from real machines: virtualization
+bridges sitting on the network address of their own subnet, and point-to-point
+tunnels sitting on what looks like one.
+"""
+
+import pytest
+
+import nowplaying.processes.webserver  # pylint: disable=import-error
+
+
+def advertisable(ip_addr, netmask):
+    """call the filter under test"""
+    return nowplaying.processes.webserver.WebHandler._advertisable_address(  # pylint: disable=protected-access
+        ip_addr, netmask
+    )
+
+
+@pytest.mark.parametrize(
+    "ip_addr,netmask,expected,why",
+    [
+        ("192.168.100.221", "255.255.255.0", True, "ordinary LAN address"),
+        ("192.168.139.3", "255.255.254.0", True, "ordinary address on a /23"),
+        ("10.0.0.1", "255.0.0.0", True, "ordinary address on a /8"),
+        # An OrbStack bridge was seen holding 192.168.97.0/24: the host address
+        # is also the network address, so nothing can source a packet from it.
+        ("192.168.97.0", "255.255.255.0", False, "network address of its own /24"),
+        ("10.0.0.0", "255.0.0.0", False, "network address of its own /8"),
+        ("192.168.1.255", "255.255.255.0", False, "broadcast address"),
+        ("127.0.0.1", "255.0.0.0", False, "loopback"),
+        ("127.0.0.53", "255.0.0.0", False, "loopback, not just .0.1"),
+        ("169.254.10.4", "255.255.0.0", False, "link-local, reachable by nobody"),
+        ("0.0.0.0", "255.255.255.0", False, "unspecified"),
+        # RFC 3021 /31 links and /32 tunnel endpoints legitimately sit on an
+        # address ipaddress reports as the network address.  Rejecting these
+        # would stop advertising over a VPN, which is when discovery matters.
+        ("10.8.0.2", "255.255.255.255", True, "/32 tunnel endpoint"),
+        ("10.8.0.0", "255.255.255.254", True, "/31 point-to-point, low half"),
+        ("10.8.0.1", "255.255.255.254", True, "/31 point-to-point, high half"),
+        ("192.168.5.7", None, True, "missing netmask falls back to /32"),
+        ("garbage", "255.255.255.0", False, "unparseable address"),
+        ("192.168.1.5", "not-a-mask", False, "unparseable netmask"),
+    ],
+)
+def test_advertisable_address(ip_addr, netmask, expected, why):
+    """only addresses a client could actually reach are advertised"""
+    assert advertisable(ip_addr, netmask) is expected, why
+
+
+def test_malformed_input_does_not_raise():
+    """a DJ set does not stop because netifaces returned something strange"""
+    for ip_addr, netmask in [
+        ("", ""),
+        ("::1", "255.255.255.0"),
+        ("999.999.999.999", "255.255.255.0"),
+        ("192.168.1.1", "255.255.255.0/24"),
+    ]:
+        try:
+            assert isinstance(advertisable(ip_addr, netmask), bool)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            pytest.fail(f"_advertisable_address({ip_addr!r}, {netmask!r}) raised {exc}")

--- a/tests/webserver/test_webserver_mdns_addresses.py
+++ b/tests/webserver/test_webserver_mdns_addresses.py
@@ -43,8 +43,8 @@ def advertisable(ip_addr, netmask):
         ("10.8.0.0", "255.255.255.254", True, "/31 point-to-point, low half"),
         ("10.8.0.1", "255.255.255.254", True, "/31 point-to-point, high half"),
         ("192.168.5.7", None, True, "missing netmask falls back to /32"),
-        ("garbage", "255.255.255.0", False, "unparseable address"),
-        ("192.168.1.5", "not-a-mask", False, "unparseable netmask"),
+        ("garbage", "255.255.255.0", False, "unparsable address"),
+        ("192.168.1.5", "not-a-mask", False, "unparsable netmask"),
     ],
 )
 def test_advertisable_address(ip_addr, netmask, expected, why):


### PR DESCRIPTION
discord and watchdog go into NOISY_LIBRARIES; the dictConfig calls #1884 removed were all that had been keeping them quiet. watchdog needs "fsevents" listed too, which its macOS observer hardcodes.

mDNS advertised anything not starting with 127., so link-local addresses and VM bridges sitting on their own network address were published as routes to the webserver, and zeroconf tried to announce from them. The A records and zeroconf's interface list now share one filter, which keeps /31 and /32.

Every watcher logs the event it acts on, so watchdog's tracing is redundant. serato 4, djay Pro and remote were not logging theirs. The debounced ones now log when the writes stop rather than once per write.

remote opened its database after starting the watcher, so its own unlink arrived as an event with nowhere to read from.

## Summary by Sourcery

Improve runtime logging and make mDNS announcements reliable across local, virtual, and point-to-point network interfaces.

Bug Fixes:
- Fix mDNS discovery to advertise only usable interface addresses and configure zeroconf with the same filtered interface list.
- Ensure the remote database is opened before its filesystem watcher starts, preventing startup events from being lost.

Enhancements:
- Reduce redundant filesystem watcher logging while adding consistent action-level logging, including debounced database refreshes.
- Quiet watchdog, fsevents, and Discord library logging during application startup.

Tests:
- Add coverage for mDNS address filtering, including loopback, link-local, network, broadcast, malformed, /31, and /32 addresses.