### PR TITLE
Open DJ software databases read-only

### DIFF
--- a/nowplaying/djaypro/locationdb.py
+++ b/nowplaying/djaypro/locationdb.py
@@ -97,7 +97,9 @@ def _probe_djay_max_rowid(djay_dbfile: pathlib.Path) -> int | None:
     """Return MAX(rowid) for location collections in djay's DB, or None on error."""
 
     def query() -> int:
-        with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
+        with nowplaying.utils.sqlite.sqlite_connection(
+            str(djay_dbfile), timeout=1, read_only=True
+        ) as conn:
             row = conn.execute(
                 f"SELECT MAX(rowid) FROM database2 WHERE collection IN ({_LOCATION_PLACEHOLDERS})",
                 _LOCATION_COLLECTIONS,
@@ -123,7 +125,9 @@ def _fetch_new_rows(
 
     def query() -> list[tuple[str, str, str, str | None, str | None]]:
         results: list[tuple[str, str, str, str | None, str | None]] = []
-        with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
+        with nowplaying.utils.sqlite.sqlite_connection(
+            str(djay_dbfile), timeout=1, read_only=True
+        ) as conn:
             cursor = conn.execute(
                 f"SELECT key, data FROM database2"
                 f" WHERE collection IN ({_LOCATION_PLACEHOLDERS}) AND rowid > ?",
@@ -238,7 +242,9 @@ def lookup_direct(djay_dbfile: pathlib.Path, title_id: str) -> tuple[str | None,
     """
 
     def query() -> tuple[str | None, str | None]:
-        with nowplaying.utils.sqlite.sqlite_connection(str(djay_dbfile), timeout=1) as conn:
+        with nowplaying.utils.sqlite.sqlite_connection(
+            str(djay_dbfile), timeout=1, read_only=True
+        ) as conn:
             row = conn.execute(
                 "SELECT data FROM database2"
                 f" WHERE collection IN ({_LOCATION_PLACEHOLDERS}) AND key = ?",

--- a/nowplaying/djaypro/mediadb.py
+++ b/nowplaying/djaypro/mediadb.py
@@ -45,7 +45,9 @@ def query_recent_history(dbfile: pathlib.Path, limit: int = 20) -> list[dict]:
 
     def query_db():
         records = []
-        with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=1) as connection:
+        with nowplaying.utils.sqlite.sqlite_connection(
+            str(dbfile), timeout=1, read_only=True
+        ) as connection:
             cursor = connection.cursor()
             cursor.execute(
                 "SELECT data FROM database2 "
@@ -76,7 +78,9 @@ def get_analyzed_data_by_uuid(dbfile: pathlib.Path | None, track_uuid: str) -> d
         return {}
 
     def query_db() -> dict:
-        with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=1) as connection:
+        with nowplaying.utils.sqlite.sqlite_connection(
+            str(dbfile), timeout=1, read_only=True
+        ) as connection:
             cursor = connection.cursor()
             cursor.execute(
                 "SELECT data FROM database2 WHERE collection='mediaItemAnalyzedData' AND key=?",
@@ -147,7 +151,7 @@ def has_tracks_in_entire_library(dbfile: pathlib.Path | None, artist_name: str) 
     if not dbfile or not artist_lower:
         return False
 
-    with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=5) as conn:
+    with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=5, read_only=True) as conn:
         cursor = conn.cursor()
         cursor.execute("SELECT data FROM database2 WHERE collection='mediaItemTitleIDs'")
         for (blob,) in cursor:
@@ -188,7 +192,7 @@ def has_tracks_in_playlists(
         ' WHERE p."group" = ?'
         "   AND d.collection = 'mediaItemTitleIDs'"
     )
-    with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=5) as conn:
+    with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=5, read_only=True) as conn:
         cursor = conn.cursor()
         for playlist_name in playlist_names:
             try:
@@ -210,7 +214,7 @@ def get_available_playlists_sync(dbfile: pathlib.Path | None) -> list[str]:
     """Return sorted list of playlist names from view_mediaItemPlaylistView_page."""
     if not dbfile:
         return []
-    with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=5) as conn:
+    with nowplaying.utils.sqlite.sqlite_connection(str(dbfile), timeout=5, read_only=True) as conn:
         cursor = conn.cursor()
         try:
             cursor.execute(

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -46,6 +46,7 @@ from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
 import nowplaying.utils
+import nowplaying.utils.sqlite
 from nowplaying.exceptions import PluginVerifyError
 from nowplaying.inputs import InputPlugin
 from nowplaying.types import TrackMetadata
@@ -188,7 +189,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
             "FROM tracks WHERE album=? AND artist=? AND title=? "
             "ORDER BY last_played"
         )
-        async with aiosqlite.connect(dbfile, timeout=30) as connection:
+        async with aiosqlite.connect(
+            nowplaying.utils.sqlite.read_only_dsn(str(dbfile)), uri=True, timeout=30
+        ) as connection:
             connection.row_factory = sqlite3.Row
             cursor = await connection.cursor()
             params = (
@@ -260,7 +263,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         dbfile = pathlib.Path(self.djuceddir).joinpath("DJUCED.db")
         playlists = []
 
-        async with aiosqlite.connect(dbfile, timeout=30) as connection:
+        async with aiosqlite.connect(
+            nowplaying.utils.sqlite.read_only_dsn(str(dbfile)), uri=True, timeout=30
+        ) as connection:
             connection.row_factory = sqlite3.Row
             cursor = await connection.cursor()
 
@@ -393,7 +398,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         """Get a random track from playlist (handles both static and smart playlists)"""
         dbfile = pathlib.Path(self.djuceddir).joinpath("DJUCED.db")
 
-        async with aiosqlite.connect(dbfile, timeout=30) as connection:
+        async with aiosqlite.connect(
+            nowplaying.utils.sqlite.read_only_dsn(str(dbfile)), uri=True, timeout=30
+        ) as connection:
             connection.row_factory = sqlite3.Row
             cursor = await connection.cursor()
 
@@ -436,7 +443,9 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
         )
 
         try:
-            async with aiosqlite.connect(dbfile, timeout=30) as connection:
+            async with aiosqlite.connect(
+                nowplaying.utils.sqlite.read_only_dsn(str(dbfile)), uri=True, timeout=30
+            ) as connection:
                 connection.row_factory = sqlite3.Row
                 cursor = await connection.cursor()
 

--- a/nowplaying/serato/plugin.py
+++ b/nowplaying/serato/plugin.py
@@ -505,7 +505,9 @@ class Plugin(nowplaying.inputs.InputPlugin):  # pylint: disable=too-many-instanc
         try:
 
             async def _query_library() -> bool:
-                async with aiosqlite.connect(db_path) as connection:
+                async with aiosqlite.connect(
+                    nowplaying.utils.sqlite.read_only_dsn(str(db_path)), uri=True
+                ) as connection:
                     connection.row_factory = aiosqlite.Row
 
                     # Search asset table for artist (case-insensitive)

--- a/nowplaying/serato/reader.py
+++ b/nowplaying/serato/reader.py
@@ -34,7 +34,9 @@ class Serato4SQLiteReader:
             return {}
 
         async def _query_locations() -> dict[int, pathlib.Path]:
-            async with aiosqlite.connect(self.db_path) as connection:
+            async with aiosqlite.connect(
+                nowplaying.utils.sqlite.read_only_dsn(str(self.db_path)), uri=True
+            ) as connection:
                 connection.row_factory = aiosqlite.Row
 
                 # Query location_connections view to get database paths for each location
@@ -91,7 +93,9 @@ class Serato4SQLiteReader:
             return []
 
         async def _query_db_paths() -> list[pathlib.Path]:
-            async with aiosqlite.connect(self.db_path) as connection:
+            async with aiosqlite.connect(
+                nowplaying.utils.sqlite.read_only_dsn(str(self.db_path)), uri=True
+            ) as connection:
                 connection.row_factory = aiosqlite.Row
 
                 # Query location_connections view to get all database paths
@@ -133,7 +137,9 @@ class Serato4SQLiteReader:
         played_filter = "AND played = 1" if self.require_played else ""
 
         async def _query_tracks() -> list[dict[str, t.Any]]:
-            async with aiosqlite.connect(self.db_path) as connection:
+            async with aiosqlite.connect(
+                nowplaying.utils.sqlite.read_only_dsn(str(self.db_path)), uri=True
+            ) as connection:
                 # Let Serato manage its own journal mode - we're just a read-only client
                 connection.row_factory = aiosqlite.Row  # Enable column access by name
 
@@ -239,7 +245,9 @@ class Serato4RootReader:  # pylint: disable=too-few-public-methods
             return False
 
         async def _query_crates() -> bool:
-            async with aiosqlite.connect(self.db_path) as connection:
+            async with aiosqlite.connect(
+                nowplaying.utils.sqlite.read_only_dsn(str(self.db_path)), uri=True
+            ) as connection:
                 connection.row_factory = aiosqlite.Row
 
                 # Build placeholders for crate names

--- a/nowplaying/utils/sqlite.py
+++ b/nowplaying/utils/sqlite.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import pathlib
 import random
 import sqlite3
 import time
@@ -139,9 +140,20 @@ async def retry_sqlite_operation_async(
             raise
 
 
+def read_only_dsn(database_path: str | pathlib.Path) -> str:
+    """URI for a database WNP does not own. Pass uri=True alongside it.
+
+    as_uri() rather than a hand-built f-string because a Windows path has no
+    leading slash, which SQLite would read as a relative URI. resolve() first
+    because as_uri() rejects a relative path, and a settings wipe can leave a
+    plugin holding one.
+    """
+    return pathlib.Path(database_path).resolve().as_uri() + "?mode=ro"
+
+
 @contextlib.contextmanager
 def sqlite_connection(
-    database_path: str, timeout: int = 10, row_factory=None
+    database_path: str, timeout: int = 10, row_factory=None, read_only: bool = False
 ) -> Iterator[sqlite3.Connection]:
     """Context manager for sqlite3 connections that properly handles cleanup in Python 3.13.
 
@@ -152,6 +164,7 @@ def sqlite_connection(
         database_path: Path to SQLite database file
         timeout: Connection timeout in seconds
         row_factory: Optional row factory (e.g., sqlite3.Row)
+        read_only: Open through read_only_dsn(), for a database WNP does not own.
 
     Yields:
         sqlite3.Connection object ready for use
@@ -163,7 +176,11 @@ def sqlite_connection(
             rows = cursor.fetchall()
             cursor.close()
     """
-    with contextlib.closing(sqlite3.connect(database_path, timeout=timeout)) as connection:
+    if read_only:
+        opener = sqlite3.connect(read_only_dsn(database_path), timeout=timeout, uri=True)
+    else:
+        opener = sqlite3.connect(database_path, timeout=timeout)
+    with contextlib.closing(opener) as connection:
         if row_factory:
             connection.row_factory = row_factory
         with connection:

--- a/tests/test_input_djaypro.py
+++ b/tests/test_input_djaypro.py
@@ -1195,3 +1195,60 @@ async def test_get_available_playlists_missing_db(bootstrap):
         # No MediaLibrary.db created
 
         assert await plugin.get_available_playlists() == []
+
+
+# ---------------------------------------------------------------------------
+# read-only access to djay's database
+# ---------------------------------------------------------------------------
+
+
+def _wal_state(dbfile: pathlib.Path) -> tuple[int, bytes] | None:
+    """Snapshot MediaLibrary.db-wal so any write to it is visible.
+
+    Only the -wal file, because that is the one _fs_event acts on. Even a
+    read-only connection writes -shm, which is why the filter there has to stay
+    narrow.
+
+    Contents and mtime, because neither is sufficient alone. After a read-only
+    open the -wal is zero length, so the regression this guards -- a read-write
+    close checkpointing and deleting it, then the next read recreating it --
+    leaves the bytes identical and moves only the mtime. A rewrite in place
+    would do the reverse.
+    """
+    wal = dbfile.with_name(dbfile.name + "-wal")
+    if not wal.exists():
+        return None
+    return (wal.stat().st_mtime_ns, wal.read_bytes())
+
+
+def test_reading_djay_db_does_not_touch_the_wal(tmp_path):
+    """Reading djay's database must not write its WAL sidecars.
+
+    A read-write connection checkpoints on close and deletes -wal and -shm, so
+    the plugin's own watcher on MediaLibrary.db-wal saw every read as a djay Pro
+    write: each event scheduled a debounce whose handler read the database
+    again, at several events per second, with djay Pro not even running.
+    """
+    dbfile = tmp_path / "MediaLibrary.db"
+    blob = _build_tsaf_blob(
+        "ADCMediaItemAnalyzedData", [("DJ", "artist"), ("Track", "title"), (128.0, "bpm")]
+    )
+    _make_db_with_collections(dbfile, {"historySessionItems": [("key-0", blob)]})
+    with sqlite3.connect(dbfile) as conn:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+    conn.close()
+
+    # Settle the empty -wal a first open legitimately creates, then confirm
+    # further reads leave it alone.
+    nowplaying.djaypro.mediadb.query_recent_history(dbfile)
+    before = _wal_state(dbfile)
+
+    # A read-only open does create the -wal, so its absence means the open
+    # failed. query_recent_history() swallows OperationalError and returns [],
+    # which is what a DSN this platform cannot parse produces -- without this
+    # the loop below would compare None to None and pass.
+    assert before is not None, "the read never opened the database"
+
+    for _ in range(3):
+        nowplaying.djaypro.mediadb.query_recent_history(dbfile)
+        assert _wal_state(dbfile) == before

--- a/tests/test_utils_sqlite.py
+++ b/tests/test_utils_sqlite.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Tests for nowplaying.utils.sqlite."""
+
+import pathlib
+import sqlite3
+
+import pytest  # pylint: disable=import-error
+
+import nowplaying.utils.sqlite
+
+
+def _make_db(path: pathlib.Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript("CREATE TABLE t(a); INSERT INTO t VALUES (1);")
+    conn.close()
+
+
+def test_read_only_dsn_round_trips_an_awkward_path(tmp_path):
+    """Spaces and non-ASCII are ordinary in a DJ library folder."""
+    db = tmp_path / "djay Pró" / "Media Library.db"
+    _make_db(db)
+
+    dsn = nowplaying.utils.sqlite.read_only_dsn(db)
+    assert dsn.startswith("file:///"), f"not an absolute file URI: {dsn}"
+    assert dsn.endswith("?mode=ro")
+
+    with sqlite3.connect(dsn, uri=True) as conn:
+        assert conn.execute("SELECT a FROM t").fetchone() == (1,)
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO t VALUES (2)")
+    conn.close()
+
+
+def test_read_only_dsn_accepts_a_relative_path(tmp_path, monkeypatch):
+    """as_uri() rejects a relative path, and plugins can be holding one.
+
+    A settings wipe leaves input plugins with paths like History/Sessions, so
+    resolve() has to run first or reading the library raises ValueError instead
+    of failing to find a file. Not raising mid-set is the right trade, but note
+    this pins the resolve-against-CWD behaviour rather than the wipe itself
+    being fixed: that path is still wrong, just quietly wrong.
+    """
+    _make_db(tmp_path / "Library" / "master.db")
+    monkeypatch.chdir(tmp_path)
+
+    dsn = nowplaying.utils.sqlite.read_only_dsn("Library/master.db")
+
+    assert dsn.startswith("file:///")
+    with sqlite3.connect(dsn, uri=True) as conn:
+        assert conn.execute("SELECT a FROM t").fetchone() == (1,)
+    conn.close()


### PR DESCRIPTION
Port of a462f9c9 (#1901) without the Rekordbox half, which has no plugin on this branch.

WNP only ever writes its own SQLite files, but nothing enforced that. A read-write connection writes regardless of the statements run: closing the last one to a WAL-mode database checkpoints it and deletes the -wal. djay Pro's watcher matches MediaLibrary.db-wal, so every read scheduled the debounce that caused the next one, several times a second with djay Pro shut down. Such an open also creates the file when the path is wrong, leaving a stray empty database in the user's library folder.

Seventeen sites across djay Pro, DJUCED and Serato 4. sqlite_connection() gained read_only; read_only_dsn() builds the URI for aiosqlite, which takes uri=True but does not go through it. It uses Path.as_uri() rather than an f-string, because a Windows path has no leading slash and SQLite would read that as a relative URI, and resolves first because as_uri() rejects a relative path and a settings wipe can leave a plugin holding one.

## Summary by Sourcery

Open all external DJ software databases in read-only mode to avoid side effects during library inspection.

Bug Fixes:
- Prevent reads of third-party DJ databases from modifying WAL files, triggering unnecessary filesystem watcher activity, or creating missing database files.

Enhancements:
- Add shared read-only SQLite connection support for synchronous and asynchronous database access across djay Pro, DJUCED, and Serato integrations.
- Build portable read-only SQLite URIs that handle absolute, relative, Windows, and non-ASCII database paths.

Tests:
- Add coverage verifying read-only URI behavior and ensuring repeated djay Pro database reads leave WAL state unchanged.