### PR TITLE
fix: retry failed input plugin start instead of spinning forever

### DIFF
--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -183,6 +183,8 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
                 await self.input.start()
             except Exception as error:  # pylint: disable=broad-except
                 logging.error("cannot start %s: %s", self.previousinput, error)
+                self.input = None
+                self.previousinput = None  # force input plugin restart on next iteration
                 return False
 
         await self._manage_earshot_plugin()


### PR DESCRIPTION
switch_input_plugin() set self.previousinput before attempting start(), so when start() raised (caught locally, never reaching the outer recovery handler in run()), the next poll cycle saw previousinput == configured and skipped straight past the create-and-start block, believing the plugin was already running. Every subsequent poll then called getplayingtrack() on a plugin that never actually started, repeating the same error forever instead of retrying.

## Summary by Sourcery

Bug Fixes:
- Reset the failed input plugin state after startup errors so the next polling cycle retries plugin creation and startup instead of repeatedly using an unstarted plugin.