### PR TITLE
Say the unactionable things once, not on every retry

### DIFF
--- a/nowplaying/kick/chat.py
+++ b/nowplaying/kick/chat.py
@@ -42,6 +42,7 @@ class KickChat:  # pylint: disable=too-many-instance-attributes
             total=nowplaying.kick.constants.KICK_CHAT_TIMEOUT
         )
         self.authenticated: bool = False
+        self._reported_no_tokens: bool = False
         self._watcher_lock: asyncio.Lock = asyncio.Lock()
         self._watcher_running: bool = False
         self.last_announced: dict[str, str | None] = {"artist": None, "title": None}
@@ -57,10 +58,14 @@ class KickChat:  # pylint: disable=too-many-instance-attributes
         # Use consolidated token refresh function
         if await nowplaying.kick.utils.attempt_token_refresh(self.config):
             self.authenticated = True
+            self._reported_no_tokens = False
             logging.info("Kick chat authentication successful")
             return True
 
-        logging.error("No valid Kick tokens available for chat")
+        # run_chat() retries every 60s; same condition as the launcher's prompt.
+        if not self._reported_no_tokens:
+            logging.error("No valid Kick tokens available for chat")
+            self._reported_no_tokens = True
         return False
 
     async def _send_message(self, message: str) -> bool:

--- a/nowplaying/kick/launch.py
+++ b/nowplaying/kick/launch.py
@@ -38,6 +38,7 @@ class KickLaunch:  # pylint: disable=too-many-instance-attributes
             self.config
         )
         self.tasks: set[asyncio.Task[Any]] = set()
+        self._asked_for_reauth: bool = False
 
         # Register signal handler in main thread during initialization
         signal.signal(signal.SIGINT, self.forced_stop)
@@ -96,11 +97,16 @@ class KickLaunch:  # pylint: disable=too-many-instance-attributes
             # Use consolidated token refresh function
             if await nowplaying.kick.utils.attempt_token_refresh(self.config):
                 logging.info("Kick token is valid - proceeding with chat")
+                self._asked_for_reauth = False
                 self.config.cparser.setValue(OAUTH_STATUS_KEY, OAUTH_STATUS_AUTHENTICATED)
                 self.config.cparser.sync()
                 return True
 
-            logging.error("Please re-authenticate via Settings -> Kick -> Authenticate")
+            # Every 97s from the retry loop, and the user cannot re-authenticate
+            # any harder than they already have not.
+            if not self._asked_for_reauth:
+                logging.error("Please re-authenticate via Settings -> Kick -> Authenticate")
+                self._asked_for_reauth = True
             self.config.cparser.setValue(OAUTH_STATUS_KEY, OAUTH_STATUS_EXPIRED)
             self.config.cparser.sync()
 

--- a/nowplaying/musicbrainz/helper.py
+++ b/nowplaying/musicbrainz/helper.py
@@ -12,7 +12,9 @@ import orjson
 from wnpmb import (
     MusicBrainzClient,
     MusicBrainzError,
+    NetworkError,
     RateLimitError,
+    ServerBusyError,
     extract_artist_urls,
 )
 from wnpmb.client._base import RetrySettings
@@ -130,6 +132,11 @@ class MusicBrainzHelper:
                 if attempt < max_attempts - 1:
                     continue
                 logger.warning("Rate limited after %d attempts: %s", max_attempts, error_msg)
+                return default
+            except (NetworkError, ServerBusyError) as err:
+                # Slow or busy says nothing about our request, so no traceback:
+                # an outage otherwise logs a full stack per affected lookup.
+                logger.warning("MusicBrainz unavailable for %s: %s", error_msg, err)
                 return default
             except MusicBrainzError:
                 logger.exception("MusicBrainz error: %s", error_msg)
@@ -469,6 +476,17 @@ class MusicBrainzHelper:
                     webdata = await self.mb_client.get_artist_by_id(
                         artistid, includes=["url-rels"]
                     )
+                except RateLimitError as err:
+                    # break, not continue: being rate limited means the rest of
+                    # idlist is limited too, so carrying on would blame every
+                    # remaining id for the same condition.
+                    logger.warning("MusicBrainz rate limited; skipping artist URLs: %s", err)
+                    break
+                except (NetworkError, ServerBusyError) as err:
+                    # Same reason as above; only a real response supports
+                    # saying MusicBrainz does not know this id.
+                    logger.warning("MusicBrainz unavailable for artistid %s: %s", artistid, err)
+                    continue
                 except Exception:  # pylint: disable=broad-exception-caught
                     logger.exception("MusicBrainz does not know artistid %s", artistid)
                     continue

--- a/nowplaying/twitch/redemptions.py
+++ b/nowplaying/twitch/redemptions.py
@@ -45,6 +45,10 @@ class TwitchRedemptions:  # pylint: disable=too-many-instance-attributes
         self.watcher = None
         self.twitch: Twitch | None = None
         self.user_id: str | None = None
+        # Dedicated login for redemptions (broadcaster account only), kept for
+        # the lifetime of this object so its report-once state survives the
+        # retry loop in run_redemptions().
+        self.redemption_login = nowplaying.twitch.utils.TwitchLogin(self.config)
 
     async def callback_redemption(self, data: ChannelPointsCustomRewardRedemptionAddEvent):
         """handle the channel point redemption"""
@@ -149,8 +153,11 @@ class TwitchRedemptions:  # pylint: disable=too-many-instance-attributes
 
     async def _setup_eventsub_connection(self) -> bool:
         """Set up EventSub connection and authentication"""
-        # Create dedicated TwitchLogin for redemptions (broadcaster account only)
-        redemption_login = nowplaying.twitch.utils.TwitchLogin(self.config)
+        # Held on the instance, not built per call: the retry loop above runs
+        # this every 10 seconds while there is no token, and a fresh TwitchLogin
+        # each pass would have an empty _said and so report the same missing
+        # token six times a minute.
+        redemption_login = self.redemption_login
         self.twitch = await redemption_login.api_login()
         if not self.twitch:
             logging.debug("something happened getting twitch api_login; aborting")

--- a/nowplaying/twitch/utils.py
+++ b/nowplaying/twitch/utils.py
@@ -163,6 +163,26 @@ class TwitchLogin:
 
     def __init__(self, config: "nowplaying.config.ConfigFile"):
         self.config = config
+        self._said: set[str] = set()
+
+    def _say_once(self, key: str, level, msg: str, *args) -> None:
+        """Report a condition on the way in, then stay quiet about it.
+
+        run_chat retries every 60 seconds, so anything the user has to fix
+        themselves would otherwise fill a set's worth of log. Kept in memory
+        rather than off the oauth status keys: those are QSettings, so they
+        survive a restart, and they are written by the failure paths here --
+        keying on them would suppress the first occurrence.
+        """
+        if key in self._said:
+            logging.debug(msg, *args)
+            return
+        self._said.add(key)
+        level(msg, *args)
+
+    def _clear_said(self) -> None:
+        """Authentication worked, so the next failure is worth hearing about."""
+        self._said.clear()
 
     async def get_oauth_client(self):
         """Get or create OAuth2 client"""
@@ -174,7 +194,7 @@ class TwitchLogin:
                 TwitchLogin.OAUTH_CLIENT = nowplaying.twitch.oauth2.TwitchOAuth2(self.config)
             return TwitchLogin.OAUTH_CLIENT
 
-    async def attempt_token_refresh(self):
+    async def attempt_token_refresh(self):  # pylint: disable=too-many-statements
         """Try to refresh existing tokens"""
         oauth_client = await self.get_oauth_client()
 
@@ -206,6 +226,7 @@ class TwitchLogin:
                     self.config.cparser.setValue(
                         BROADCASTER_OAUTH_STATUS_KEY, OAUTH_STATUS_AUTHENTICATED
                     )
+                    self._clear_said()
                     self.config.cparser.setValue(
                         BROADCASTER_USERNAME_KEY, validation.get("login", "")
                     )
@@ -231,6 +252,7 @@ class TwitchLogin:
                     self.config.cparser.setValue(
                         BROADCASTER_OAUTH_STATUS_KEY, OAUTH_STATUS_AUTHENTICATED
                     )
+                    self._clear_said()
                     new_validation = await oauth_client.validate_token_async(new_access_token)
                     if new_validation:
                         self.config.cparser.setValue(
@@ -244,7 +266,9 @@ class TwitchLogin:
                 logging.debug("No refresh_token available")
 
         except Exception as error:  # pylint: disable=broad-except
-            logging.error("Token refresh failed: %s", error)
+            # exception, not error: the first occurrence is worth a traceback
+            # and the repeats are not.
+            self._say_once("refresh", logging.exception, "Token refresh failed: %s", error)
 
         self.config.cparser.setValue(BROADCASTER_OAUTH_STATUS_KEY, OAUTH_STATUS_EXPIRED)
         self.config.cparser.sync()
@@ -303,11 +327,15 @@ class TwitchLogin:
                 return twitch
 
             except Exception as error:  # pylint: disable=broad-except
-                logging.error("Failed to create TwitchAPI object: %s", error)
+                self._say_once(
+                    "client", logging.exception, "Failed to create TwitchAPI object: %s", error
+                )
                 return None
 
         # If no valid tokens, need to initiate OAuth flow
-        logging.info("No valid Twitch tokens found. OAuth flow required.")
+        self._say_once(
+            "notokens", logging.info, "No valid Twitch tokens found. OAuth flow required."
+        )
         return None
 
     async def save_refreshed_tokens(self, access_token: str, refresh_token: str):

--- a/tests/twitch/test_twitch_utils.py
+++ b/tests/twitch/test_twitch_utils.py
@@ -2,6 +2,7 @@
 """Unit tests for Twitch utils functionality."""
 
 import json
+import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -402,3 +403,27 @@ async def test_get_user_image_error():
     with simulate_client_exception(Exception("Network error")):
         result = await nowplaying.twitch.utils.get_user_image(mock_oauth, "test_user")
         assert result is None
+
+
+@pytest.mark.asyncio
+async def test_login_failure_is_reported_once_not_every_retry(bootstrap, caplog):
+    """The callers retry every 10-60s and the user cannot fix it any faster.
+
+    One five-hour log was a third re-authentication lines. The report-once
+    state lives on the TwitchLogin instance, so this only holds while callers
+    keep the instance -- building a fresh one per attempt gives it an empty
+    set and restores the flood, which is what redemptions.py did.
+    """
+    login = nowplaying.twitch.utils.TwitchLogin(bootstrap)
+
+    with (
+        patch.object(login, "attempt_token_refresh", new=AsyncMock(return_value=False)),
+        caplog.at_level(logging.DEBUG),
+    ):
+        for _ in range(10):
+            assert await login.api_login() is None
+
+    said = [r for r in caplog.records if "No valid Twitch tokens" in r.getMessage()]
+    assert len(said) == 10, "expected one record per attempt"
+    above_debug = [r for r in said if r.levelno > logging.DEBUG]
+    assert len(above_debug) == 1, f"reported {len(above_debug)} times across 10 attempts"


### PR DESCRIPTION
Closes #1898, closes #1893.

MusicBrainz being slow or busy says nothing about the request, but it was caught as a generic MusicBrainzError and logged with a full traceback at ERROR. During an outage that is one stack per affected lookup. _websites() reported the same timeouts, and rate limiting, as the artist id being unknown; a 429 also means the rest of the list is limited, so it stops rather than blaming each id in turn.

Kick and Twitch report a login that needs redoing on every attempt: the Kick launcher every 97 seconds, Kick chat every 60, and three lines from Twitch's api_login path every 60 -- or every 10 through the redemptions retry loop. One five-hour log was a third re-authentication lines, Kick's at ERROR, which reads as a crisis for a single condition the user already knows about. Each now reports on the way into the failed state and clears when authentication works, with the traceback kept on the first occurrence.

The state is per instance and in memory. Not the oauth status keys: those are QSettings, so they survive a restart, and the failure paths here write them, so keying on them would suppress the first occurrence. That does mean a caller has to keep its TwitchLogin -- redemptions built one per attempt, which is what the new test fails on.

## Summary by Sourcery

Report persistent authentication and MusicBrainz availability failures once while preserving meaningful diagnostics and retry behavior.

Bug Fixes:
- Reduce repeated high-severity logging for persistent Kick and Twitch authentication failures by reporting the initial failure and subsequent retries at debug level until authentication recovers.
- Classify MusicBrainz network and service outages separately from request errors, and stop or skip URL lookups appropriately when rate limits or availability issues affect multiple requests.

Enhancements:
- Track authentication failure reporting per client instance and reset it after successful authentication.
- Retain the Twitch redemption login instance across retries so repeated authentication failures are suppressed.

Tests:
- Add coverage ensuring repeated Twitch login failures produce only one non-debug report.