### PR TITLE
Fall back to playing.txt when DJUCED.db is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@
     label, and date for up to a week afterward
 * The settings window fits a 1200x600 screen again, and no longer opens larger
     than it needs to be
+* WNP now opens DJ software libraries read-only. It never wrote to them, but
+    opening them for writing was enough to make WNP re-read djay Pro's
+    library several times a second, even with djay Pro closed
 
 ### Platform
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
 * WNP now opens DJ software libraries read-only. It never wrote to them, but
     opening them for writing was enough to make WNP re-read djay Pro's
     library several times a second, even with djay Pro closed
+* DJUCED tracks no longer go missing before DJUCED has created its database.
+    The artist and title still come through; only the extra details are lost
 
 ### Platform
 

--- a/nowplaying/inputs/djuced.py
+++ b/nowplaying/inputs/djuced.py
@@ -221,6 +221,12 @@ class Plugin(InputPlugin):  # pylint: disable=too-many-instance-attributes
     async def _try_db(self, deck: str) -> TrackMetadata:
         metadata = {}
         dbfile = pathlib.Path(self.djuceddir).joinpath("DJUCED.db")
+        if not dbfile.exists():
+            # DJUCED has not written it yet. Returning empty lets the caller
+            # fall back to playing.txt; raising would lose the track, since
+            # nothing reports the exception of the task we run in.
+            logging.debug("%s does not exist yet; using playing.txt only", dbfile)
+            return metadata
         sql = (
             "SELECT  artist, comment, coverimage, title, bpm, tracknumber, length, absolutepath "
             "FROM tracks WHERE album=? AND artist=? AND title=? "

--- a/tests/test_djuced.py
+++ b/tests/test_djuced.py
@@ -1,0 +1,32 @@
+"""test DJUCED input plugin"""
+# pylint: disable=protected-access
+
+import pytest
+
+import nowplaying.inputs.djuced
+
+
+@pytest.mark.asyncio
+async def test_a_missing_database_falls_back_to_playing_txt(bootstrap, tmp_path):
+    """DJUCED may not have written its database yet, and the track still matters.
+
+    _try_db() is awaited from a task whose exception nothing reports, so raising
+    there loses the track silently instead of degrading to the artist and title
+    playing.txt already supplied.
+    """
+    config = bootstrap
+    config.cparser.setValue("djuced/directory", str(tmp_path))
+    assert not (tmp_path / "DJUCED.db").exists()
+
+    plugin = nowplaying.inputs.djuced.Plugin(config=config)
+    plugin.djuceddir = str(tmp_path)
+    nowplaying.inputs.djuced.Plugin.decktracker["1"] = {
+        "title": "Whitelightgenerator",
+        "artist": "Ladytron",
+        "album": "Witching Hour",
+    }
+
+    await plugin._get_metadata("1")
+
+    assert nowplaying.inputs.djuced.Plugin.metadata["artist"] == "Ladytron"
+    assert nowplaying.inputs.djuced.Plugin.metadata["title"] == "Whitelightgenerator"


### PR DESCRIPTION
DJUCED has not necessarily written its database when a playing.txt event arrives, and _try_db() raised rather than returning empty, so _get_metadata() never reached its fallback. The track was lost with nothing in the log, because the caller runs as a task whose exception nothing reports.

Checks for the file the way serato/reader.py does. This does not cover a database that exists but cannot be read; has_tracks_by_artist() catches that case for its own query, and the other two readers still do not.

Also adds the 5.2.3 changelog entry for #1901, which should have been in that PR.

## Summary by Sourcery

Prevent early DJUCED playing.txt events from being silently lost when the library database is not yet available.

Bug Fixes:
- Preserve DJUCED track artist and title metadata when playing.txt arrives before DJUCED has created its database.

Documentation:
- Add the missing 5.2.3 changelog entries for read-only DJ software library access and the DJUCED fallback behavior.

Tests:
- Add coverage for falling back to playing.txt when DJUCED.db is absent.