### PR TITLE
Give input plugins a lifecycle contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,9 @@ playing" information from various DJ software.
 
 - `nowplaying/plugin.py` - Base plugin class (WNPBasePlugin)
 - Input plugins in `nowplaying/inputs/` - Read track data from DJ software
-  (Serato, Traktor, etc.)
+  (Serato, Traktor, etc.). Read `nowplaying/inputs/CLAUDE.md` before working in
+  here — it covers the `start()`/`stop()`/`status()` contract, which exists
+  because trackpoll and the wizard drive plugins independently
 - Output processes in `nowplaying/processes/` - Send data to various
   destinations (OBS, Twitch, Discord)
 - Artist extras in `nowplaying/artistextras/` - Fetch additional metadata

--- a/nowplaying/db.py
+++ b/nowplaying/db.py
@@ -138,6 +138,26 @@ class DBWatcher:
         self.observer.schedule(self.event_handler, directory, recursive=False)
         self.observer.start()
 
+    def is_alive(self) -> bool:
+        """Whether the watch is actually delivering events.
+
+        The emitter can die after start() returned without anything raising
+        here -- scheduling a path another observer already holds kills it that
+        way -- and it delivers nothing afterwards while looking exactly like a
+        quiet directory.
+
+        The observer's own thread is the wrong thing to ask: it is the event
+        dispatcher, it loops on dispatch_events() swallowing queue.Empty, and it
+        stays up whether or not any emitter is left feeding it. A dead emitter
+        stays in the set, so each one has to be checked. An empty set is not
+        alive rather than vacuously true; schedule() adds the emitter before
+        start() returns, so empty means nothing is watching.
+        """
+        if not self.observer or not self.observer.is_alive():
+            return False
+        emitters = list(self.observer.emitters)
+        return bool(emitters) and all(emitter.is_alive() for emitter in emitters)
+
     def update_time(self, event):  # pylint: disable=unused-argument
         """just need to update the time"""
         self.updatetime = time.time()

--- a/nowplaying/denon/plugin.py
+++ b/nowplaying/denon/plugin.py
@@ -12,6 +12,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+import nowplaying.inputs
 import nowplaying.upgrades
 from nowplaying.inputs import Detected, InputPlugin
 from nowplaying.types import TrackMetadata
@@ -171,6 +172,35 @@ class DenonPlugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     def getmixmode(self) -> str:
         """Get the current mix mode"""
         return self.metadata_processor.get_mixmode()
+
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report on discovery and connected players.
+
+        WAITING is the state that fires in practice: announcements go out every
+        few seconds and nothing is connected until a player answers.
+
+        A task ending is insurance rather than a working state. The discovery
+        loop catches Exception and goes round again, so it only ends on
+        cancellation, on something that is not an Exception at all, or if the
+        handler itself throws. But start() returns before any of that could
+        happen, so if it ever does there is otherwise nothing to notice it.
+
+        Cancelled tasks are excluded: stop() cancels these, and a deliberate
+        shutdown must not read as a fault.
+        """
+        stopped = [
+            task for task in self.connection_manager.tasks if task.done() and not task.cancelled()
+        ]
+        if stopped:
+            return nowplaying.inputs.InputStatus.needs_restart(
+                "Stopped looking for Denon players.",
+                f"{len(stopped)} of {len(self.connection_manager.tasks)} tasks ended",
+            )
+        if not self.connection_manager.active:
+            return nowplaying.inputs.InputStatus.waiting(
+                "Looking for Denon players on the network."
+            )
+        return nowplaying.inputs.InputStatus()
 
     async def start(self):
         """Initialize the StagelinQ connection"""

--- a/nowplaying/djaypro/plugin.py
+++ b/nowplaying/djaypro/plugin.py
@@ -665,7 +665,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
                 self._wal_timer = None
         if self.observer:
             self.observer.stop()
-            self.observer.join()
+            await asyncio.to_thread(self.observer.join)
             self.observer = None
         self._deck_tracks.clear()
         self._started = False

--- a/nowplaying/inputs/CLAUDE.md
+++ b/nowplaying/inputs/CLAUDE.md
@@ -1,0 +1,120 @@
+# Input Plugin Documentation
+
+Input plugins read what is playing from DJ software. `__init__.py` holds the base
+class and the lifecycle contract; everything else here is one plugin, or a thin
+wrapper around a package that is (`denon.py`, `rekordbox.py`, `serato.py`).
+
+## The lifecycle contract
+
+Two things drive a plugin independently and neither knows about the other:
+
+* `processes/trackpoll.py` in the running app
+* `wizard/verify.py`, which constructs the plugin itself and never touches
+  trackpoll
+
+That is why the rules below are rules rather than conventions. Before they were
+written down, each caller had grown its own defences against the same unknowns
+and guessed differently.
+
+1. `start()` returns promptly, or says in its own docstring that it does not.
+   Denon runs discovery and Icecast waits on a broadcaster; callers bound those
+   with a timeout
+2. `start()` is atomic: it either succeeds or leaves nothing allocated
+3. `stop()` is safe at any time, including after a failed or never-called
+   `start()`. Callers run it on every path out, so check what is held rather
+   than assuming
+4. Recoverable conditions are the plugin's to retry, silently. No raising, no
+   caller-side loop
+5. `start()` does not raise for anything operational. A busy port, an
+   unreachable host or a key that does not work are reported through `status()`.
+   Exceptions are for bugs
+
+## status()
+
+An exception can only say "dead". The caller needs to know what to *do*, and
+only the plugin knows, so `status()` returns an `InputStatus`. Build it with one
+of the named constructors rather than by hand:
+
+| constructor | meaning | caller |
+| --- | --- | --- |
+| `InputStatus()` | working | poll |
+| `InputStatus.starting(msg)` | not ready yet | poll; this is what licenses the setup |
+| `InputStatus.waiting(msg)` | recoverable, being retried here | poll, quietly |
+| `InputStatus.needs_user(msg)` | configuration is wrong | stop polling, show the message |
+| `InputStatus.needs_restart(msg)` | a `stop()`/`start()` would clear it | rebuild after 30s |
+| `InputStatus.broken(msg)` | unrecoverable | stop polling, show the message |
+
+Each takes an optional second `detail` for the log. `OK` is the only case with
+no message, which is why it is the only one spelled as a bare constructor: the
+message is shown to a person and the caller cannot invent one. Its absence is
+how `verify.py` ended up scraping exception text to find something to display,
+so the signatures require it now.
+
+`InputStatus` is truthy for the first three, so `if not plugin.status():` reads
+as "not worth polling". Note that is broader than "setup finished" -- `WAITING`
+is truthy -- so a guard meaning the latter tests `health is InputHealth.OK`.
+
+### status() is called every cycle
+
+Including while the caller has stopped polling. That is not incidental, it is
+the recovery mechanism: a plugin in `NEEDS_USER` re-reads the setting that was
+wrong and reports `STARTING` once it looks right.
+
+So `status()` may read configuration -- Icecast has always re-read its port this
+way -- but must not open a socket, a database or a file. Anything like that
+happens on the plugin's own schedule, and `status()` hands back the answer.
+
+### Report STARTING, not OK
+
+The mistake to avoid, made four times during the original conversion: noticing
+the setting has been fixed and reporting `OK`. `start()` has usually given up by
+then and built nothing, so `getplayingtrack()` returns `None` off its own guard
+and the plugin looks healthy while doing nothing.
+
+`STARTING` is what tells the caller to poll, and `getplayingtrack()` is where
+the reopen belongs -- that call is already allowed to do work. `rekordbox.py`
+does this for its key, `jriver.py` for its session, `mpris2.py` for its handler.
+
+### Transient means WAITING, not NEEDS_USER
+
+Nothing rebuilds a plugin on `NEEDS_USER`, so it is only for something a person
+has to change. An absent database file or an unreachable host is `WAITING`: the
+drive may be mounted, the other machine may come back, and the settings may be
+perfectly correct meanwhile.
+
+## Watchers
+
+Most plugins here watch files. Two traps:
+
+* **`observer.is_alive()` is the wrong question.** That is watchdog's event
+  dispatcher, which loops on `dispatch_events()` and stays up whether or not any
+  emitter still feeds it. The emitters run on their own threads and are what
+  dies -- scheduling a path another observer already holds kills one, silently,
+  after `start()` returned. Check `observer.emitters` individually;
+  `db.DBWatcher.is_alive()` does this
+* **`schedule()` raises on a missing directory** under `PollingObserver` and
+  inotify, but not under macOS fsevents. Check the path exists first, or a Mac
+  will pass and everything else will not
+
+## EarShot is not like the others
+
+`earshot.Plugin` subclasses `remote.Plugin`, and
+`trackpoll._manage_earshot_plugin()` runs it alongside *any* source that is not
+earshot or remote, because it can always accept input. Consequences:
+
+* remote's watcher is live whenever EarShot is enabled, whatever input is
+  selected, so two observers can want the same file
+* trackpoll keeps calling `gettrack()` even when the chosen source is unusable,
+  because that is the only caller of `_check_earshot_override()`
+
+## Detection
+
+`detect()` returns `Detected(present, settings, fallback)` and writes nothing.
+`settings` is what the plugin *would* configure; callers decide, because the
+policy differs between first run, Redetect, and the wizard showing a found path
+next to a configured one. Present with empty `settings` is normal: Serato 4
+derives its path on demand, and Rekordbox needs a key that cannot be detected.
+
+`fallback=True` marks presence that comes from a platform capability rather than
+from finding the user's software -- MPRIS2 wherever D-Bus works, WinMedia
+wherever the winrt bindings import -- so it never outranks real DJ software.

--- a/nowplaying/inputs/CLAUDE.md
+++ b/nowplaying/inputs/CLAUDE.md
@@ -22,13 +22,34 @@ and guessed differently.
 2. `start()` is atomic: it either succeeds or leaves nothing allocated
 3. `stop()` is safe at any time, including after a failed or never-called
    `start()`. Callers run it on every path out, so check what is held rather
-   than assuming. It has no deadline of its own, so trackpoll bounds every call
-   through `_stop_plugin()`
-4. Recoverable conditions are the plugin's to retry, silently. No raising, no
+   than assuming
+4. `stop()` never blocks without awaiting. Joining a thread goes through
+   `await asyncio.to_thread(...)`, because the caller's timeout can only
+   interrupt work that reaches an await -- see below
+5. Recoverable conditions are the plugin's to retry, silently. No raising, no
    caller-side loop
-5. `start()` does not raise for anything operational. A busy port, an
+6. `start()` does not raise for anything operational. A busy port, an
    unreachable host or a key that does not work are reported through `status()`.
    Exceptions are for bugs
+
+### Rule 4 is not a style preference
+
+`trackpoll._stop_plugin()` wraps every `stop()` in `asyncio.wait_for`, but a
+deadline in asyncio is cooperative: it can only interrupt a coroutine that
+reaches an await. `async def` promises a signature, not that the body ever
+suspends, so a bare `observer.join()` blocks the whole event loop and
+`wait_for` returns *late without raising*. Measured at 1.00s against a 0.1s
+timeout.
+
+That makes the failure worse than the one the bound was added for -- the poll
+loop is only part of what stops. So the bound is real only if the plugin
+cooperates, which is why this is the plugin's rule and not the caller's.
+`tests/test_input_contract.py` checks it statically, since nothing at runtime
+distinguishes a slow join from a wedged one.
+
+Note this reaches beyond the obvious files: `remote.py` holds a
+`db.DBWatcher`, whose `stop()` is synchronous and joins, so the async caller
+offloads the whole call rather than the join.
 
 ## status()
 

--- a/nowplaying/inputs/CLAUDE.md
+++ b/nowplaying/inputs/CLAUDE.md
@@ -22,7 +22,8 @@ and guessed differently.
 2. `start()` is atomic: it either succeeds or leaves nothing allocated
 3. `stop()` is safe at any time, including after a failed or never-called
    `start()`. Callers run it on every path out, so check what is held rather
-   than assuming
+   than assuming. It has no deadline of its own, so trackpoll bounds every call
+   through `_stop_plugin()`
 4. Recoverable conditions are the plugin's to retry, silently. No raising, no
    caller-side loop
 5. `start()` does not raise for anything operational. A busy port, an
@@ -106,6 +107,8 @@ earshot or remote, because it can always accept input. Consequences:
   selected, so two observers can want the same file
 * trackpoll keeps calling `gettrack()` even when the chosen source is unusable,
   because that is the only caller of `_check_earshot_override()`
+* its `status()` is read too, on its own restart clock, since it inherits the
+  watcher above and is the plugin most likely to lose it
 
 ## Detection
 

--- a/nowplaying/inputs/__init__.py
+++ b/nowplaying/inputs/__init__.py
@@ -2,6 +2,7 @@
 """Input Plugin definition"""
 
 import dataclasses
+import enum
 
 # import logging
 from typing import TYPE_CHECKING
@@ -45,6 +46,70 @@ class Detected:
 
     def __bool__(self) -> bool:
         return self.present
+
+
+class InputHealth(enum.Enum):
+    """What a caller should do about an input plugin right now.
+
+    The useful question is not whether something is wrong, it is what to do
+    about it, and only the plugin knows. An exception can only say "dead",
+    which is why these are separate cases rather than error subclasses.
+    """
+
+    OK = "ok"
+    STARTING = "starting"
+    WAITING = "waiting"
+    NEEDS_USER = "needs_user"
+    NEEDS_RESTART = "needs_restart"
+    BROKEN = "broken"
+
+
+@dataclasses.dataclass(frozen=True)
+class InputStatus:
+    """An input plugin's own account of how it is doing.
+
+    `message` is shown to a person, so it says what is wrong and what would fix
+    it. `detail` is for the log. A plugin reporting anything other than OK is
+    expected to fill in `message`: the caller cannot write one, which is how
+    verify ended up scraping exception text to find something to display.
+    """
+
+    health: InputHealth = InputHealth.OK
+    message: str = ""
+    detail: str = ""
+
+    def __bool__(self) -> bool:
+        """True while the plugin is worth polling."""
+        return self.health in (InputHealth.OK, InputHealth.STARTING, InputHealth.WAITING)
+
+    # Named constructors, so that `message` is required by the signature rather
+    # than by the docstring above. Plain InputStatus() remains the OK case,
+    # which is the only one with nothing to tell anybody.
+
+    @classmethod
+    def starting(cls, message: str, detail: str = "") -> "InputStatus":
+        """Not ready yet. Being polled is what lets it finish."""
+        return cls(health=InputHealth.STARTING, message=message, detail=detail)
+
+    @classmethod
+    def waiting(cls, message: str, detail: str = "") -> "InputStatus":
+        """Something is missing and the plugin is dealing with it."""
+        return cls(health=InputHealth.WAITING, message=message, detail=detail)
+
+    @classmethod
+    def needs_user(cls, message: str, detail: str = "") -> "InputStatus":
+        """Only a person can fix this, so say what and where."""
+        return cls(health=InputHealth.NEEDS_USER, message=message, detail=detail)
+
+    @classmethod
+    def needs_restart(cls, message: str, detail: str = "") -> "InputStatus":
+        """A stop() and start() would clear it."""
+        return cls(health=InputHealth.NEEDS_RESTART, message=message, detail=detail)
+
+    @classmethod
+    def broken(cls, message: str, detail: str = "") -> "InputStatus":
+        """Nothing will change by waiting or by restarting."""
+        return cls(health=InputHealth.BROKEN, message=message, detail=detail)
 
 
 class InputPlugin(WNPBasePlugin):
@@ -136,9 +201,43 @@ class InputPlugin(WNPBasePlugin):
 
     #### Control methods
 
+    def status(self) -> InputStatus:  # pylint: disable=no-self-use
+        """How this plugin is doing, and what the caller should do about it.
+
+        Called every cycle, including while the caller has stopped polling,
+        which is how a plugin gets itself out of NEEDS_USER: re-read the setting
+        that was wrong, and report STARTING once it looks right. Icecast already
+        does this for its port, from getplayingtrack().
+
+        Reading configuration here is expected. Opening a socket, a database or
+        a file is not: a plugin that needs to check something like that does it
+        on its own schedule and records the answer for status() to hand back.
+
+        The default suits any plugin with nothing that can go wrong after it has
+        started, which is most of the file watchers.
+        """
+        return InputStatus()
+
     async def start(self) -> None:
-        """any initialization before actual polling starts"""
+        """Get ready to be polled.
+
+        Returns promptly, or says in its own docstring that it does not: Denon
+        runs discovery and Icecast waits on a broadcaster, and callers bound
+        those with a timeout.
+
+        Does not raise for anything operational. A busy port, an unreachable
+        host or a key that does not work are all reported through status(),
+        because only status() can distinguish "I am retrying" from "a person
+        has to fix this". Exceptions are for bugs.
+
+        Either succeeds or leaves nothing allocated. A caller that sees start()
+        fail is entitled to drop the plugin without calling stop().
+        """
 
     async def stop(self) -> None:
-        """stopping either the entire program or just this
-        input"""
+        """Release whatever start() acquired.
+
+        Safe at any point, including on a plugin that never started or whose
+        start() failed part way. Callers run it on every path out, so it checks
+        what it holds rather than assuming.
+        """

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -464,7 +464,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         """stop the djuced plugin"""
         if self.observer:
             self.observer.stop()
-            self.observer.join()
+            await asyncio.to_thread(self.observer.join)
             self.observer = None
 
     async def has_tracks_by_artist(self, artist_name: str) -> bool:

--- a/nowplaying/inputs/icecast.py
+++ b/nowplaying/inputs/icecast.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-modu
     QWidget,
 )
 
+import nowplaying.inputs
 from nowplaying.inputs import Detected, InputPlugin
 from nowplaying.types import TrackMetadata
 import nowplaying.wizard
@@ -575,6 +576,23 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         await self.start_port(new_port)
         if self.server is None:
             self._port_retry_after = time.monotonic() + 30.0
+
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report WAITING while the SOURCE port is not bound.
+
+        Not NEEDS_USER: the port is usually held by something that will let go,
+        and this plugin already retries on its own timer, so there is nothing
+        for a caller to do but keep asking. Not silence either, because a
+        broadcaster pointed at a port nobody is listening on otherwise looks
+        exactly like one that has not connected yet.
+        """
+        if self.server is None:
+            port = self.config.cparser.value(self._port_config_key, type=int, defaultValue=8000)
+            return nowplaying.inputs.InputStatus.waiting(
+                f"Waiting for port {port}. Another program may be using it.",
+                f"{self._port_config_key}={port} not bound",
+            )
+        return nowplaying.inputs.InputStatus()
 
     async def getplayingtrack(self) -> TrackMetadata:
         """give back the current metadata"""

--- a/nowplaying/inputs/jriver.py
+++ b/nowplaying/inputs/jriver.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
     QWidget,
 )
 
+import nowplaying.inputs
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
 import nowplaying.wizard
@@ -116,6 +117,28 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             return True
         return False
 
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report on the connection to the JRiver server.
+
+        A missing host is the user's to fill in. A host that will not answer is
+        WAITING rather than broken: it is usually another machine, and the
+        plugin already re-authenticates when it comes back, so there is nothing
+        for a caller to do but keep asking.
+        """
+        if not self.config.cparser.value("jriver/host"):
+            return nowplaying.inputs.InputStatus.needs_user("No JRiver host configured.")
+        if not self.session or not self.base_url:
+            # A host entered after start() gave up leaves nothing built, and
+            # getplayingtrack() returns None on exactly that. STARTING is what
+            # licenses it to connect; reporting OK here would promise a working
+            # plugin that never does anything.
+            return nowplaying.inputs.InputStatus.starting("Connecting to JRiver.")
+        if self._connection_failed:
+            return nowplaying.inputs.InputStatus.waiting(
+                f"Cannot reach JRiver on {self.host}.", f"host={self.host} port={self.port}"
+            )
+        return nowplaying.inputs.InputStatus()
+
     async def start(self) -> bool:
         """Initialize the plugin and authenticate"""
         self.host = self.config.cparser.value("jriver/host")
@@ -140,9 +163,11 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             self._connection_failed = False
             return True
 
-        # Don't close session on failed initialization - keep it for auto-recovery
+        # An unreachable server is not a failed start: the plugin is up and
+        # WAITING, status() says so, and the session is what it reconnects
+        # with. The return value is vestigial -- no caller reads it.
         self._connection_failed = True
-        return True  # Return True to allow plugin to be enabled for auto-recovery
+        return True
 
     async def _test_connection(self) -> bool:
         """Test connection to JRiver server"""
@@ -289,7 +314,12 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     async def getplayingtrack(self) -> TrackMetadata | None:
         """Get currently playing track from JRiver"""
         if not self.base_url or not self.session:
-            return None
+            # status() reported STARTING for this; do the connecting here, where
+            # I/O belongs, rather than in the call made every cycle.
+            if self.config and self.config.cparser.value("jriver/host"):
+                await self.start()
+            if not self.base_url or not self.session:
+                return None
 
         # Attempt auto-recovery if needed
         if not await self._attempt_auto_recovery():

--- a/nowplaying/inputs/m3u.py
+++ b/nowplaying/inputs/m3u.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Read m3u files"""
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -271,7 +272,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         self._reset_meta()
         if self.observer:
             self.observer.stop()
-            self.observer.join()
+            await asyncio.to_thread(self.observer.join)
             self.observer = None
 
     def on_m3u_dir_button(self):

--- a/nowplaying/inputs/mpris2.py
+++ b/nowplaying/inputs/mpris2.py
@@ -28,6 +28,7 @@ except ImportError:
 from multidict import CIMultiDict
 from PySide6.QtCore import Qt  # pylint: disable=no-name-in-module
 
+import nowplaying.inputs
 from nowplaying.inputs import Detected, InputPlugin
 
 MPRIS2_BASE = "org.mpris.MediaPlayer2"
@@ -267,10 +268,27 @@ class Plugin(InputPlugin):
         """
         return Detected(DBUS_STATUS, fallback=True)
 
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report on D-Bus and the chosen player.
+
+        No D-Bus at all is BROKEN: this plugin cannot work on this machine and
+        no amount of waiting changes that. A player that has not been chosen, or
+        one that is not running, is the user's to sort out.
+        """
+        if not self.dbus_status:
+            return nowplaying.inputs.InputStatus.broken("D-Bus is not available on this machine.")
+        if not self.config.cparser.value("mpris2/service"):
+            return nowplaying.inputs.InputStatus.needs_user("No MPRIS2 player chosen.")
+        if not self.mpris2:
+            # A player chosen after start() cleared the handler: getplayingtrack()
+            # rebuilds it, and STARTING is what licenses that.
+            return nowplaying.inputs.InputStatus.starting("Connecting to the chosen player.")
+        return nowplaying.inputs.InputStatus()
+
     async def gethandler(self):
         """setup the MPRIS2Handler for this session"""
 
-        if not self.mpris2 or not self.dbus_status:
+        if not self.dbus_status:
             return
 
         sameservice = self.config.cparser.value("mpris2/service")
@@ -279,6 +297,13 @@ class Plugin(InputPlugin):
             self.service = None
             self.mpris2 = None
             return
+
+        if not self.mpris2:
+            # Clearing the handler when no player was chosen used to be
+            # permanent, because the guard above tested it: choosing one later
+            # left nothing to rebuild it.
+            self.mpris2 = MPRIS2Handler()
+            self.service = None
 
         if self.service and self.service == sameservice:
             return

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (  # pylint: disable=import-error, no-name-in-modu
 )
 
 import nowplaying.db
+import nowplaying.inputs
 from nowplaying.inputs import Detected, InputPlugin
 from nowplaying.types import TrackMetadata
 import nowplaying.wizard
@@ -115,6 +116,22 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         logging.info("Opening %s for input", self.remotedbfile)
         self.observer = nowplaying.db.DBWatcher(databasefile=str(self.remotedbfile))
         self.observer.start(customhandler=self._read_track)
+
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report whether the watch is still delivering.
+
+        The watcher can die after start() succeeded: scheduling this directory
+        while another observer already holds it kills the emitter thread, which
+        then delivers nothing and is indistinguishable from nobody sending any
+        tracks. EarShot subclasses this plugin and watches the same file, which
+        is how two observers come to want it at once.
+        """
+        if self.observer and not self.observer.is_alive():
+            return nowplaying.inputs.InputStatus.needs_restart(
+                "Stopped watching for incoming tracks.",
+                f"watcher on {self.remotedbfile} is not running",
+            )
+        return nowplaying.inputs.InputStatus()
 
     def _read_track(self, event):
         if event.is_directory:

--- a/nowplaying/inputs/remote.py
+++ b/nowplaying/inputs/remote.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Beam input plugin"""
 
+import asyncio
 import logging
 import os
 import pathlib
@@ -171,7 +172,14 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         """stop the remote plugin"""
         self._reset_meta()
         if self.observer:
-            self.observer.stop()
+            # DBWatcher.stop() is synchronous and joins the observer thread, so
+            # the whole call goes off the loop: a coroutine that never awaits
+            # cannot be bounded by the caller's timeout.
+            await asyncio.to_thread(self.observer.stop)
+            # Dropping the reference is what keeps status() honest. DBWatcher
+            # clears its own observer, so a stopped watcher and a dead one look
+            # identical from here.
+            self.observer = None
 
     def on_m3u_dir_button(self):
         """filename button clicked action"""

--- a/nowplaying/inputs/virtualdj.py
+++ b/nowplaying/inputs/virtualdj.py
@@ -633,7 +633,7 @@ class Plugin(M3UPlugin):  # pylint: disable=too-many-instance-attributes,too-man
         self._reset_meta()
         if self.observer:
             self.observer.stop()
-            self.observer.join()
+            await asyncio.to_thread(self.observer.join)
             self.observer = None
 
         # Signal background processors to shutdown cleanly

--- a/nowplaying/inputs/winmedia.py
+++ b/nowplaying/inputs/winmedia.py
@@ -17,6 +17,7 @@ except ImportError:
     WINMEDIA_STATUS = False
 
 import nowplaying.utils
+import nowplaying.inputs
 from nowplaying.inputs import Detected, InputPlugin
 
 
@@ -31,6 +32,7 @@ class Plugin(InputPlugin):
         self.stopevent = asyncio.Event()
         self.metadata = {}
         self.tasks = set()
+        self._started = False
         if not WINMEDIA_STATUS:
             self.available = False
             self.winmedia_status = False
@@ -131,8 +133,27 @@ class Plugin(InputPlugin):
         """not supported"""
         return None
 
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report on the reader task.
+
+        No winrt bindings means this plugin cannot work on this machine, which
+        is BROKEN rather than something to wait for. Otherwise the task added by
+        start() discards itself when it finishes, so an empty set after start
+        means the loop ended and nothing is reading any more.
+        """
+        if not WINMEDIA_STATUS:
+            return nowplaying.inputs.InputStatus.broken(
+                "Windows media APIs are not available on this machine."
+            )
+        if self._started and not self.tasks:
+            return nowplaying.inputs.InputStatus.needs_restart(
+                "Stopped reading from Windows media.", "the reader task ended"
+            )
+        return nowplaying.inputs.InputStatus()
+
     async def start(self):
         """start loop"""
+        self._started = True
         loop = asyncio.get_running_loop()
         task = loop.create_task(self._data_loop())
         self.tasks.add(task)

--- a/nowplaying/processes/datacache.py
+++ b/nowplaying/processes/datacache.py
@@ -119,7 +119,9 @@ async def _run(
                 last_watcher_time = watcher.updatetime
                 await asyncio.sleep(0.1)
     finally:
-        watcher.stop()
+        # Off the loop: DBWatcher.stop() joins the observer thread, and the
+        # close() below still has to run.
+        await asyncio.to_thread(watcher.stop)
         await client.close()
         logging.info("DataCache worker stopped")
 

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -31,6 +31,15 @@ from nowplaying.types import TrackMetadata
 
 COREMETA = ["artist", "filename", "title"]
 
+# A plugin that asks to be restarted gets one attempt this long after asking.
+# Fixed, not escalating: a plugin that keeps asking must not be able to turn
+# the poll loop into a restart loop.
+_RESTART_DELAY_SECONDS = 30.0
+
+# stop() during cleanup is bounded so a plugin wedged in it cannot take the
+# poll loop with it.
+_STOP_TIMEOUT_SECONDS = 20.0
+
 
 def compute_final_sleep(fill_duration: float, configured_delay: float) -> float:
     """Compute grace-period sleep before checkagain.
@@ -74,6 +83,9 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         self.input: nowplaying.inputs.InputPlugin | None = None
         self.previousinput: str | None = None
         self.inputname: str | None = None
+        self._reported_health: "nowplaying.inputs.InputHealth | None" = None
+        self._restart_input_at: float = 0.0
+        self._input_pollable: bool = False
         self.tasks: set[asyncio.Task[Any]] = set()
         self.metadataprocessors = nowplaying.metadata.MetadataProcessors(config=self.config)
 
@@ -155,38 +167,123 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
     async def switch_input_plugin(self) -> bool:
         """Handle user switching source input while running.
 
-        Returns True when an input plugin is active and ready for gettrack(),
-        False when no input is configured or the plugin failed to start.
-        Callers use the False return to skip polling until the next cycle.
+        Returns True when there is something for gettrack() to do, which the
+        EarShot monitor satisfies on its own. _input_pollable carries whether
+        the chosen source is worth asking; every path through here has to reach
+        _manage_earshot_plugin(), because EarShot accepts input regardless of
+        what the chosen source is doing and nothing else stops or reads it.
         """
         configured: str | None = self.config.cparser.value("settings/input")
+
         if not configured:
-            if self.input:
-                logging.info("stopping %s", self.previousinput)
-                await self.input.stop()
-                self.input = None
-                self.previousinput = None
-            return False
-        if self.previousinput != configured:
-            if self.input:
-                logging.info("stopping %s", self.previousinput)
-                await self.input.stop()
+            await self._drop_input()
+        elif self.previousinput != configured:
+            await self._drop_input()
             self.previousinput: str | None = configured
-            self.input = self.plugins[f"nowplaying.inputs.{self.previousinput}"].Plugin(
-                config=self.config
-            )
-            logging.info("Starting %s plugin", self.previousinput)
-            if not self.input:
-                return False
+            await self._start_input(configured)
 
-            try:
-                await self.input.start()
-            except Exception as error:  # pylint: disable=broad-except
-                logging.error("cannot start %s: %s", self.previousinput, error)
-                return False
+        self._input_pollable = bool(configured) and self._act_on_status()
 
+        # One exit, because every path has to get here: EarShot is managed and
+        # read from nowhere else, and forgetting it at one return was the same
+        # bug three times over.
         await self._manage_earshot_plugin()
-        return True
+        return self._input_pollable or self.earshot_plugin is not None
+
+    async def _drop_input(self) -> None:
+        """Stop the current input, if any, and forget everything about it.
+
+        The health and the restart deadline belong to the plugin that is going
+        away: carrying either into the next one reports its first failure as
+        old news, or lets it skip the wait on an already-elapsed clock.
+        """
+        if self.input:
+            logging.info("stopping %s", self.previousinput)
+            await self.input.stop()
+        self.input = None
+        self.previousinput = None
+        self._reported_health = None
+        self._restart_input_at = 0.0
+
+    async def _start_input(self, configured: str) -> None:
+        """Build and start the configured plugin.
+
+        Per the input contract, start() does not raise for anything operational,
+        so an exception here is a defect rather than a misconfiguration. It still
+        has to be survivable: stop() runs first because start() may have got as
+        far as a watcher or a port, and it is bounded because a plugin wedged in
+        stop() would otherwise take the poll loop with it.
+
+        A failure clears self.input and sets the restart clock, so the caller
+        learns about it from status() like everything else.
+        """
+        self.input = self.plugins[f"nowplaying.inputs.{configured}"].Plugin(config=self.config)
+        logging.info("Starting %s plugin", configured)
+        try:
+            await self.input.start()
+        except Exception:  # pylint: disable=broad-except
+            logging.exception("cannot start %s", configured)
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(self.input.stop(), timeout=_STOP_TIMEOUT_SECONDS)
+            self.input = None
+            self._restart_input_at = time.monotonic() + _RESTART_DELAY_SECONDS
+            self._reported_health = nowplaying.inputs.InputHealth.BROKEN
+
+    def _act_on_status(self) -> bool:
+        """Consult the plugin and decide whether it is worth polling.
+
+        Only the plugin knows whether a problem is one it is handling, one a
+        person has to fix, or one a restart would clear, so the decision is
+        taken here rather than inferred from a poll that returned nothing.
+        """
+        if not self.input:
+            # start() failed, which set the clock; this only runs it down.
+            self._await_restart()
+            return False
+
+        status = self.input.status()
+        if status.health is not self._reported_health:
+            self._report_health(status)
+            self._reported_health = status.health
+
+        if status:
+            self._restart_input_at = 0.0
+            return True
+        if status.health is nowplaying.inputs.InputHealth.NEEDS_RESTART:
+            self._await_restart()
+        # NEEDS_USER clears when the plugin sees its setting corrected and
+        # reports STARTING. BROKEN never clears itself, so the only way out is
+        # the user choosing a different input, which the previousinput check
+        # above catches. Either way there is nothing to do here.
+        return False
+
+    def _await_restart(self) -> None:
+        """Run the clock on a restart request, and rebuild when it runs out.
+
+        Clearing previousinput is what causes the rebuild: the next cycle sees
+        it differ from the configured input and goes through the whole
+        stop-construct-start path.
+        """
+        now = time.monotonic()
+        if not self._restart_input_at:
+            self._restart_input_at = now + _RESTART_DELAY_SECONDS
+        elif now >= self._restart_input_at:
+            self._restart_input_at = 0.0
+            self.previousinput = None
+
+    @staticmethod
+    def _report_health(status: "nowplaying.inputs.InputStatus") -> None:
+        """Log a health change once, at a level that matches whose problem it is."""
+        health = status.health
+        text = status.message or health.value
+        if health is nowplaying.inputs.InputHealth.NEEDS_USER:
+            logging.error("input needs attention: %s", text)
+        elif health is nowplaying.inputs.InputHealth.BROKEN:
+            logging.error("input has stopped working: %s", text)
+        elif health is nowplaying.inputs.InputHealth.NEEDS_RESTART:
+            logging.warning("input asked to be restarted: %s", text)
+        else:
+            logging.debug("input health %s: %s", health.value, text)
 
     async def _manage_earshot_plugin(self):
         """Start or stop the secondary EarShot monitor based on config and active source."""
@@ -479,7 +576,7 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
                 metadata[key] = ""
         return metadata
 
-    async def gettrack(  # pylint: disable=too-many-branches,too-many-statements
+    async def gettrack(  # pylint: disable=too-many-branches,too-many-statements,too-many-return-statements
         self,
     ):
         """get currently playing track, returns None if not new or not found"""
@@ -488,17 +585,21 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         while self.config.getpause() and not nowplaying.utils.safe_stopevent_check(self.stopevent):
             await asyncio.sleep(0.5)
 
-        if nowplaying.utils.safe_stopevent_check(self.stopevent) or not self.input:
+        if nowplaying.utils.safe_stopevent_check(self.stopevent):
             return
 
-        try:
-            nextmeta = await self.input.getplayingtrack() or {}
-            for key, value in self.input.get_source_agent_data().items():
-                if key not in nextmeta:
-                    nextmeta[key] = value
-        except Exception as err:  # pylint: disable=broad-except
-            logging.exception("Failed during getplayingtrack() (%s)", err)
-            await asyncio.sleep(1)
+        nextmeta: TrackMetadata = {}
+        if self._input_pollable and self.input:
+            try:
+                nextmeta = await self.input.getplayingtrack() or {}
+                for key, value in self.input.get_source_agent_data().items():
+                    if key not in nextmeta:
+                        nextmeta[key] = value
+            except Exception as err:  # pylint: disable=broad-except
+                logging.exception("Failed during getplayingtrack() (%s)", err)
+                await asyncio.sleep(1)
+                return
+        elif not self.earshot_plugin:
             return
 
         nextmeta, _ = await self._check_earshot_override(nextmeta)
@@ -577,7 +678,9 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             await self._process_artistextras()
 
         # checkagain
-        nextcheck = await self.input.getplayingtrack() or {}
+        nextcheck = {}
+        if self._input_pollable and self.input:
+            nextcheck = await self.input.getplayingtrack() or {}
         if not self._ismetaempty(nextcheck) and not self._ismetasame(nextcheck):
             logging.info("Track changed during delay, skipping")
             self.currentmeta = oldmeta

--- a/nowplaying/processes/trackpoll.py
+++ b/nowplaying/processes/trackpoll.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-lines
 """thread to poll music player"""
 
 import asyncio
@@ -39,6 +40,9 @@ _RESTART_DELAY_SECONDS = 30.0
 # stop() during cleanup is bounded so a plugin wedged in it cannot take the
 # poll loop with it.
 _STOP_TIMEOUT_SECONDS = 20.0
+
+# No configured name to log: it runs alongside whatever the user did choose.
+_EARSHOT_NAME = "EarShot secondary monitor"
 
 
 def compute_final_sleep(fill_duration: float, configured_delay: float) -> float:
@@ -100,6 +104,8 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         # EarShot secondary monitor (runs alongside any non-EarShot source)
         self.earshot_plugin: nowplaying.inputs.InputPlugin | None = None
         self.earshot_last_meta: TrackMetadata = {}
+        self._reported_earshot_health: "nowplaying.inputs.InputHealth | None" = None
+        self._restart_earshot_at: float = 0.0
         # When EarShot overrides, remember what the main source was reporting
         # so its stale data does not immediately win back.
         self.main_source_suppressed_meta: TrackMetadata = {}
@@ -185,21 +191,35 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         self._input_pollable = bool(configured) and self._act_on_status()
 
         # One exit, because every path has to get here: EarShot is managed and
-        # read from nowhere else, and forgetting it at one return was the same
-        # bug three times over.
+        # read from nowhere else, and an early return skipped it three times.
         await self._manage_earshot_plugin()
         return self._input_pollable or self.earshot_plugin is not None
+
+    @staticmethod
+    async def _stop_plugin(plugin: "nowplaying.inputs.InputPlugin", name: str | None) -> None:
+        """Stop a plugin without letting it take the poll loop with it.
+
+        Every caller is on a path that has to continue regardless: an input
+        switch, a restart, or shutdown. The contract asks stop() to be safe at
+        any time but says nothing about how long it may take.
+        """
+        logging.info("stopping %s", name)
+        try:
+            await asyncio.wait_for(plugin.stop(), timeout=_STOP_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logging.error("%s did not stop within %ss", name, _STOP_TIMEOUT_SECONDS)
+        except Exception:  # pylint: disable=broad-except
+            logging.exception("error stopping %s", name)
 
     async def _drop_input(self) -> None:
         """Stop the current input, if any, and forget everything about it.
 
-        The health and the restart deadline belong to the plugin that is going
-        away: carrying either into the next one reports its first failure as
-        old news, or lets it skip the wait on an already-elapsed clock.
+        The health and the restart deadline belong to the plugin going away:
+        carrying either into the next one reports its first failure as old
+        news, or lets it skip the wait on an already-elapsed clock.
         """
         if self.input:
-            logging.info("stopping %s", self.previousinput)
-            await self.input.stop()
+            await self._stop_plugin(self.input, self.previousinput)
         self.input = None
         self.previousinput = None
         self._reported_health = None
@@ -211,20 +231,21 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         Per the input contract, start() does not raise for anything operational,
         so an exception here is a defect rather than a misconfiguration. It still
         has to be survivable: stop() runs first because start() may have got as
-        far as a watcher or a port, and it is bounded because a plugin wedged in
-        stop() would otherwise take the poll loop with it.
+        far as a watcher or a port.
 
         A failure clears self.input and sets the restart clock, so the caller
         learns about it from status() like everything else.
         """
-        self.input = self.plugins[f"nowplaying.inputs.{configured}"].Plugin(config=self.config)
+        plugin: nowplaying.inputs.InputPlugin = self.plugins[
+            f"nowplaying.inputs.{configured}"
+        ].Plugin(config=self.config)
+        self.input = plugin
         logging.info("Starting %s plugin", configured)
         try:
-            await self.input.start()
+            await plugin.start()
         except Exception:  # pylint: disable=broad-except
             logging.exception("cannot start %s", configured)
-            with contextlib.suppress(Exception):
-                await asyncio.wait_for(self.input.stop(), timeout=_STOP_TIMEOUT_SECONDS)
+            await self._stop_plugin(plugin, configured)
             self.input = None
             self._restart_input_at = time.monotonic() + _RESTART_DELAY_SECONDS
             self._reported_health = nowplaying.inputs.InputHealth.BROKEN
@@ -272,21 +293,60 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             self.previousinput = None
 
     @staticmethod
-    def _report_health(status: "nowplaying.inputs.InputStatus") -> None:
+    def _report_health(status: "nowplaying.inputs.InputStatus", label: str = "input") -> None:
         """Log a health change once, at a level that matches whose problem it is."""
         health = status.health
         text = status.message or health.value
         if health is nowplaying.inputs.InputHealth.NEEDS_USER:
-            logging.error("input needs attention: %s", text)
+            logging.error("%s needs attention: %s", label, text)
         elif health is nowplaying.inputs.InputHealth.BROKEN:
-            logging.error("input has stopped working: %s", text)
+            logging.error("%s has stopped working: %s", label, text)
         elif health is nowplaying.inputs.InputHealth.NEEDS_RESTART:
-            logging.warning("input asked to be restarted: %s", text)
+            logging.warning("%s asked to be restarted: %s", label, text)
         else:
-            logging.debug("input health %s: %s", health.value, text)
+            logging.debug("%s health %s: %s", label, health.value, text)
+
+    async def _act_on_earshot_status(self) -> None:
+        """Rebuild the EarShot monitor when it asks.
+
+        It inherits remote's watcher, which dies when another observer already
+        holds the same file and then stores arriving tracks where nobody reads
+        them. Only NEEDS_RESTART is acted on: nothing here can clear NEEDS_USER
+        or BROKEN for a monitor the user never chose.
+        """
+        if not self.earshot_plugin:
+            return
+
+        status = self.earshot_plugin.status()
+        if status.health is not self._reported_earshot_health:
+            self._report_health(status, _EARSHOT_NAME)
+            self._reported_earshot_health = status.health
+
+        if status:
+            self._restart_earshot_at = 0.0
+            return
+        if status.health is not nowplaying.inputs.InputHealth.NEEDS_RESTART:
+            return
+
+        now = time.monotonic()
+        if not self._restart_earshot_at:
+            self._restart_earshot_at = now + _RESTART_DELAY_SECONDS
+        elif now >= self._restart_earshot_at:
+            # Dropping it is the rebuild: next cycle sees no monitor and starts one.
+            await self._stop_earshot_plugin()
+
+    async def _stop_earshot_plugin(self) -> None:
+        """Stop the EarShot monitor and clear everything derived from it."""
+        if self.earshot_plugin:
+            await self._stop_plugin(self.earshot_plugin, _EARSHOT_NAME)
+        self.earshot_plugin = None
+        self.earshot_last_meta = {}
+        self.main_source_suppressed_meta = {}
+        self._reported_earshot_health = None
+        self._restart_earshot_at = 0.0
 
     async def _manage_earshot_plugin(self):
-        """Start or stop the secondary EarShot monitor based on config and active source."""
+        """Start, stop or restart the secondary EarShot monitor."""
         active = self.config.cparser.value("settings/input")
         always_accept = self.config.cparser.value(
             "earshot/always_accept", type=bool, defaultValue=True
@@ -297,19 +357,19 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
         )
 
         if should_run and self.earshot_plugin is None:
-            logging.info("Starting secondary EarShot monitor")
+            logging.info("Starting %s", _EARSHOT_NAME)
             self.earshot_plugin = self.plugins[earshot_key].Plugin(config=self.config)
+            self._reported_earshot_health = None
+            self._restart_earshot_at = 0.0
             try:
                 await self.earshot_plugin.start()
             except Exception as err:  # pylint: disable=broad-except
-                logging.error("Cannot start EarShot secondary monitor: %s", err)
+                logging.error("Cannot start %s: %s", _EARSHOT_NAME, err)
                 self.earshot_plugin = None
         elif not should_run and self.earshot_plugin is not None:
-            logging.info("Stopping secondary EarShot monitor")
-            await self.earshot_plugin.stop()
-            self.earshot_plugin = None
-            self.earshot_last_meta = {}
-            self.main_source_suppressed_meta = {}
+            await self._stop_earshot_plugin()
+        elif self.earshot_plugin is not None:
+            await self._act_on_earshot_status()
 
     async def run(self):
         """track polling process"""
@@ -363,11 +423,9 @@ class TrackPoll:  # pylint: disable=too-many-instance-attributes
             await self._publish(self._pending_meta)
             self._pending_meta = None
         self.stopevent.set()
-        if self.earshot_plugin:
-            await self.earshot_plugin.stop()
-            self.earshot_plugin = None
+        await self._stop_earshot_plugin()
         if self.input:
-            await self.input.stop()
+            await self._stop_plugin(self.input, self.previousinput)
         self.plugins = None
         loop = asyncio.get_running_loop()
         if not self.testmode:

--- a/nowplaying/rekordbox/config.py
+++ b/nowplaying/rekordbox/config.py
@@ -104,27 +104,26 @@ class ConfigReader:
 
     @staticmethod
     def get_password() -> str:
-        """Return the database decryption password.
+        """Return the database decryption password, if one can be auto-detected.
 
-        For RB6 the password is Blowfish-encrypted in the 'dp' field of
-        options.json and decrypted here.  For RB7 no password is embedded;
-        the caller must supply one via the custom_key setting (ask an AI
-        assistant for the Rekordbox 7 database key).
+        The password is Blowfish-encrypted in the 'dp' field of
+        options.json.  This field is present on RB6 installs and also on
+        RB7 installs that were upgraded from RB6, but is not guaranteed
+        on a fresh RB7 install (Pioneer's own docs suggest RB7 has no
+        embedded key). Callers must independently validate any key this
+        returns actually opens the database before trusting it, and fall
+        back to the custom_key setting if it doesn't.
         """
         options_path = _get_options_path()
         if options_path.exists():
             try:
                 options = _parse_options_json(options_path)
-                app_ver = options.get("app_ver", "")
-                major = int(app_ver.split(".")[0]) if app_ver else 0
-
-                if major < 7:
-                    dp = options.get("dp", "")
-                    if dp:
-                        logging.debug("Decrypting RB6 password from options.json")
-                        return _decrypt_rb6_dp(dp)
+                dp = options.get("dp", "")
+                if dp:
+                    logging.debug("Decrypting database password from options.json")
+                    return _decrypt_rb6_dp(dp)
             except Exception:  # pylint: disable=broad-exception-caught
-                logging.exception("Could not extract RB6 password from options.json")
+                logging.exception("Could not extract database password from options.json")
 
         return ""
 

--- a/nowplaying/rekordbox/database.py
+++ b/nowplaying/rekordbox/database.py
@@ -73,19 +73,28 @@ class DatabaseReader:
         Raises:
             RekordboxError: If initialization fails
         """
+        no_key_error = RekordboxError(
+            "No database key configured. "
+            "Enter the Rekordbox 7 key in Settings → Input → Rekordbox. "
+            'Search: "what is the rekordbox 7 sqlcipher key for master.db"'
+        )
         try:
+            auto_detected = not custom_key
             self.encryption_key = custom_key or self.config_reader.get_password()
 
             if not self.encryption_key:
-                raise RekordboxError(
-                    "No database key configured. "
-                    "Enter the Rekordbox 7 key in Settings → Input → Rekordbox. "
-                    'Search: "what is the rekordbox 7 sqlcipher key for master.db"'
-                )
+                raise no_key_error
 
             # PRAGMA key cannot use parameterized queries (SQLCipher limitation).
             # Validate the key is a 64-character hex string before it reaches any SQL.
             if not _KEY_RE.match(self.encryption_key):
+                self.encryption_key = None
+                if auto_detected:
+                    # A fresh RB7 install has a dp field that is not an RB6
+                    # password, so decrypting it yields garbage. Telling the
+                    # user their key is the wrong shape would be about a field
+                    # they never filled in.
+                    raise no_key_error
                 raise RekordboxError("Database key must be a 64-character hexadecimal string.")
 
             # Set database path
@@ -94,12 +103,46 @@ class DatabaseReader:
             if not self.database_path.exists():
                 raise RekordboxError(f"Rekordbox database not found: {self.database_path}")
 
+            try:
+                await asyncio.to_thread(self._validate_key_sync)
+            except RekordboxError as err:
+                self.encryption_key = None
+                if auto_detected:
+                    # Auto-detected key (e.g. a leftover RB6 'dp' field on an
+                    # upgraded install) didn't actually open the database -
+                    # this install needs a manually supplied key instead.
+                    raise no_key_error from err
+                raise
+
             logging.info("Successfully initialized Rekordbox database reader")
 
         except RekordboxError:
             raise
         except Exception as err:  # pylint: disable=broad-exception-caught
             raise RekordboxError(f"Failed to initialize database reader: {err}") from err
+
+    def _validate_key_sync(self) -> None:
+        """Confirm the configured key can actually decrypt the database.
+
+        PRAGMA key never fails on its own; SQLCipher only errors on the
+        first real query, so without this check a wrong key would surface
+        later as a confusing generic query failure instead of a clear,
+        actionable initialization error.
+        """
+
+        def _query() -> None:
+            with sqlite.connect(str(self.database_path)) as conn:  # pylint: disable=no-member
+                self._open_conn(conn)
+                # Cheapest thing that forces SQLCipher to decrypt a page;
+                # count(*) would scan the whole table to prove the same point.
+                conn.execute("SELECT 1 FROM djmdContent LIMIT 1").fetchone()
+
+        try:
+            nowplaying.utils.sqlite.retry_sqlite_operation(_query)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            raise RekordboxError(
+                f"Database key is incorrect or database is unreadable: {err}"
+            ) from err
 
     def _open_conn(self, conn):
         """Apply standard SQLCipher pragmas to an open connection."""

--- a/nowplaying/rekordbox/plugin.py
+++ b/nowplaying/rekordbox/plugin.py
@@ -7,6 +7,7 @@ It handles the plugin lifecycle, UI integration, and track detection via file wa
 """
 
 import asyncio
+import contextlib
 import logging
 import threading
 from typing import TYPE_CHECKING
@@ -20,6 +21,7 @@ from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
+import nowplaying.inputs
 import nowplaying.wizard
 from nowplaying.inputs import Detected, InputPlugin
 
@@ -93,6 +95,8 @@ class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attribu
         self._last_wal_mtime: float = 0.0
         self._wal_timer: threading.Timer | None = None
         self._wal_timer_lock = threading.Lock()
+        self._status = nowplaying.inputs.InputStatus()
+        self._tried_key: str = ""
 
     def detect(self) -> Detected:
         """Report whether the Rekordbox data directory exists on this machine.
@@ -181,18 +185,130 @@ class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attribu
             self._wal_timer = None
         self._needs_refresh = True
 
+    def _database_present(self) -> bool:
+        """Whether the database file is there, recording WAITING when it is not."""
+        try:
+            present = self.config_reader.get_database_path().exists()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Rekordbox database location is unknown")
+            self._status = nowplaying.inputs.InputStatus.broken(
+                "Cannot work out where the Rekordbox database lives."
+            )
+            return False
+        if not present:
+            self._status = nowplaying.inputs.InputStatus.waiting(
+                "Waiting for the Rekordbox library.", "the database file is not there yet"
+            )
+        return present
+
+    async def _open_database(self) -> bool:
+        """Try to open the database with whatever key is configured.
+
+        Records the key it tried, so status() can tell a key the user has since
+        corrected from the one that failed.
+
+        An absent database file is WAITING, not NEEDS_USER: Rekordbox may not
+        have been launched yet, or the library may be on a drive that is not
+        mounted. Calling that the user's problem would wedge the plugin, since
+        nothing rebuilds it and the key it has may be perfectly good.
+        """
+        if not self._database_present():
+            return False
+
+        self._tried_key = self.config.cparser.value("rekordbox/custom_key", defaultValue="")
+        try:
+            await self.database_reader.initialize(custom_key=self._tried_key)
+        except RekordboxError as err:
+            self._status = nowplaying.inputs.InputStatus.needs_user(str(err), repr(err))
+            return False
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logging.exception("Rekordbox database reader would not initialize")
+            self._status = nowplaying.inputs.InputStatus.broken(
+                "Rekordbox could not be read. See the log for details.",
+                repr(err),
+            )
+            return False
+        self._status = nowplaying.inputs.InputStatus()
+        return True
+
+    def status(self) -> "nowplaying.inputs.InputStatus":
+        """Report health, noticing what has changed since the last attempt.
+
+        Both recoveries go through STARTING rather than straight to OK, because
+        STARTING is what licenses getplayingtrack() to do the setup: reporting
+        OK from here would promise a working plugin while nothing had reopened
+        anything. It stays cheap for the same reason -- this runs every cycle,
+        so it reads configuration and stats a directory, and leaves the work to
+        the call already allowed to do it.
+        """
+        health = self._status.health
+        if health is nowplaying.inputs.InputHealth.NEEDS_USER:
+            configured = self.config.cparser.value("rekordbox/custom_key", defaultValue="")
+            if configured != self._tried_key:
+                self._status = nowplaying.inputs.InputStatus.starting(
+                    "Trying the new Rekordbox key."
+                )
+        elif health is nowplaying.inputs.InputHealth.WAITING:
+            # Only leave WAITING when the thing being waited for has appeared,
+            # or getplayingtrack() would retry the setup on every cycle.
+            with contextlib.suppress(Exception):
+                if self.config_reader.get_database_path().exists():
+                    self._status = nowplaying.inputs.InputStatus.starting(
+                        "Found the Rekordbox library."
+                    )
+        return self._status
+
     async def start(self, testmode: bool = False):  # pylint: disable=unused-argument
-        """Initialize and start the plugin"""
+        """Initialize and start the plugin.
+
+        Nothing here raises for an operational problem. A missing directory or a
+        key that does not open the database are both reported through status(),
+        and _ensure_started() is safe to call again once whatever was wrong has
+        changed.
+        """
         logging.info("Starting Rekordbox plugin")
+        await self._ensure_started()
+
+    async def _ensure_started(self) -> None:
+        """Set up whatever is not set up yet. Safe to call repeatedly.
+
+        The watcher comes before the database and is kept even when the key is
+        wrong: which directory to watch comes from options.json rather than
+        from decrypting anything, so a plugin waiting on a corrected key still
+        gets told when the database changes. Without it the plugin would fall
+        back to _check_wal_mtime() stat polling for the rest of the session.
+        """
+        if not self._start_watcher():
+            return
+        await self._open_database()
+
+    def _start_watcher(self) -> bool:
+        """Watch the database directory. False if there is nothing to watch yet.
+
+        The directory can be absent for ordinary reasons -- Rekordbox not
+        installed yet, or a library on a drive that is not mounted -- so this is
+        WAITING and gets tried again rather than being the user's problem.
+        Checking first matters because PollingObserver and inotify both raise
+        from schedule() on a missing path, where fsevents does not.
+        """
+        if self.observer:
+            return True
 
         try:
-            custom_key = self.config.cparser.value("rekordbox/custom_key", defaultValue="")
-            await self.database_reader.initialize(custom_key=custom_key)
-        except Exception as err:  # pylint: disable=broad-exception-caught
-            logging.error("Failed to initialize Rekordbox database reader: %s", err)
-            raise
+            db_dir = self.config_reader.get_database_path().parent
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Rekordbox database location is unknown")
+            self._status = nowplaying.inputs.InputStatus.broken(
+                "Cannot work out where the Rekordbox database lives."
+            )
+            return False
 
-        db_dir = str(self.database_reader.database_path.parent)
+        if not db_dir.is_dir():
+            self._status = nowplaying.inputs.InputStatus.waiting(
+                "Waiting for the Rekordbox library to appear.", f"{db_dir} is not there"
+            )
+            return False
+
         logging.info("Watching for Rekordbox database changes in %s", db_dir)
 
         self.event_handler = PatternMatchingEventHandler(
@@ -209,12 +325,20 @@ class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attribu
         else:
             self.observer = Observer()
 
-        self.observer.schedule(self.event_handler, db_dir, recursive=False)
-        self.observer.start()
+        try:
+            self.observer.schedule(self.event_handler, str(db_dir), recursive=False)
+            self.observer.start()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Could not watch %s", db_dir)
+            self.observer = None
+            self._status = nowplaying.inputs.InputStatus.waiting(
+                "Waiting for the Rekordbox library to appear.", f"could not watch {db_dir}"
+            )
+            return False
+
         self._running = True
         self._needs_refresh = True
-
-        logging.info("Rekordbox plugin started successfully")
+        return True
 
     async def stop(self):
         """Stop the plugin and cleanup"""
@@ -247,7 +371,20 @@ class RekordboxPlugin(InputPlugin):  # pylint: disable=too-many-instance-attribu
         return False
 
     async def getplayingtrack(self) -> dict:
-        """Get the currently playing track metadata"""
+        """Get the currently playing track metadata.
+
+        Reopens the database when status() has noticed a new key: this is where
+        that belongs, since it is the call already allowed to do the work.
+        """
+        if self._status.health is nowplaying.inputs.InputHealth.STARTING:
+            await self._ensure_started()
+            # Setup has to have finished, which is narrower than "worth
+            # polling": InputStatus is truthy for WAITING too, so testing the
+            # status itself would walk into a read with no database open.
+            if self._status.health is not nowplaying.inputs.InputHealth.OK:
+                return self._current_track or {}
+            self._needs_refresh = True
+
         if self._check_wal_mtime():
             self._needs_refresh = True
         if self._needs_refresh:

--- a/nowplaying/serato/handler.py
+++ b/nowplaying/serato/handler.py
@@ -89,7 +89,7 @@ class Serato4Handler:  # pylint: disable=too-many-instance-attributes
         """Stop the handler and clean up resources"""
         if self.observer:
             self.observer.stop()
-            self.observer.join()
+            await asyncio.to_thread(self.observer.join)
             self.observer = None
 
         # Cancel any pending tasks and wait for them to finish

--- a/nowplaying/serato3/plugin.py
+++ b/nowplaying/serato3/plugin.py
@@ -191,7 +191,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes,too-m
             self.local = stilllocal
             self.url = stillurl
             if self.serato:
-                self.serato.stop()
+                await asyncio.to_thread(self.serato.stop)
             polling_interval = self.config.cparser.value(
                 "quirks/pollinginterval", type=float, defaultValue=1.0
             )
@@ -366,7 +366,7 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes,too-m
     async def stop(self):
         """stop the handler"""
         if self.serato:
-            self.serato.stop()
+            await asyncio.to_thread(self.serato.stop)
         # Clear crate cache on stop
         self._crate_count_cache.clear()
 

--- a/nowplaying/wizard/verify.py
+++ b/nowplaying/wizard/verify.py
@@ -11,9 +11,13 @@ import contextlib
 import dataclasses
 import enum
 import logging
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QThread, Signal  # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QWidget  # pylint: disable=no-name-in-module
+
+if TYPE_CHECKING:
+    import nowplaying.inputs
 
 # A plugin's start() may never return -- Denon runs discovery, Icecast waits on
 # a broadcaster -- so every call the worker makes is bounded.
@@ -122,8 +126,12 @@ class VerifyWorker(QThread):
         assert self._stop is not None
         while not self._stop.is_set():
             try:
-                meta = await asyncio.wait_for(plugin.getplayingtrack(), timeout=POLL_TIMEOUT)
-                self.observed.emit(_classify(meta))
+                status = plugin.status()
+                if (settled := _from_status(status)) is not None:
+                    self.observed.emit(settled)
+                else:
+                    meta = await asyncio.wait_for(plugin.getplayingtrack(), timeout=POLL_TIMEOUT)
+                    self.observed.emit(_classify(meta, waiting=status.message))
             except TimeoutError:
                 self.observed.emit(
                     VerifyResult(VerifyStatus.TIMEOUT, "This source stopped responding.")
@@ -139,24 +147,53 @@ class VerifyWorker(QThread):
                 await asyncio.wait_for(self._stop.wait(), timeout=POLL_INTERVAL)
 
 
+def _from_status(status: "nowplaying.inputs.InputStatus") -> VerifyResult | None:
+    """Report what the plugin says about itself, or None to go on polling.
+
+    A plugin that cannot work knows why and says so in terms fit to show
+    someone, which is the whole reason status() carries a message. Polling it
+    anyway would produce "No track yet." indefinitely and leave the user to
+    guess whether they had done something wrong.
+    """
+    if status:
+        # OK, STARTING and WAITING all expect to produce a track, so carry on
+        # polling; WAITING's message becomes the label if nothing arrives.
+        return None
+    return VerifyResult(
+        VerifyStatus.FAILED,
+        status.message or "This source cannot run right now.",
+        detail=status.detail or None,
+    )
+
+
 def _explain(error: BaseException) -> str:
     """Prefer the plugin's own words.
 
     Plugins raise domain errors that already say what to do -- Rekordbox's
     names the missing key and where to enter it -- and replacing that with a
     generic "could not start" throws away the only actionable part.
+
+    Only start() failures reach this now: per the input contract those are
+    defects rather than misconfiguration, so there is no message written for a
+    user to read and the exception text is the best available.
     """
     text = str(error).strip()
     return text or "Could not start this source."
 
 
-def _classify(meta) -> VerifyResult:
-    """Turn a getplayingtrack() result into something worth showing a user."""
+def _classify(meta, waiting: str = "") -> VerifyResult:
+    """Turn a getplayingtrack() result into something worth showing a user.
+
+    `waiting` is what the plugin said it was waiting on, used in place of the
+    generic label so a stalled source explains itself rather than looking the
+    same as one nobody has played a track on yet.
+    """
+    nothing = waiting or "No track yet."
     if not meta:
-        return VerifyResult(VerifyStatus.WAITING, "No track yet.")
+        return VerifyResult(VerifyStatus.WAITING, nothing)
     artist = meta.get("artist") or ""
     title = meta.get("title") or ""
     if not (artist or title):
-        return VerifyResult(VerifyStatus.WAITING, "No track yet.")
+        return VerifyResult(VerifyStatus.WAITING, nothing)
     seen = " — ".join(part for part in (artist, title) if part)
     return VerifyResult(VerifyStatus.OK, f"Reading: {seen}")

--- a/tests-qt/test_wizard_verify_retry.py
+++ b/tests-qt/test_wizard_verify_retry.py
@@ -165,3 +165,49 @@ def test_display_machine_page_gets_verification(bootstrap, qtbot):  # pylint: di
     assert page.verification_module is not None, (
         "display machine page has no verification_module, so it never verifies"
     )
+
+
+def test_a_plugin_that_cannot_work_says_so_instead_of_no_track_yet():
+    """Its own message reaches the user, rather than being inferred from silence."""
+    status = nowplaying.inputs.InputStatus(
+        health=nowplaying.inputs.InputHealth.NEEDS_USER,
+        message="Rekordbox key does not open the database.",
+        detail="file is not a database",
+    )
+    result = nowplaying.wizard.verify._from_status(status)  # pylint: disable=protected-access
+    assert result is not None
+    assert result.status is nowplaying.wizard.verify.VerifyStatus.FAILED
+    assert result.message == "Rekordbox key does not open the database."
+    assert result.detail == "file is not a database"
+
+
+def test_healthy_and_waiting_plugins_keep_being_polled():
+    """WAITING is the plugin handling something, not a verdict to report."""
+    for health in (
+        nowplaying.inputs.InputHealth.OK,
+        nowplaying.inputs.InputHealth.STARTING,
+        nowplaying.inputs.InputHealth.WAITING,
+    ):
+        status = nowplaying.inputs.InputStatus(health=health, message="hold on")
+        assert (
+            nowplaying.wizard.verify._from_status(status) is None  # pylint: disable=protected-access
+        ), f"{health.name} should keep polling"
+
+
+def test_waiting_message_replaces_the_generic_label():
+    """A stalled source explains itself instead of looking unplayed."""
+    stalled = nowplaying.wizard.verify._classify(None, waiting="Port 8000 is in use.")  # pylint: disable=protected-access
+    assert stalled.status is nowplaying.wizard.verify.VerifyStatus.WAITING
+    assert stalled.message == "Port 8000 is in use."
+
+    quiet = nowplaying.wizard.verify._classify(None)  # pylint: disable=protected-access
+    assert quiet.message == "No track yet."
+
+
+def test_a_track_beats_any_waiting_message():
+    """Something playing is the answer the page is waiting for."""
+    result = nowplaying.wizard.verify._classify(  # pylint: disable=protected-access
+        {"artist": "Wire", "title": "The 15th"}, waiting="Port 8000 is in use."
+    )
+    assert result.status is nowplaying.wizard.verify.VerifyStatus.OK
+    assert "Wire" in result.message and "The 15th" in result.message

--- a/tests/test_denon.py
+++ b/tests/test_denon.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 """Tests for Denon DJ StagelinQ input plugin"""
+
+# pylint: disable=too-many-lines
 # pylint: disable=protected-access,redefined-outer-name
 
 import asyncio
+import contextlib
 import struct
 import time
 
 import pytest
 
-import nowplaying.inputs.denon
 from nowplaying.denon import StagelinqError
 from nowplaying.denon.connection import ConnectionManager, DeviceConnection
 from nowplaying.denon.protocol import StagelinqProtocol
 from nowplaying.denon.types import MSG_SERVICES_REQUEST, DenonDevice, DenonService, DenonState
+import nowplaying.inputs
+import nowplaying.inputs.denon
 
 DEVICE_TOKEN_1 = b"\x01" * 16
 DEVICE_TOKEN_2 = b"\x02" * 16
@@ -975,3 +979,62 @@ def test_get_broadcast_addresses():
     assert "255.255.255.255" in addresses
     for address in addresses:
         assert not address.startswith("127.")
+
+
+@pytest.mark.asyncio
+async def test_denon_asks_for_a_restart_when_discovery_stops(bootstrap):  # pylint: disable=redefined-outer-name
+    """A discovery task that ended is the failure start() could never report.
+
+    start() launches endless tasks and returns, so nothing raises when one of
+    them falls out of its loop; the plugin simply stops finding players. This is
+    the only way a caller learns.
+    """
+    plugin = nowplaying.inputs.denon.Plugin(config=bootstrap)
+
+    async def _ended():
+        """A task that has already finished."""
+
+    task = asyncio.create_task(_ended())
+    await task
+    plugin.connection_manager.tasks.append(task)
+
+    status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.NEEDS_RESTART
+    assert not status, "nothing is looking for players, so do not keep polling"
+    assert "Denon" in status.message
+
+
+@pytest.mark.asyncio
+async def test_denon_waits_while_it_looks_for_players(bootstrap):  # pylint: disable=redefined-outer-name
+    """No players yet is WAITING: normal, and worth saying rather than silence."""
+    plugin = nowplaying.inputs.denon.Plugin(config=bootstrap)
+
+    status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.WAITING
+    assert status, "still expects to find something, so keep polling"
+
+
+@pytest.mark.asyncio
+async def test_denon_shutdown_is_not_a_fault(bootstrap):  # pylint: disable=redefined-outer-name
+    """stop() cancels the discovery tasks, which must not read as failure.
+
+    Without excluding cancelled tasks, a deliberate shutdown looks exactly like
+    the catastrophic case and the plugin asks to be restarted on its way out.
+    """
+    plugin = nowplaying.inputs.denon.Plugin(config=bootstrap)
+
+    async def _forever():
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(_forever())
+    await asyncio.sleep(0)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+    plugin.connection_manager.tasks.append(task)
+
+    status = plugin.status()
+    assert status.health is not nowplaying.inputs.InputHealth.NEEDS_RESTART, (
+        "a cancelled task is a shutdown, not a failure"
+    )

--- a/tests/test_icecast.py
+++ b/tests/test_icecast.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import nowplaying.inputs
+import nowplaying.utils.network
 import nowplaying.inputs.icecast
 
 
@@ -818,3 +820,35 @@ def test_empty_explicit_fields_do_not_clobber_song(query, expected, description)
         f"GET /admin/metadata?mode=updinfo&{query} HTTP/1.0".encode()
     )
     assert callback.call_args[0][0] == expected
+
+
+@pytest.mark.asyncio
+async def test_icecast_reports_waiting_when_the_port_is_not_bound(bootstrap):  # pylint: disable=redefined-outer-name
+    """An unbound port is WAITING, not the user's problem.
+
+    Whatever holds the port usually lets go, and this plugin already retries on
+    its own timer, so there is nothing for a caller to do but keep asking. It
+    still has to say so: a broadcaster aimed at a port nobody is listening on
+    otherwise looks like one that simply has not connected.
+    """
+    plugin = nowplaying.inputs.icecast.Plugin(config=bootstrap)
+    assert plugin.server is None
+
+    status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.WAITING
+    assert status, "WAITING still expects to produce a track, so keep polling"
+    assert "port" in status.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_icecast_is_ok_once_the_port_is_bound(bootstrap):  # pylint: disable=redefined-outer-name
+    """The healthy case has to be quiet or WAITING carries no information."""
+    plugin = nowplaying.inputs.icecast.Plugin(config=bootstrap)
+    port = nowplaying.utils.network.first_free_port(8010)
+    bootstrap.cparser.setValue(plugin._port_config_key, port)  # pylint: disable=protected-access
+    await plugin.start()
+    try:
+        assert plugin.server is not None, f"could not bind {port} for the test"
+        assert plugin.status().health is nowplaying.inputs.InputHealth.OK
+    finally:
+        await plugin.stop()

--- a/tests/test_input_contract.py
+++ b/tests/test_input_contract.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Rules that hold for every input plugin, checked once rather than per plugin.
+
+See nowplaying/inputs/CLAUDE.md for the contract these enforce.
+"""
+
+import ast
+import asyncio
+import pathlib
+import time
+
+import pytest  # pylint: disable=import-error
+
+NOWPLAYING = pathlib.Path(__file__).parent.parent / "nowplaying"
+
+
+def _thread_joins(node: ast.AST) -> list[int]:
+    """Line numbers of no-argument .join() calls inside node.
+
+    No arguments is what separates a thread or process join from str.join(),
+    which always takes an iterable.
+    """
+    return [
+        child.lineno
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and child.func.attr == "join"
+        and not child.args
+        and not child.keywords
+    ]
+
+
+def _async_functions_that_join() -> list[str]:
+    """Every async def in nowplaying/ that joins a thread without offloading it."""
+    offenders = []
+    for path in sorted(NOWPLAYING.rglob("*.py")):
+        if "vendor" in path.parts:
+            continue
+        source = path.read_text()
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+            joins = _thread_joins(node)
+            if not joins:
+                continue
+            segment = ast.get_source_segment(source, node) or ""
+            if "to_thread" in segment:
+                continue
+            rel = path.relative_to(NOWPLAYING.parent)
+            offenders.append(f"{rel}:{joins[0]} in async {node.name}()")
+    return offenders
+
+
+def test_no_coroutine_joins_a_thread_without_offloading_it():
+    """A coroutine that blocks without awaiting cannot be bounded or cancelled.
+
+    trackpoll bounds every stop() with asyncio.wait_for, but a deadline is
+    cooperative: it can only interrupt work that reaches an await. A bare
+    observer.join() in an async def blocks the whole event loop instead, and
+    wait_for returns late without even raising.
+
+    asyncio.to_thread is the house fix -- it moves the join off the loop and
+    creates the suspension point that makes the timeout real.
+    """
+    offenders = _async_functions_that_join()
+    assert not offenders, "blocking join inside a coroutine:\n" + "\n".join(offenders)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cannot_bound_a_coroutine_that_never_awaits():
+    """Why the rule above exists, rather than a style preference.
+
+    Pins the asyncio behaviour the contract depends on, so the reasoning
+    survives someone deciding the static check is pedantic.
+    """
+
+    async def blocks_without_awaiting():
+        time.sleep(0.5)
+
+    started = time.monotonic()
+    await asyncio.wait_for(blocks_without_awaiting(), timeout=0.05)
+    assert time.monotonic() - started >= 0.5, "the sleep was somehow interrupted"
+
+    async def blocks_on_a_thread():
+        await asyncio.to_thread(time.sleep, 0.5)
+
+    started = time.monotonic()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(blocks_on_a_thread(), timeout=0.05)
+    assert time.monotonic() - started < 0.5, "offloading did not make it cancellable"

--- a/tests/test_jriver.py
+++ b/tests/test_jriver.py
@@ -11,6 +11,7 @@ import pytest
 import pytest_asyncio
 from utils_aiohttp import simulate_client_exception
 
+import nowplaying.inputs  # pylint: disable=import-error,no-name-in-module
 import nowplaying.inputs.jriver  # pylint: disable=import-error,no-name-in-module
 
 
@@ -1212,3 +1213,79 @@ def test_log_rate_limiting():
     # After waiting, should allow logging again
     time.sleep(0.2)
     assert plugin._should_log_error()  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_jriver_without_a_host_needs_the_user(bootstrap):  # pylint: disable=redefined-outer-name
+    """No host configured cannot be fixed by waiting."""
+    bootstrap.cparser.remove("jriver/host")
+    plugin = nowplaying.inputs.jriver.Plugin(config=bootstrap)
+    status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.NEEDS_USER
+    assert not status, "nothing to poll until a host is set"
+
+
+@pytest.mark.asyncio
+async def test_jriver_unreachable_host_is_waiting(bootstrap):  # pylint: disable=redefined-outer-name
+    """A host that will not answer may come back, so keep polling.
+
+    Points at a port nothing is listening on, so this needs no JRiver.
+    """
+    bootstrap.cparser.setValue("jriver/host", "127.0.0.1")
+    bootstrap.cparser.setValue("jriver/port", "52198")
+    plugin = nowplaying.inputs.jriver.Plugin(config=bootstrap)
+    await plugin.start()
+    try:
+        status = plugin.status()
+        assert status.health is nowplaying.inputs.InputHealth.WAITING
+        assert status, "it may come back, so keep asking"
+        assert "127.0.0.1" in status.message
+    finally:
+        await plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_jriver_reports_ok_once_it_has_a_server(aiointercept_mock, bootstrap):  # pylint: disable=redefined-outer-name
+    """A reachable server reports OK, so the caller polls it.
+
+    Verified against a real Media Center 36 during development; kept mocked so
+    it means the same thing on a machine that has no JRiver.
+    """
+    bootstrap.cparser.setValue("jriver/host", "localhost")
+    bootstrap.cparser.setValue("jriver/port", "52199")
+    aiointercept_mock.get(
+        "http://localhost:52199/MCWS/v1/Alive",
+        body='<Response Status="OK"><Item Name="ProgramName">JRiver Media Center</Item></Response>',
+    )
+
+    plugin = nowplaying.inputs.jriver.Plugin(config=bootstrap)  # pylint: disable=no-member
+    assert await plugin.start() is True
+    try:
+        status = plugin.status()
+        assert status.health is nowplaying.inputs.InputHealth.OK
+        assert status, "a working server is worth polling"
+    finally:
+        await plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_host_entered_later_reports_starting(bootstrap):  # pylint: disable=redefined-outer-name
+    """start() gave up with no host, so nothing was built to poll with.
+
+    Reporting OK once the host appears would promise a working plugin while
+    getplayingtrack() went on returning None off the base_url guard. STARTING
+    is what licenses the connect.
+    """
+    bootstrap.cparser.remove("jriver/host")
+    plugin = nowplaying.inputs.jriver.Plugin(config=bootstrap)  # pylint: disable=no-member
+    await plugin.start()
+    try:
+        assert plugin.status().health is nowplaying.inputs.InputHealth.NEEDS_USER
+
+        bootstrap.cparser.setValue("jriver/host", "localhost")
+        bootstrap.cparser.setValue("jriver/port", "52199")
+        status = plugin.status()
+        assert status.health is nowplaying.inputs.InputHealth.STARTING
+        assert status, "STARTING is polled, which is how the connect happens"
+    finally:
+        await plugin.stop()

--- a/tests/test_mpris2.py
+++ b/tests/test_mpris2.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     DBUS_FAST_AVAILABLE = False
 
+import nowplaying.inputs
 import nowplaying.inputs.mpris2  # pylint: disable=import-error,no-member,no-name-in-module
 
 
@@ -242,3 +243,25 @@ async def test_getplayingtrack_multiple_artists():
         assert result["artist"] == "Artist One/Artist Two/Artist Three"
         assert result["title"] == "Collaboration Song"
         assert result["duration"] == 180
+
+
+def test_choosing_a_player_later_is_recoverable(bootstrap):  # pylint: disable=redefined-outer-name
+    """Clearing the handler used to be permanent.
+
+    gethandler() guarded on self.mpris2 and then set it to None when no player
+    was chosen, so choosing one afterwards left nothing to rebuild it. Patches
+    dbus_status because this machine has no D-Bus.
+    """
+    plugin = nowplaying.inputs.mpris2.Plugin(config=bootstrap)
+    plugin.dbus_status = True
+    plugin.mpris2 = None
+    bootstrap.cparser.remove("mpris2/service")
+
+    assert plugin.status().health is nowplaying.inputs.InputHealth.NEEDS_USER
+
+    bootstrap.cparser.setValue("mpris2/service", "spotify")
+    status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.STARTING, (
+        "reporting OK here would promise a plugin with no handler"
+    )
+    assert status, "STARTING is polled, which is how the handler gets rebuilt"

--- a/tests/test_rekordbox.py
+++ b/tests/test_rekordbox.py
@@ -2,6 +2,7 @@
 """Test Rekordbox plugin"""
 # pylint: disable=protected-access,missing-function-docstring,redefined-outer-name
 
+import base64
 import json
 import pathlib
 import sys
@@ -10,13 +11,28 @@ from contextlib import asynccontextmanager
 
 import pytest
 import pytest_asyncio
+from Crypto.Cipher import Blowfish
 
+import nowplaying.inputs  # pylint: disable=import-error
 import nowplaying.rekordbox.config
 import nowplaying.rekordbox.database
 import nowplaying.rekordbox.plugin
 import nowplaying.rekordbox.types
 
 _TEST_KEY = "0123456789abcdef" * 4  # valid 64-char hex key for tests
+
+
+def _make_dp_blob(plaintext: str) -> str:
+    """Encrypt plaintext the same way Rekordbox's options.json 'dp' field is
+    encrypted, so tests can exercise a real decrypt round-trip."""
+    magic = nowplaying.rekordbox.config._decode_secret(
+        nowplaying.rekordbox.config._RB6_MAGIC_BLOB
+    ).encode()
+    cipher = Blowfish.new(magic, Blowfish.MODE_ECB)
+    data = plaintext.encode("utf-8")
+    pad_len = 8 - (len(data) % 8)
+    padded = data + bytes([pad_len]) * pad_len
+    return base64.b64encode(cipher.encrypt(padded)).decode()
 
 
 class MockSqlCipher:  # pylint: disable=too-few-public-methods
@@ -167,6 +183,9 @@ async def _db_reader(mock_database_path, mock_data=None):
     ):
         reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
         await reader.initialize(custom_key=_TEST_KEY)
+        # initialize() validates the key with a query of its own. Drop it so
+        # callers can index executed_queries by what they actually exercised.
+        mock_sq.executed_queries.clear()
         yield mock_sq, reader
 
 
@@ -238,8 +257,8 @@ def test_config_data_path_windows_fallback(monkeypatch):
     assert path.parts[-4:] == ("AppData", "Roaming", "Pioneer", "rekordbox")
 
 
-def test_config_get_password_rb7_fallback():
-    """get_password() returns empty string for RB7 (no embedded key)"""
+def test_config_get_password_missing_options_file():
+    """get_password() returns empty string when options.json doesn't exist"""
     config = nowplaying.rekordbox.config.ConfigReader()
     with unittest.mock.patch(
         "nowplaying.rekordbox.config._get_options_path",
@@ -249,8 +268,28 @@ def test_config_get_password_rb7_fallback():
     assert password == ""
 
 
-def test_config_get_password_rb7_from_options(tmp_path):
-    """get_password() returns empty string when options.json reports app_ver=7.x"""
+@pytest.mark.parametrize("app_ver", ["6.8.5", "7.1.4"])
+def test_config_get_password_decrypts_dp_regardless_of_version(tmp_path, app_ver):
+    """get_password() decrypts a valid 'dp' field regardless of app_ver.
+
+    RB6 and RB7 installs upgraded from RB6 both carry this field; only a
+    fresh RB7 install may lack it, which callers must handle separately
+    by validating the returned key actually opens the database.
+    """
+    options_file = tmp_path / "options.json"
+    options_file.write_text(
+        json.dumps({"options": [["dp", _make_dp_blob(_TEST_KEY)], ["app_ver", app_ver]]})
+    )
+    config = nowplaying.rekordbox.config.ConfigReader()
+    with unittest.mock.patch(
+        "nowplaying.rekordbox.config._get_options_path",
+        return_value=options_file,
+    ):
+        assert config.get_password() == _TEST_KEY
+
+
+def test_config_get_password_undecryptable_dp_returns_empty(tmp_path):
+    """get_password() gracefully returns empty string when 'dp' can't be decrypted"""
     options_file = tmp_path / "options.json"
     options_file.write_text(
         '{"options":[["db-path","/tmp/master.db"],["dp","ignored"],["app_ver","7.1.4"]]}'
@@ -359,8 +398,12 @@ def test_types_track_to_metadata():
 @pytest.mark.asyncio
 async def test_database_initialization(mock_database_path):
     config_reader = nowplaying.rekordbox.config.ConfigReader()
-    with unittest.mock.patch.object(
-        config_reader, "get_database_path", return_value=mock_database_path
+    mock_sq = MockSqlCipher()
+    with (
+        unittest.mock.patch.object(
+            config_reader, "get_database_path", return_value=mock_database_path
+        ),
+        unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sq),
     ):
         reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
         await reader.initialize(custom_key=_TEST_KEY)
@@ -424,6 +467,8 @@ async def test_database_get_random_track_from_playlist(mock_database_path):
 
 @pytest.mark.asyncio
 async def test_database_connection_failure(mock_database_path):
+    """A connection failure during the key-validation query now surfaces from
+    initialize() itself rather than later from get_recent_track()."""
     config_reader = nowplaying.rekordbox.config.ConfigReader()
     mock_sqlite = unittest.mock.Mock()
     mock_sqlite.connect.side_effect = Exception("Connection failed")
@@ -434,9 +479,8 @@ async def test_database_connection_failure(mock_database_path):
         unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite),
     ):
         reader = nowplaying.rekordbox.database.DatabaseReader(config_reader)
-        await reader.initialize(custom_key=_TEST_KEY)
         with pytest.raises(nowplaying.rekordbox.types.RekordboxError):
-            await reader.get_recent_track()
+            await reader.initialize(custom_key=_TEST_KEY)
 
 
 @pytest.mark.asyncio
@@ -570,6 +614,30 @@ async def test_plugin_get_random_track(rekordbox_plugin, mock_sqlcipher):
 
 
 @pytest.mark.asyncio
+async def test_plugin_reports_needs_user_when_key_does_not_validate(rekordbox_plugin):
+    """A key that cannot open the database is the user's to fix, not an exception.
+
+    Reporting it through status() is what lets the wizard show the reason and
+    trackpoll stop polling, neither of which an exception could express.
+    """
+    mock_sqlite = unittest.mock.Mock()
+    mock_sqlite.connect.side_effect = Exception("file is not a database")
+    with unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite):
+        await rekordbox_plugin.start(testmode=True)
+
+    try:
+        status = rekordbox_plugin.status()
+        assert status.health is nowplaying.inputs.InputHealth.NEEDS_USER
+        assert status.message, "the user needs to be told what to do"
+        assert not status, "a plugin needing the user is not worth polling"
+        # _running means the watcher is up, which it is: whether the plugin can
+        # actually read anything is what status() answers.
+        assert rekordbox_plugin._running  # pylint: disable=protected-access
+    finally:
+        await rekordbox_plugin.stop()
+
+
+@pytest.mark.asyncio
 async def test_plugin_components_connected(mock_database_path):
     """Plugin wires config_reader into database_reader at construction"""
     mock_config = unittest.mock.Mock()
@@ -636,3 +704,95 @@ async def test_database_bpm_scaling_end_to_end(mock_database_path):
     assert track is not None
     assert track.bpm == 128.0
     assert track.to_metadata()["bpm"] == "128"
+
+
+@pytest.mark.asyncio
+async def test_a_corrected_key_recovers_without_a_restart(rekordbox_plugin):
+    """status() notices the new key, and getplayingtrack() does the reopening.
+
+    status() is called every cycle, so it stays a config read; the database work
+    happens in the call that is already allowed to do work.
+    """
+    mock_sqlite = unittest.mock.Mock()
+    mock_sqlite.connect.side_effect = Exception("file is not a database")
+    with unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite):
+        await rekordbox_plugin.start(testmode=True)
+        assert rekordbox_plugin.status().health is nowplaying.inputs.InputHealth.NEEDS_USER
+
+        # Same key: still the user's problem, and no further database attempts.
+        attempts = mock_sqlite.connect.call_count
+        for _ in range(5):
+            assert rekordbox_plugin.status().health is nowplaying.inputs.InputHealth.NEEDS_USER
+        assert mock_sqlite.connect.call_count == attempts, "status() must not touch the database"
+
+        # The user enters a different key.
+        rekordbox_plugin.config.cparser.setValue("rekordbox/custom_key", "b" * 64)
+        assert rekordbox_plugin.status().health is nowplaying.inputs.InputHealth.STARTING
+
+
+@pytest.mark.asyncio
+async def test_a_bad_key_still_leaves_the_watcher_running(rekordbox_plugin):
+    """The directory to watch comes from options.json, not from decrypting anything.
+
+    Returning early on a bad key would leave no observer, and the later reopen
+    does not create one, so the plugin would spend the session on
+    _check_wal_mtime() stat polling instead of file events.
+    """
+    mock_sqlite = unittest.mock.Mock()
+    mock_sqlite.connect.side_effect = Exception("file is not a database")
+    with unittest.mock.patch("nowplaying.rekordbox.database.sqlite", mock_sqlite):
+        await rekordbox_plugin.start(testmode=True)
+    try:
+        assert rekordbox_plugin.status().health is nowplaying.inputs.InputHealth.NEEDS_USER
+        assert rekordbox_plugin.observer is not None, "no observer was created"
+        assert rekordbox_plugin.observer.is_alive(), "the observer is not running"
+        assert rekordbox_plugin._running  # pylint: disable=protected-access
+    finally:
+        await rekordbox_plugin.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("polling", [False, True])
+async def test_a_missing_library_waits_instead_of_raising(bootstrap, tmp_path, polling):  # pylint: disable=redefined-outer-name
+    """start() must not raise for a library that is not there.
+
+    PollingObserver and inotify both raise FileNotFoundError from schedule() on
+    a missing path, where macOS fsevents does not, so this is parameterized:
+    testing only the default observer passes on a Mac and breaks elsewhere.
+    """
+    bootstrap.cparser.setValue("quirks/pollingobserver", polling)
+    bootstrap.cparser.setValue("quirks/pollinginterval", 0.5)
+    missing = tmp_path / "not-here" / "master.db"
+
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=bootstrap)
+    with unittest.mock.patch.object(
+        plugin.config_reader, "get_database_path", return_value=missing
+    ):
+        await plugin.start(testmode=True)
+        try:
+            status = plugin.status()
+            assert status.health is nowplaying.inputs.InputHealth.WAITING
+            assert status, "a library that may yet appear is worth polling"
+            assert plugin.observer is None, "nothing to watch, so no observer"
+        finally:
+            await plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_library_appearing_moves_to_starting(bootstrap, tmp_path):  # pylint: disable=redefined-outer-name
+    """WAITING lifts only once the file is actually there.
+
+    Reporting STARTING on a still-missing library would have getplayingtrack()
+    redo the setup every cycle.
+    """
+    later = tmp_path / "master.db"
+    plugin = nowplaying.rekordbox.plugin.RekordboxPlugin(config=bootstrap)
+    with unittest.mock.patch.object(plugin.config_reader, "get_database_path", return_value=later):
+        await plugin.start(testmode=True)
+        try:
+            assert plugin.status().health is nowplaying.inputs.InputHealth.WAITING
+
+            later.write_bytes(b"not a real database, but it exists")
+            assert plugin.status().health is nowplaying.inputs.InputHealth.STARTING
+        finally:
+            await plugin.stop()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import nowplaying.db
+import nowplaying.inputs
 import nowplaying.inputs.remote
 
 
@@ -318,3 +319,46 @@ async def test_remote_plugin_integration_with_metadatadb_write(remote_bootstrap)
     assert plugin.metadata["artist"] == "Artist Two"
     assert plugin.metadata["title"] == "Title Two"
     assert plugin.metadata["filename"] == "track2.mp3"
+
+
+@pytest.mark.asyncio
+async def test_remote_reports_needs_restart_when_the_watcher_dies(bootstrap):  # pylint: disable=redefined-outer-name
+    """A dead watcher delivers nothing and looks like nobody is sending.
+
+    Scheduling the same directory another observer already holds kills the
+    emitter thread after start() has returned, so nothing raises and the plugin
+    goes quiet. status() is the only way that becomes visible.
+    """
+    plugin = nowplaying.inputs.remote.Plugin(config=bootstrap)
+    await plugin.start()
+    try:
+        assert plugin.status().health is nowplaying.inputs.InputHealth.OK
+
+        # Kill the emitter, not the dispatcher: an "already scheduled"
+        # RuntimeError takes out the emitter thread and leaves the observer's
+        # own thread looping happily, which is what made this reportable.
+        for emitter in list(plugin.observer.observer.emitters):
+            emitter.stop()
+            emitter.join()
+        assert plugin.observer.observer.is_alive(), (
+            "the dispatcher should still be up -- otherwise this tests the wrong thread"
+        )
+
+        status = plugin.status()
+        assert status.health is nowplaying.inputs.InputHealth.NEEDS_RESTART
+        assert not status, "a plugin needing a restart is not worth polling"
+        assert "tracks" in status.message
+    finally:
+        await plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_remote_is_ok_while_the_watcher_runs(bootstrap):  # pylint: disable=redefined-outer-name
+    """The healthy case has to stay quiet or the restart means nothing."""
+    plugin = nowplaying.inputs.remote.Plugin(config=bootstrap)
+    await plugin.start()
+    try:
+        for _ in range(5):
+            assert plugin.status().health is nowplaying.inputs.InputHealth.OK
+    finally:
+        await plugin.stop()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -180,15 +180,18 @@ async def test_remote_plugin_stop(remote_bootstrap):  # pylint: disable=redefine
     config = remote_bootstrap
     plugin = nowplaying.inputs.remote.Plugin(config=config)
 
-    # Set up observer
-    plugin.observer = MagicMock()
+    # Set up observer. Held in a local because stop() drops the reference, so
+    # status() cannot mistake a stopped watcher for a dead one.
+    observer = MagicMock()
+    plugin.observer = observer
     plugin.metadata = {"artist": "Test Artist", "title": "Test Title", "filename": "test.mp3"}
 
     await plugin.stop()
 
     # Should reset metadata and stop observer
     assert plugin.metadata == {"artist": None, "title": None, "filename": None}
-    plugin.observer.stop.assert_called_once()
+    observer.stop.assert_called_once()
+    assert plugin.observer is None
 
 
 @pytest.mark.asyncio
@@ -362,3 +365,25 @@ async def test_remote_is_ok_while_the_watcher_runs(bootstrap):  # pylint: disabl
             assert plugin.status().health is nowplaying.inputs.InputHealth.OK
     finally:
         await plugin.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_cleanly_stopped_remote_does_not_report_needs_restart(bootstrap):  # pylint: disable=redefined-outer-name
+    """ "Stopped" and "the watcher died" must not be the same signal.
+
+    DBWatcher.stop() clears its own inner observer, so a DBWatcher that was
+    asked to stop is indistinguishable from one whose emitter died unless the
+    plugin drops the reference too. trackpoll rebuilds on NEEDS_RESTART, so
+    leaving it set after a deliberate stop invites a restart loop.
+    """
+    plugin = nowplaying.inputs.remote.Plugin(config=bootstrap)
+    await plugin.start()
+    assert plugin.status().health is nowplaying.inputs.InputHealth.OK
+
+    await plugin.stop()
+
+    assert plugin.observer is None, "stop() has to drop the watcher, not just stop it"
+    status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.OK, (
+        f"a stopped plugin reported {status.health}, which would trigger a rebuild"
+    )

--- a/tests/test_trackpoll.py
+++ b/tests/test_trackpoll.py
@@ -7,11 +7,13 @@ import logging
 import pathlib
 import sys
 import threading
+import time
 import unittest.mock
 
 import pytest  # pylint: disable=import-error
 import pytest_asyncio  # pylint: disable=import-error
 
+import nowplaying.inputs  # pylint: disable=import-error
 import nowplaying.processes.trackpoll  # pylint: disable=import-error
 from tests.utils_images import jpeg_bytes, png_bytes
 
@@ -745,3 +747,253 @@ async def test_check_earshot_override_ignores_same_as_main(trackpoll_testmode): 
     assert result == main_meta
     # earshot_last_meta updated so next poll does not recheck
     assert tptest.earshot_last_meta == earshot_meta  # pylint: disable=protected-access
+
+
+def _status_plugin(status, started=None, stopped=None):
+    """Build a Plugin class reporting a fixed status."""
+
+    class Reports:  # pylint: disable=no-self-use,too-few-public-methods
+        """Starts fine and reports whatever the test asked for."""
+
+        def __init__(self, config=None):  # pylint: disable=unused-argument
+            pass
+
+        async def start(self):
+            """Succeed, per the contract."""
+            if started is not None:
+                started.append(True)
+
+        async def stop(self):
+            """Release nothing."""
+            if stopped is not None:
+                stopped.append(True)
+
+        def status(self):
+            """Report the health under test."""
+            return status
+
+        async def getplayingtrack(self):
+            """No track."""
+            return None
+
+    return Reports
+
+
+def _use_plugin(trackpoll, config, plugin_cls):
+    """Point trackpoll at a single fake input."""
+    config.cparser.setValue("settings/input", "pretend")
+    trackpoll.plugins = {"nowplaying.inputs.pretend": unittest.mock.MagicMock(Plugin=plugin_cls)}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "health,pollable",
+    [
+        (nowplaying.inputs.InputHealth.OK, True),
+        (nowplaying.inputs.InputHealth.STARTING, True),
+        (nowplaying.inputs.InputHealth.WAITING, True),
+        (nowplaying.inputs.InputHealth.NEEDS_USER, False),
+        (nowplaying.inputs.InputHealth.NEEDS_RESTART, False),
+        (nowplaying.inputs.InputHealth.BROKEN, False),
+    ],
+)
+async def test_status_decides_whether_to_poll(bootstrap, trackpoll_testmode, health, pollable):  # pylint: disable=redefined-outer-name
+    """WAITING is the plugin saying it has this in hand, so polling continues."""
+    status = nowplaying.inputs.InputStatus(health=health, message="because")
+    _use_plugin(trackpoll_testmode, bootstrap, _status_plugin(status))
+    assert await trackpoll_testmode.switch_input_plugin() is pollable
+
+
+@pytest.mark.asyncio
+async def test_needs_user_is_reported_once(bootstrap, trackpoll_testmode, caplog):  # pylint: disable=redefined-outer-name
+    """The message cannot change until the user acts, so say it once."""
+    status = nowplaying.inputs.InputStatus(
+        health=nowplaying.inputs.InputHealth.NEEDS_USER,
+        message="Rekordbox key does not open the database",
+    )
+    _use_plugin(trackpoll_testmode, bootstrap, _status_plugin(status))
+
+    with caplog.at_level(logging.ERROR):
+        for _ in range(10):
+            assert await trackpoll_testmode.switch_input_plugin() is False
+
+    said = [r for r in caplog.records if "needs attention" in r.message]
+    assert len(said) == 1, f"reported {len(said)} times"
+    assert "does not open the database" in said[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_needs_restart_waits_then_rebuilds(bootstrap, trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """A restart is honoured once, after the delay, not on the next cycle."""
+    started = []
+    status = nowplaying.inputs.InputStatus(
+        health=nowplaying.inputs.InputHealth.NEEDS_RESTART, message="discovery died"
+    )
+    _use_plugin(trackpoll_testmode, bootstrap, _status_plugin(status, started=started))
+
+    assert await trackpoll_testmode.switch_input_plugin() is False
+    assert len(started) == 1
+
+    for _ in range(10):  # still inside the delay
+        await trackpoll_testmode.switch_input_plugin()
+    assert len(started) == 1, "restarted before the delay elapsed"
+
+    # Arrive at the far side of the wait without sleeping through it.
+    trackpoll_testmode._restart_input_at = time.monotonic() - 1  # pylint: disable=protected-access
+    await trackpoll_testmode.switch_input_plugin()  # notices the wait is over
+    await trackpoll_testmode.switch_input_plugin()  # rebuilds
+    assert len(started) == 2, "the restart never happened"
+
+
+@pytest.mark.asyncio
+async def test_earshot_is_still_read_when_the_main_source_cannot_run(
+    bootstrap, trackpoll_testmode
+):  # pylint: disable=redefined-outer-name
+    """gettrack() is the only thing that reads EarShot, so it has to keep running.
+
+    EarShot writes whether or not the chosen source works, and returning False
+    from switch_input_plugin() skips gettrack() entirely -- so a source stuck on
+    NEEDS_USER would silently discard everything EarShot produced.
+    """
+    config = bootstrap
+    config.cparser.setValue("settings/input", "pretend")
+    status = nowplaying.inputs.InputStatus(
+        health=nowplaying.inputs.InputHealth.NEEDS_USER, message="fix me"
+    )
+    healthy = nowplaying.inputs.InputStatus()
+    trackpoll_testmode.plugins = {
+        "nowplaying.inputs.pretend": unittest.mock.MagicMock(Plugin=_status_plugin(status)),
+    }
+
+    # No EarShot available: nothing to run, so the loop skips gettrack().
+    assert await trackpoll_testmode.switch_input_plugin() is False
+    assert trackpoll_testmode._input_pollable is False  # pylint: disable=protected-access
+
+    # EarShot present, so _manage_earshot_plugin() starts it and the loop has
+    # to reach gettrack() even though the chosen source cannot run.
+    trackpoll_testmode.plugins["nowplaying.inputs.earshot"] = unittest.mock.MagicMock(
+        Plugin=_status_plugin(healthy)
+    )
+    assert await trackpoll_testmode.switch_input_plugin() is True
+    assert trackpoll_testmode.earshot_plugin is not None
+    assert trackpoll_testmode._input_pollable is False, (  # pylint: disable=protected-access
+        "the main source is still not worth polling"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_restart_deadline_does_not_carry_across_plugins(bootstrap, trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """A deadline from a previous plugin would skip the wait the constant exists for."""
+    config = bootstrap
+    config.cparser.setValue("settings/input", "pretend")
+    status = nowplaying.inputs.InputStatus(
+        health=nowplaying.inputs.InputHealth.NEEDS_RESTART, message="again"
+    )
+    trackpoll_testmode.plugins = {
+        "nowplaying.inputs.pretend": unittest.mock.MagicMock(Plugin=_status_plugin(status)),
+        "nowplaying.inputs.other": unittest.mock.MagicMock(Plugin=_status_plugin(status)),
+    }
+
+    await trackpoll_testmode.switch_input_plugin()
+    # Pretend its wait already expired, then switch to a different input.
+    trackpoll_testmode._restart_input_at = time.monotonic() - 1  # pylint: disable=protected-access
+    config.cparser.setValue("settings/input", "other")
+    await trackpoll_testmode.switch_input_plugin()
+
+    pending = trackpoll_testmode._restart_input_at  # pylint: disable=protected-access
+    assert pending == 0.0 or pending > time.monotonic(), (
+        "the new plugin inherited an expired deadline"
+    )
+
+
+@pytest.mark.asyncio
+async def test_earshot_overrides_a_source_reporting_nothing(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """EarShot always accepts input, so it has to win against an empty source.
+
+    A source that cannot run contributes {} now rather than not being polled,
+    and EarShot's identification has to come through that.
+    """
+    heard = {"artist": "Wire", "title": "The 15th"}
+    earshot = unittest.mock.AsyncMock()
+    earshot.getplayingtrack.return_value = heard
+    trackpoll_testmode.earshot_plugin = earshot
+
+    used, overrode = await trackpoll_testmode._check_earshot_override({})  # pylint: disable=protected-access
+
+    assert overrode is True, "EarShot should have overridden an empty source"
+    assert used["artist"] == "Wire" and used["title"] == "The 15th"
+    assert not trackpoll_testmode.main_source_suppressed_meta, (
+        "there is no stale main track to suppress"
+    )
+
+
+@pytest.mark.asyncio
+async def test_earshot_is_managed_even_when_the_source_will_not_start(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """A source that cannot start must not leave EarShot unmanaged for a cycle.
+
+    Returning early on start failure skipped _manage_earshot_plugin(), so
+    EarShot was neither started nor stopped until the next pass.
+    """
+    config = trackpoll_testmode.config
+    config.cparser.setValue("settings/input", "pretend")
+
+    class WillNotStart:  # pylint: disable=no-self-use,too-few-public-methods
+        """Raises out of start(), which the contract calls a defect."""
+
+        def __init__(self, config=None):  # pylint: disable=unused-argument
+            pass
+
+        async def start(self):
+            """Fail."""
+            raise RuntimeError("no soup for you")
+
+        async def stop(self):
+            """Nothing held."""
+
+    trackpoll_testmode.plugins = {
+        "nowplaying.inputs.pretend": unittest.mock.MagicMock(Plugin=WillNotStart),
+        "nowplaying.inputs.earshot": unittest.mock.MagicMock(
+            Plugin=_status_plugin(nowplaying.inputs.InputStatus())
+        ),
+    }
+
+    assert await trackpoll_testmode.switch_input_plugin() is True, (
+        "EarShot is running, so the loop still has work"
+    )
+    assert trackpoll_testmode.earshot_plugin is not None, "EarShot was left unmanaged"
+    assert trackpoll_testmode.input is None
+    assert trackpoll_testmode._input_pollable is False  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_losing_the_input_setting_still_manages_earshot(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """A config reset clears settings/input while EarShot may be running.
+
+    Returning early there left the monitor neither stopped nor read: it keeps
+    its watcher on remotedb, which is the collision hazard for the remote
+    plugin, and keeps writing with nobody looking.
+    """
+    config = trackpoll_testmode.config
+    config.cparser.setValue("settings/input", "pretend")
+    trackpoll_testmode.plugins = {
+        "nowplaying.inputs.pretend": unittest.mock.MagicMock(
+            Plugin=_status_plugin(nowplaying.inputs.InputStatus())
+        ),
+        "nowplaying.inputs.earshot": unittest.mock.MagicMock(
+            Plugin=_status_plugin(nowplaying.inputs.InputStatus())
+        ),
+    }
+
+    assert await trackpoll_testmode.switch_input_plugin() is True
+    assert trackpoll_testmode.earshot_plugin is not None
+
+    # The setting goes away underneath us.
+    config.cparser.remove("settings/input")
+    assert await trackpoll_testmode.switch_input_plugin() is True, (
+        "EarShot alone is still something to poll"
+    )
+    assert trackpoll_testmode.input is None
+    assert trackpoll_testmode._input_pollable is False  # pylint: disable=protected-access
+    assert trackpoll_testmode.earshot_plugin is not None, (
+        "EarShot should still be managed, not orphaned"
+    )

--- a/tests/test_trackpoll.py
+++ b/tests/test_trackpoll.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-lines
 """test the trackpoller"""
 
 import asyncio
@@ -997,3 +998,86 @@ async def test_losing_the_input_setting_still_manages_earshot(trackpoll_testmode
     assert trackpoll_testmode.earshot_plugin is not None, (
         "EarShot should still be managed, not orphaned"
     )
+
+
+@pytest.mark.asyncio
+async def test_an_input_wedged_in_stop_does_not_hang_the_switch(
+    bootstrap, trackpoll_testmode, monkeypatch
+):  # pylint: disable=redefined-outer-name
+    """A plugin that never returns from stop() must not take the poll loop.
+
+    The contract asks stop() to be safe at any time but sets no bound on how
+    long it may take, so every caller here has to impose one.
+    """
+    monkeypatch.setattr(nowplaying.processes.trackpoll, "_STOP_TIMEOUT_SECONDS", 0.05)
+
+    class Wedges:  # pylint: disable=no-self-use,too-few-public-methods
+        """Starts fine, then never returns from stop()."""
+
+        def __init__(self, config=None):  # pylint: disable=unused-argument
+            pass
+
+        async def start(self):
+            """Succeed, per the contract."""
+
+        async def stop(self):
+            """Never return."""
+            await asyncio.sleep(3600)
+
+        def status(self):
+            """Healthy right up to the switch."""
+            return nowplaying.inputs.InputStatus()
+
+        async def getplayingtrack(self):
+            """No track."""
+            return None
+
+    _use_plugin(trackpoll_testmode, bootstrap, Wedges)
+    assert await trackpoll_testmode.switch_input_plugin() is True
+
+    # Switching away stops the old plugin, which is where it wedges.
+    bootstrap.cparser.setValue("settings/input", "other")
+    trackpoll_testmode.plugins["nowplaying.inputs.other"] = unittest.mock.MagicMock(
+        Plugin=_status_plugin(nowplaying.inputs.InputStatus())
+    )
+
+    await asyncio.wait_for(trackpoll_testmode.switch_input_plugin(), timeout=5)
+    assert trackpoll_testmode.previousinput == "other", "the switch never completed"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_earshot_monitor_is_rebuilt(trackpoll_testmode):  # pylint: disable=redefined-outer-name
+    """EarShot's watcher can die after start() and nothing else would notice.
+
+    It subclasses remote, so it inherits the watcher that dies when another
+    observer already holds remotedb, and then stores arriving tracks where
+    nobody reads them.
+    """
+    config = trackpoll_testmode.config
+    config.cparser.setValue("settings/input", "pretend")
+    started = []
+    trackpoll_testmode.plugins = {
+        "nowplaying.inputs.pretend": unittest.mock.MagicMock(
+            Plugin=_status_plugin(nowplaying.inputs.InputStatus())
+        ),
+        "nowplaying.inputs.earshot": unittest.mock.MagicMock(
+            Plugin=_status_plugin(
+                nowplaying.inputs.InputStatus.needs_restart("Stopped watching for tracks."),
+                started=started,
+            )
+        ),
+    }
+
+    assert await trackpoll_testmode.switch_input_plugin() is True
+    assert len(started) == 1
+
+    for _ in range(10):  # still inside the delay
+        await trackpoll_testmode.switch_input_plugin()
+    assert len(started) == 1, "rebuilt before the delay elapsed"
+
+    # Arrive at the far side of the wait without sleeping through it.
+    trackpoll_testmode._restart_earshot_at = time.monotonic() - 1  # pylint: disable=protected-access
+    await trackpoll_testmode.switch_input_plugin()  # drops the dead monitor
+    assert trackpoll_testmode.earshot_plugin is None
+    await trackpoll_testmode.switch_input_plugin()  # rebuilds it
+    assert len(started) == 2, "the dead monitor was never rebuilt"

--- a/tests/test_winmedia.py
+++ b/tests/test_winmedia.py
@@ -2,9 +2,11 @@
 """test winmedia ... ok, not really."""
 
 import sys
+import unittest.mock
 
 import pytest
 
+import nowplaying.inputs
 import nowplaying.inputs.winmedia  # pylint: disable=import-error
 
 
@@ -20,3 +22,31 @@ async def test_winmedia():
         assert plugin.available
     else:
         assert not plugin.available
+
+
+def test_winmedia_without_winrt_is_broken():
+    """No bindings means this machine cannot run it, which waiting will not fix."""
+    plugin = nowplaying.inputs.winmedia.Plugin()
+    with unittest.mock.patch.object(nowplaying.inputs.winmedia, "WINMEDIA_STATUS", False):
+        status = plugin.status()
+    assert status.health is nowplaying.inputs.InputHealth.BROKEN
+    assert not status, "nothing to poll on a machine that cannot run it"
+
+
+def test_winmedia_reader_task_ending_asks_for_a_restart():
+    """start() adds a task that discards itself when done, so empty means dead.
+
+    Patches the availability flag so the task branches are reachable off
+    Windows; the flag itself is covered above.
+    """
+    plugin = nowplaying.inputs.winmedia.Plugin()
+    with unittest.mock.patch.object(nowplaying.inputs.winmedia, "WINMEDIA_STATUS", True):
+        assert plugin.status().health is nowplaying.inputs.InputHealth.OK, "not started yet"
+
+        plugin._started = True  # pylint: disable=protected-access
+        status = plugin.status()
+        assert status.health is nowplaying.inputs.InputHealth.NEEDS_RESTART
+        assert not status
+
+        plugin.tasks.add(object())  # a task that is still running
+        assert plugin.status().health is nowplaying.inputs.InputHealth.OK


### PR DESCRIPTION
start() and stop() said only "any initialization before actual polling starts" and "stopping either the entire program or just this input", so trackpoll and the wizard each grew their own defences against the same unknowns and guessed differently. The wizard ended up with a timeout, a stop() in a finally, a suppress around that stop, and a function that scrapes exception text for something to show a user.

status() answers the question a caller actually has, which is not whether something is wrong but what to do about it: wait, restart, tell the user, or give up. An exception cannot express "I am retrying, leave me alone", which is why icecast swallowed its own bind failure while five other plugins raised theirs. start() no longer raises for anything operational.

Converted: rekordbox reports a key that does not open the database and picks up a corrected one without a restart; remote notices its watcher dying, which until now made it accept POSTs and report nothing; icecast says it is waiting on the port it already retried silently; denon reports a discovery task that ended, which start() returns too early to see; jriver, mpris2 and winmedia map state they already tracked and could not expose. The eight file watchers keep the inherited OK, which is accurate for them.

DBWatcher grows is_alive(). The observer's own thread is the event dispatcher and stays up regardless, so a watch that has stopped delivering is only visible by asking each emitter.

## Summary by Sourcery

Establish and adopt a lifecycle and health contract for input plugins so independent callers can safely poll, recover, stop, and explain plugin failures.

New Features:
- Add a structured input-plugin status API that distinguishes healthy, starting, waiting, user-action, restart, and unrecoverable states.
- Enable callers to recover from corrected Rekordbox keys and restart failed plugin watchers or background tasks without restarting the application.

Bug Fixes:
- Prevent operational plugin conditions such as unavailable ports, missing libraries, unreachable servers, dead watchers, and ended tasks from being misreported or silently ignored.
- Prevent blocking watcher and database shutdowns from freezing the asyncio event loop.

Enhancements:
- Define a lifecycle contract requiring prompt, atomic starts, safe stops, non-operational-error reporting through status(), and non-blocking cleanup.
- Update track polling and wizard verification to act on plugin status, provide actionable user messages, preserve EarShot monitoring, and apply bounded restart and shutdown handling.
- Expose watcher liveness through DBWatcher and add lifecycle guidance for input-plugin contributors.

Documentation:
- Document the input-plugin lifecycle and status contract, including recovery semantics, watcher behavior, and EarShot interactions.

Tests:
- Add coverage for status handling, lifecycle guarantees, recovery behavior, watcher failures, non-blocking shutdowns, and actionable wizard output.